### PR TITLE
feat: zplug → Antidote 移行 + クロスプラットフォーム対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Install platform-specific system packages:
 - macOS: `brew bundle --file Brewfile`
 - Linux/WSL: `sudo apt install $(cat apt-packages.txt)`
 
-
 # Supported tools
 - NeoVim
 - Z Shell

--- a/README.md
+++ b/README.md
@@ -24,9 +24,6 @@ Install platform-specific system packages:
 - macOS: `brew bundle --file Brewfile`
 - Linux/WSL: `sudo apt install $(cat apt-packages.txt)`
 
-> **Note**: mise is not yet activated in the shell configuration. Currently
-> python/ruby/node from existing pyenv/rbenv/n will take precedence over mise.
-> Shell integration will be added in a follow-up PR.
 
 # Supported tools
 - NeoVim

--- a/docs/planning/DOC-001_ai-housekeeping_計画.md
+++ b/docs/planning/DOC-001_ai-housekeeping_計画.md
@@ -7,8 +7,8 @@
 
 | 孫 | ブランチ | 内容 | 状況 |
 |---|---|---|---|
-| 1 | `ai/ai-repo-housekeeping` | 土台整理: .gitignore更新 + LICENSE追加 + サブモジュール除去 + vim/削除 | 🔄 実装中 |
-| 2 | `ai/mise-env-pinning` | miseによる環境固定化 + Brewfile + apt-packages | ⬜ 待機中 |
+| 1 | `ai/repo-structure-cleanup` | 土台整理: .gitignore更新 + LICENSE追加 + サブモジュール除去 + vim/削除 | ✅ PR #9 マージ済 |
+| 2 | `ai/ai-mise-env-pinning` | miseによる環境固定化 + Brewfile + apt-packages | ✅ PR #10 マージ済 |
 | 3 | `ai/zsh-antidote` | zsh: zplug→Antidote移行 + クロスプラットフォーム + バグ修正 | ⬜ 待機中 |
 | 4 | `ai/global-deploy` | 全体デプロイシステム + helpers.sh拡充 | ⬜ 待機中 |
 | 5 | `ai/tmux-cross-platform` | tmux: クロスプラットフォーム + 設定モダン化 | ⬜ 待機中 |

--- a/shared/helpers.sh
+++ b/shared/helpers.sh
@@ -15,6 +15,14 @@ case "$(uname -s)" in
     ;;
 esac
 
+# is_wsl
+# Detect if running under Windows Subsystem for Linux (WSL).
+# Returns 0 if WSL, 1 otherwise.
+is_wsl() {
+  [ -n "${WSL_DISTRO_NAME}" ] && return 0
+  grep -qi microsoft /proc/version 2>/dev/null
+}
+
 # ensure_command <cmd> [hint]
 # Check if a command is available, print install instructions if not.
 # Returns 0 if found, 1 if not found.

--- a/shared/helpers.sh
+++ b/shared/helpers.sh
@@ -19,7 +19,7 @@ esac
 # Detect if running under Windows Subsystem for Linux (WSL).
 # Returns 0 if WSL, 1 otherwise.
 is_wsl() {
-  [ -n "${WSL_DISTRO_NAME}" ] && return 0
+  [ -n "${WSL_DISTRO_NAME:-}" ] && return 0
   grep -qi microsoft /proc/version 2>/dev/null
 }
 

--- a/zsh/.zsh_plugins.txt
+++ b/zsh/.zsh_plugins.txt
@@ -1,0 +1,13 @@
+# Theme
+sindresorhus/pure kind:fpath
+
+# Syntax highlighting
+zsh-users/zsh-syntax-highlighting
+
+# History search
+zsh-users/zsh-history-substring-search
+
+# Completion
+zsh-users/zsh-autosuggestions
+zsh-users/zsh-completions
+chrissicool/zsh-256color

--- a/zsh/.zsh_plugins.txt
+++ b/zsh/.zsh_plugins.txt
@@ -1,13 +1,15 @@
 # Theme
-sindresorhus/pure kind:fpath
-
-# Syntax highlighting
-zsh-users/zsh-syntax-highlighting
-
-# History search
-zsh-users/zsh-history-substring-search
+sindresorhus/pure
 
 # Completion
-zsh-users/zsh-autosuggestions
 zsh-users/zsh-completions
 chrissicool/zsh-256color
+
+# Autosuggestions
+zsh-users/zsh-autosuggestions
+
+# Syntax highlighting (must be second to last)
+zsh-users/zsh-syntax-highlighting
+
+# History search (must come after syntax highlighting)
+zsh-users/zsh-history-substring-search

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -10,17 +10,11 @@ unset _ZSHRC_PATH
 
 # =============================================================================
 # Source shared helpers (CURRENT_PLATFORM, is_wsl, ensure_command)
+# Note: only CURRENT_PLATFORM is actively used in this file.
+# is_wsl and ensure_command are available for interactive use but not called here.
 # =============================================================================
 if [ -f "$DOTFILES_DIR/shared/helpers.sh" ]; then
   source "$DOTFILES_DIR/shared/helpers.sh"
-fi
-
-# Fallback WSL detection if helpers.sh is unavailable
-# (minimum fallback — keep in sync with shared/helpers.sh)
-if ! command -v is_wsl >/dev/null 2>&1; then
-  is_wsl() {
-    [ -n "${WSL_DISTRO_NAME:-}" ] || grep -qi microsoft /proc/version 2>/dev/null
-  }
 fi
 
 # Fallback platform detection if helpers.sh didn't set CURRENT_PLATFORM
@@ -40,7 +34,7 @@ if [ -f "$ANTIDOTE_HOME/antidote.zsh" ] && [ -f "$HOME/.zsh_plugins.txt" ]; then
   source "$ANTIDOTE_HOME/antidote.zsh"
   antidote load "$HOME/.zsh_plugins.txt"
 else
-  print -ru2 -- "zshrc: Antidote not set up. Run <dotfiles>/zsh/deploy.sh"
+  print -ru2 -- "zshrc: Antidote not set up. Run ${DOTFILES_DIR}/zsh/deploy.sh"
 fi
 
 # Initialize completion system (zplug used to do this; antidote doesn't)
@@ -48,8 +42,11 @@ autoload -Uz compinit && compinit
 
 # History substring search keybindings
 # zsh-history-substring-search doesn't bind keys by itself — do it here.
-bindkey '^[[A' history-substring-search-up
-bindkey '^[[B' history-substring-search-down
+# Guard against unavailable widget (e.g. Antidote not installed).
+if (( $+functions[history-substring-search-up] )); then
+  bindkey '^[[A' history-substring-search-up
+  bindkey '^[[B' history-substring-search-down
+fi
 
 # =============================================================================
 # History

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -1,20 +1,25 @@
 # =============================================================================
 # Resolve dotfiles directory (follows symlinks from ~/.zshrc)
 # =============================================================================
-_ZSHCONFIG_DIR="${0:A:h}"
-DOTFILES_DIR="${_ZSHCONFIG_DIR:h}"
+# Use %x prompt expansion to get the sourced file path.
+# This works regardless of FUNCTION_ARGZERO / POSIX_ARGZERO settings,
+# unlike $0 which depends on those options.
+_ZSHRC_PATH="${${(%):-%x}:A}"
+DOTFILES_DIR="${_ZSHRC_PATH:h:h}"
+unset _ZSHRC_PATH
 
 # =============================================================================
-# Source shared helpers (is_wsl, CURRENT_PLATFORM, ensure_command)
+# Source shared helpers (CURRENT_PLATFORM, is_wsl, ensure_command)
 # =============================================================================
 if [ -f "$DOTFILES_DIR/shared/helpers.sh" ]; then
   source "$DOTFILES_DIR/shared/helpers.sh"
 fi
 
 # Fallback WSL detection if helpers.sh is unavailable
+# (minimum fallback — keep in sync with shared/helpers.sh)
 if ! command -v is_wsl >/dev/null 2>&1; then
   is_wsl() {
-    [ -n "${WSL_DISTRO_NAME}" ] || grep -qi microsoft /proc/version 2>/dev/null
+    [ -n "${WSL_DISTRO_NAME:-}" ] || grep -qi microsoft /proc/version 2>/dev/null
   }
 fi
 
@@ -22,16 +27,23 @@ fi
 # Antidote Plugin Manager
 # =============================================================================
 ANTIDOTE_HOME="${ANTIDOTE_HOME:-$HOME/.antidote}"
-if [ -f "$ANTIDOTE_HOME/antidote.zsh" ]; then
+if [ -f "$ANTIDOTE_HOME/antidote.zsh" ] && [ -f "$HOME/.zsh_plugins.txt" ]; then
   source "$ANTIDOTE_HOME/antidote.zsh"
   antidote load "$HOME/.zsh_plugins.txt"
+else
+  print -ru2 -- "zshrc: Antidote not set up. Run <dotfiles>/zsh/deploy.sh"
 fi
+
+# Initialize completion system (zplug used to do this; antidote doesn't)
+autoload -Uz compinit && compinit
 
 # =============================================================================
 # History
 # =============================================================================
-HISTSIZE=1000
-HISTFILESIZE=2000
+HISTFILE="$HOME/.zsh_history"
+HISTSIZE=10000
+SAVEHIST=10000
+setopt SHARE_HISTORY HIST_IGNORE_DUPS HIST_IGNORE_SPACE HIST_VERIFY
 
 # =============================================================================
 # Aliases
@@ -43,10 +55,12 @@ alias l='ls -CF'
 alias be="bundle exec"
 alias bx="bundle exec"
 
-# NeoVim
-alias vim="nvim"
-alias vi="nvim"
-export EDITOR=nvim
+# NeoVim (only if installed)
+if command -v nvim >/dev/null 2>&1; then
+  alias vim="nvim"
+  alias vi="nvim"
+  export EDITOR=nvim
+fi
 
 # one-liner httpd
 alias webrick="ruby -rwebrick -e 'WEBrick::HTTPServer.new(:DocumentRoot => \"./\", :Port => 8000).start'"
@@ -54,8 +68,8 @@ alias webrick="ruby -rwebrick -e 'WEBrick::HTTPServer.new(:DocumentRoot => \"./\
 # =============================================================================
 # Platform-specific Homebrew PATH
 # =============================================================================
-case "$(uname -s)" in
-  Darwin)
+case "$CURRENT_PLATFORM" in
+  Mac)
     if [ -d /opt/homebrew/bin ]; then
       # Apple Silicon
       export PATH="/opt/homebrew/bin:$PATH"
@@ -76,20 +90,25 @@ esac
 # =============================================================================
 # rbenv (Ruby) - skip if not installed
 # =============================================================================
-if command -v rbenv >/dev/null 2>&1; then
+if [ -d "$HOME/.rbenv/bin" ]; then
   export PATH="$HOME/.rbenv/bin:$PATH"
+fi
+if command -v rbenv >/dev/null 2>&1; then
   eval "$(rbenv init -)"
 fi
 
 # =============================================================================
 # pyenv (Python) - skip if not installed
 # =============================================================================
-if command -v pyenv >/dev/null 2>&1; then
-  export PYENV_ROOT="$HOME/.pyenv"
+export PYENV_ROOT="${PYENV_ROOT:-$HOME/.pyenv}"
+if [ -d "$PYENV_ROOT/bin" ]; then
   export PATH="$PYENV_ROOT/bin:$PATH"
+fi
+if command -v pyenv >/dev/null 2>&1; then
   eval "$(pyenv init --path)"
   eval "$(pyenv init -)"
-  if pyenv commands 2>/dev/null | grep -q virtualenv-init; then
+  # Check for pyenv-virtualenv via directory, not subprocess
+  if [ -d "$PYENV_ROOT/plugins/pyenv-virtualenv" ]; then
     eval "$(pyenv virtualenv-init -)"
   fi
 fi
@@ -103,9 +122,9 @@ if [ -d "$HOME/.n" ]; then
 fi
 
 # =============================================================================
-# PostgreSQL (macOS only — skip on WSL/Linux)
+# PostgreSQL (macOS only — WSL and Linux skip)
 # =============================================================================
-if ! is_wsl && [ "$(uname -s)" = "Darwin" ] && [ -d /usr/local/var/postgres ]; then
+if [ "$CURRENT_PLATFORM" = "Mac" ] && [ -d /usr/local/var/postgres ]; then
   export PGDATA=/usr/local/var/postgres
 fi
 
@@ -119,26 +138,34 @@ fi
 # =============================================================================
 # Google Cloud SDK
 # =============================================================================
-# Try Homebrew-installed SDK first, then fall back to manual installation paths
-_gcloud_sdk_path=""
+# Search candidates: brew cask symlink, brew cask realpath, manual installs.
+# brew --prefix (no formula name) is called once for performance.
+_gcloud_candidates=()
 if command -v brew >/dev/null 2>&1; then
-  _gcloud_sdk_path="$(brew --prefix google-cloud-sdk 2>/dev/null)"
+  _brew_prefix="$(brew --prefix)"
+  _gcloud_candidates+=(
+    "$_brew_prefix/share/google-cloud-sdk"
+    "$_brew_prefix/Caskroom/google-cloud-sdk/latest/google-cloud-sdk"
+  )
 fi
+_gcloud_candidates+=(
+  /usr/local/share/google-cloud-sdk
+  "$HOME/google-cloud-sdk"
+)
 
-if [ -n "$_gcloud_sdk_path" ] && [ -f "$_gcloud_sdk_path/path.zsh.inc" ]; then
-  source "$_gcloud_sdk_path/path.zsh.inc"
-elif [ -f /usr/local/share/google-cloud-sdk/path.zsh.inc ]; then
-  source /usr/local/share/google-cloud-sdk/path.zsh.inc
-elif [ -f "$HOME/google-cloud-sdk/path.zsh.inc" ]; then
-  source "$HOME/google-cloud-sdk/path.zsh.inc"
+for _dir in $_gcloud_candidates; do
+  if [ -f "$_dir/path.zsh.inc" ]; then
+    source "$_dir/path.zsh.inc"
+    [ -f "$_dir/completion.zsh.inc" ] && source "$_dir/completion.zsh.inc"
+    break
+  fi
+done
+unset _gcloud_candidates _brew_prefix _dir
+
+# =============================================================================
+# mise version manager (if installed)
+# =============================================================================
+# mise activates last so its shims take precedence for Python/Ruby/Node.
+if command -v mise >/dev/null 2>&1; then
+  eval "$(mise activate zsh)"
 fi
-
-if [ -n "$_gcloud_sdk_path" ] && [ -f "$_gcloud_sdk_path/completion.zsh.inc" ]; then
-  source "$_gcloud_sdk_path/completion.zsh.inc"
-elif [ -f /usr/local/share/google-cloud-sdk/completion.zsh.inc ]; then
-  source /usr/local/share/google-cloud-sdk/completion.zsh.inc
-elif [ -f "$HOME/google-cloud-sdk/completion.zsh.inc" ]; then
-  source "$HOME/google-cloud-sdk/completion.zsh.inc"
-fi
-
-unset _gcloud_sdk_path

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -1,82 +1,144 @@
-source ~/.zplug/init.zsh
+# =============================================================================
+# Resolve dotfiles directory (follows symlinks from ~/.zshrc)
+# =============================================================================
+_ZSHCONFIG_DIR="${0:A:h}"
+DOTFILES_DIR="${_ZSHCONFIG_DIR:h}"
 
-zplug 'zplug/zplug', hook-build:'zplug --self-manage'
-
-# Theme
-zplug "mafredri/zsh-async", from:github
-zplug "sindresorhus/pure", use:pure.zsh, from:github, as:theme
-
-# Syntax highlighting
-zplug "zsh-users/zsh-syntax-highlighting"
-
-# Searching for command history
-zplug "zsh-users/zsh-history-substring-search"
-
-# Completion
-zplug "zsh-users/zsh-autosuggestions"
-zplug "zsh-users/zsh-completions"
-zplug "chrissicool/zsh-256color"
-
-# Install plugins if there are plugins that have not been installed
-if ! zplug check --verbose; then
-  printf "Install? [y/N]: "
-  if read -q; then
-    echo; zplug install
-  fi
+# =============================================================================
+# Source shared helpers (is_wsl, CURRENT_PLATFORM, ensure_command)
+# =============================================================================
+if [ -f "$DOTFILES_DIR/shared/helpers.sh" ]; then
+  source "$DOTFILES_DIR/shared/helpers.sh"
 fi
 
-# Then, source plugins and add commands to $PATH
-zplug load
+# Fallback WSL detection if helpers.sh is unavailable
+if ! command -v is_wsl >/dev/null 2>&1; then
+  is_wsl() {
+    [ -n "${WSL_DISTRO_NAME}" ] || grep -qi microsoft /proc/version 2>/dev/null
+  }
+fi
 
-# for setting history length see HISTSIZE and HISTFILESIZE in bash(1)
+# =============================================================================
+# Antidote Plugin Manager
+# =============================================================================
+ANTIDOTE_HOME="${ANTIDOTE_HOME:-$HOME/.antidote}"
+if [ -f "$ANTIDOTE_HOME/antidote.zsh" ]; then
+  source "$ANTIDOTE_HOME/antidote.zsh"
+  antidote load "$HOME/.zsh_plugins.txt"
+fi
+
+# =============================================================================
+# History
+# =============================================================================
 HISTSIZE=1000
 HISTFILESIZE=2000
 
-# some more ls aliases
+# =============================================================================
+# Aliases
+# =============================================================================
 alias ll='ls -alF'
 alias la='ls -A'
 alias l='ls -CF'
 
-# rbenv
-export PATH="$HOME/.rbenv/bin:$PATH"
-eval "$(rbenv init -)"
-
-# postgresql
-export PGDATA=/usr/local/var/postgres
-
-# one-liner httpd
-alias webrick="ruby -rwebrick -e 'WEBrick::HTTPServer.new(:DocumentRoot => \"./\", :Port => 8000).start'"
-
-# use brew-installed libraries primarily
-export PATH=/usr/local/bin:$PATH
-
-# shortened command "bundle exec"
 alias be="bundle exec"
 alias bx="bundle exec"
-
-# Rust
-export PATH="$HOME/.cargo/bin:$PATH"
-
-# pyenv
-export PYENV_ROOT="$HOME/.pyenv"
-export PATH="$PYENV_ROOT/bin:$PATH"
-eval "$(pyenv init --path)"
-eval "$(pyenv init -)"
-eval "$(pyenv virtualenv-init -)"
 
 # NeoVim
 alias vim="nvim"
 alias vi="nvim"
 export EDITOR=nvim
 
-# n (node.js version manager)
-export N_PREFIX="$HOME/.n"
-export PATH="$PATH:$N_PREFIX/bin"
+# one-liner httpd
+alias webrick="ruby -rwebrick -e 'WEBrick::HTTPServer.new(:DocumentRoot => \"./\", :Port => 8000).start'"
 
+# =============================================================================
+# Platform-specific Homebrew PATH
+# =============================================================================
+case "$(uname -s)" in
+  Darwin)
+    if [ -d /opt/homebrew/bin ]; then
+      # Apple Silicon
+      export PATH="/opt/homebrew/bin:$PATH"
+    elif [ -d /usr/local/bin ]; then
+      # Intel Mac
+      export PATH="/usr/local/bin:$PATH"
+    fi
+    ;;
+  Linux)
+    if [ -d /home/linuxbrew/.linuxbrew/bin ]; then
+      export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
+    elif [ -d /usr/local/bin ]; then
+      export PATH="/usr/local/bin:$PATH"
+    fi
+    ;;
+esac
+
+# =============================================================================
+# rbenv (Ruby) - skip if not installed
+# =============================================================================
+if command -v rbenv >/dev/null 2>&1; then
+  export PATH="$HOME/.rbenv/bin:$PATH"
+  eval "$(rbenv init -)"
+fi
+
+# =============================================================================
+# pyenv (Python) - skip if not installed
+# =============================================================================
+if command -v pyenv >/dev/null 2>&1; then
+  export PYENV_ROOT="$HOME/.pyenv"
+  export PATH="$PYENV_ROOT/bin:$PATH"
+  eval "$(pyenv init --path)"
+  eval "$(pyenv init -)"
+  if pyenv commands 2>/dev/null | grep -q virtualenv-init; then
+    eval "$(pyenv virtualenv-init -)"
+  fi
+fi
+
+# =============================================================================
+# n (Node.js version manager) - skip if not installed
+# =============================================================================
+if [ -d "$HOME/.n" ]; then
+  export N_PREFIX="$HOME/.n"
+  export PATH="$PATH:$N_PREFIX/bin"
+fi
+
+# =============================================================================
+# PostgreSQL (macOS only — skip on WSL/Linux)
+# =============================================================================
+if ! is_wsl && [ "$(uname -s)" = "Darwin" ] && [ -d /usr/local/var/postgres ]; then
+  export PGDATA=/usr/local/var/postgres
+fi
+
+# =============================================================================
+# Rust
+# =============================================================================
+if [ -d "$HOME/.cargo/bin" ]; then
+  export PATH="$HOME/.cargo/bin:$PATH"
+fi
+
+# =============================================================================
 # Google Cloud SDK
-if [ ! -f "$(brew --prefix)/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/path.zsh.inc" ]; then
-  source "$(brew --prefix)/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/path.zsh.inc"
+# =============================================================================
+# Try Homebrew-installed SDK first, then fall back to manual installation paths
+_gcloud_sdk_path=""
+if command -v brew >/dev/null 2>&1; then
+  _gcloud_sdk_path="$(brew --prefix google-cloud-sdk 2>/dev/null)"
 fi
-if [ ! -f "$(brew --prefix)/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/completion.zsh.inc" ]; then
-  source "$(brew --prefix)/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/completion.zsh.inc"
+
+if [ -n "$_gcloud_sdk_path" ] && [ -f "$_gcloud_sdk_path/path.zsh.inc" ]; then
+  source "$_gcloud_sdk_path/path.zsh.inc"
+elif [ -f /usr/local/share/google-cloud-sdk/path.zsh.inc ]; then
+  source /usr/local/share/google-cloud-sdk/path.zsh.inc
+elif [ -f "$HOME/google-cloud-sdk/path.zsh.inc" ]; then
+  source "$HOME/google-cloud-sdk/path.zsh.inc"
 fi
+
+if [ -n "$_gcloud_sdk_path" ] && [ -f "$_gcloud_sdk_path/completion.zsh.inc" ]; then
+  source "$_gcloud_sdk_path/completion.zsh.inc"
+elif [ -f /usr/local/share/google-cloud-sdk/completion.zsh.inc ]; then
+  source /usr/local/share/google-cloud-sdk/completion.zsh.inc
+elif [ -f "$HOME/google-cloud-sdk/completion.zsh.inc" ]; then
+  source "$HOME/google-cloud-sdk/completion.zsh.inc"
+fi
+
+unset _gcloud_sdk_path

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -38,13 +38,9 @@ else
 fi
 
 # Initialize completion system (zplug used to do this; antidote doesn't)
-# On macOS with Homebrew, /opt/homebrew/share is often group-writable,
-# which triggers compinit's "insecure directories" warning on every shell start.
-# Disable compfix to suppress the noisy (and in this context, expected) prompt.
-if [ "$CURRENT_PLATFORM" = "Mac" ]; then
-  ZSH_DISABLE_COMPFIX="true"
-fi
-autoload -Uz compinit && compinit
+# Use -i to silently skip insecure directories (common on macOS with Homebrew
+# where /opt/homebrew/share may be group-writable).
+autoload -Uz compinit && compinit -i
 
 # History substring search keybindings
 # zsh-history-substring-search doesn't bind keys by itself — do it here.

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -38,6 +38,12 @@ else
 fi
 
 # Initialize completion system (zplug used to do this; antidote doesn't)
+# On macOS with Homebrew, /opt/homebrew/share is often group-writable,
+# which triggers compinit's "insecure directories" warning on every shell start.
+# Disable compfix to suppress the noisy (and in this context, expected) prompt.
+if [ "$CURRENT_PLATFORM" = "Mac" ]; then
+  ZSH_DISABLE_COMPFIX="true"
+fi
 autoload -Uz compinit && compinit
 
 # History substring search keybindings

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -23,6 +23,15 @@ if ! command -v is_wsl >/dev/null 2>&1; then
   }
 fi
 
+# Fallback platform detection if helpers.sh didn't set CURRENT_PLATFORM
+if [ -z "${CURRENT_PLATFORM:-}" ]; then
+  case "$(uname -s)" in
+    Darwin)  CURRENT_PLATFORM='Mac' ;;
+    Linux*)  CURRENT_PLATFORM='Linux' ;;
+    *)       CURRENT_PLATFORM='Unknown' ;;
+  esac
+fi
+
 # =============================================================================
 # Antidote Plugin Manager
 # =============================================================================
@@ -36,6 +45,11 @@ fi
 
 # Initialize completion system (zplug used to do this; antidote doesn't)
 autoload -Uz compinit && compinit
+
+# History substring search keybindings
+# zsh-history-substring-search doesn't bind keys by itself — do it here.
+bindkey '^[[A' history-substring-search-up
+bindkey '^[[B' history-substring-search-down
 
 # =============================================================================
 # History

--- a/zsh/README.md
+++ b/zsh/README.md
@@ -2,10 +2,8 @@
 
 ## Requirements
 
-- **Zsh** (5.0+)
+- **Zsh** (5.4.2+) — required by Antidote and Pure
 - **Git** — for plugin installation
-- **curl** — for optional tool installers
-- **mise** (optional) — version manager for runtime tools
 
 ## What's Included
 
@@ -14,8 +12,8 @@
 | Plugin manager | [Antidote](https://github.com/mattmc3/antidote) |
 | Theme | [Pure](https://github.com/sindresorhus/pure) |
 | Plugins | syntax highlighting, autosuggestions, history search, completions, 256color |
-| Version managers | rbenv, pyenv, n (auto-detected, skipped if not installed) |
-| Editor | NeoVim aliases (`vim`/`vi` → `nvim`) |
+| Version managers | rbenv, pyenv, n, mise (auto-detected, skipped if not installed) |
+| Editor | NeoVim aliases (`vim`/`vi` → `nvim`, skipped if not installed) |
 | Cloud | Google Cloud SDK (auto-detected) |
 | Language | Rust, Ruby, Python, Node.js PATH setup (skipped if not installed) |
 
@@ -40,7 +38,16 @@ sudo apt install zsh
 
 ### 2. Set Zsh as default shell
 
+First, register the shell path if needed (macOS with Homebrew):
+
 ```bash
+# macOS: Homebrew zsh is not in /etc/shells by default
+sudo sh -c "echo $(brew --prefix)/bin/zsh >> /etc/shells"
+chsh -s "$(brew --prefix)/bin/zsh"
+```
+
+```bash
+# Linux / WSL
 chsh -s "$(which zsh)"
 ```
 
@@ -62,8 +69,7 @@ The script will:
 exec zsh
 ```
 
-Antidote will automatically install plugins declared in `~/.zsh_plugins.txt` on first run.
-No interactive prompts — it just works.
+Antidote will automatically clone plugins declared in `~/.zsh_plugins.txt` on first run.
 
 ## Platform Notes
 
@@ -88,4 +94,22 @@ To add or remove a plugin, edit `zsh/.zsh_plugins.txt` and reload:
 source ~/.zshrc
 ```
 
-Or start a new shell. Antidote handles install/update automatically.
+Or start a new shell.
+
+### Updating plugins
+
+Antidote does **not** update plugins automatically. To update all plugins:
+
+```bash
+antidote update
+```
+
+### Custom install location
+
+Set the `ANTIDOTE_HOME` environment variable to change where Antidote is installed
+(default: `~/.antidote`). This must be set **before** sourcing `.zshrc`:
+
+```bash
+export ANTIDOTE_HOME="$HOME/.local/share/antidote"
+source ~/.zshrc
+```

--- a/zsh/README.md
+++ b/zsh/README.md
@@ -107,9 +107,17 @@ antidote update
 ### Custom install location
 
 Set the `ANTIDOTE_HOME` environment variable to change where Antidote is installed
-(default: `~/.antidote`). This must be set **before** sourcing `.zshrc`:
+(default: `~/.antidote`). This must be set **before** running `deploy.sh` so that
+Antidote is cloned to the custom path:
 
 ```bash
 export ANTIDOTE_HOME="$HOME/.local/share/antidote"
-source ~/.zshrc
+./deploy.sh
+```
+
+The same variable must also be visible when `.zshrc` is sourced. To make it permanent,
+add it to your `~/.zshenv` (sourced before `.zshrc`):
+
+```bash
+echo 'export ANTIDOTE_HOME="$HOME/.local/share/antidote"' >> ~/.zshenv
 ```

--- a/zsh/README.md
+++ b/zsh/README.md
@@ -1,28 +1,91 @@
-# Setup
+# Zsh Setup
+
 ## Requirements
-* UNIX-like OS (Windows is not supported for now)
-* Z shell
+
+- **Zsh** (5.0+)
+- **Git** — for plugin installation
+- **curl** — for optional tool installers
+- **mise** (optional) — version manager for runtime tools
+
+## What's Included
+
+| Feature | Details |
+|---|---|
+| Plugin manager | [Antidote](https://github.com/mattmc3/antidote) |
+| Theme | [Pure](https://github.com/sindresorhus/pure) |
+| Plugins | syntax highlighting, autosuggestions, history search, completions, 256color |
+| Version managers | rbenv, pyenv, n (auto-detected, skipped if not installed) |
+| Editor | NeoVim aliases (`vim`/`vi` → `nvim`) |
+| Cloud | Google Cloud SDK (auto-detected) |
+| Language | Rust, Ruby, Python, Node.js PATH setup (skipped if not installed) |
 
 ## Installation
+
+### 1. Install Zsh
+
+#### macOS
+```bash
+brew install zsh
+```
+
+#### Linux (Debian/Ubuntu)
+```bash
+sudo apt install zsh
+```
+
+#### WSL (Windows Subsystem for Linux)
+```bash
+sudo apt install zsh
+```
+
+### 2. Set Zsh as default shell
+
+```bash
+chsh -s "$(which zsh)"
+```
+
+### 3. Run the deploy script
+
+```bash
+cd zsh
+./deploy.sh
+```
+
+The script will:
+- Create symlinks for `.zshrc` and `.zsh_plugins.txt`
+- Install [Antidote](https://github.com/mattmc3/antidote) via `git clone`
+- Warn if optional tools (rbenv, pyenv, n, mise) are missing
+
+### 4. Open a new shell
+
+```bash
+exec zsh
+```
+
+Antidote will automatically install plugins declared in `~/.zsh_plugins.txt` on first run.
+No interactive prompts — it just works.
+
+## Platform Notes
+
 ### macOS
-#### Install zsh
+- Homebrew paths are auto-detected for both Apple Silicon (`/opt/homebrew`) and Intel (`/usr/local`)
+- PostgreSQL `PGDATA` is set to `/usr/local/var/postgres` if the directory exists
+
+### Linux
+- Homebrew path defaults to `/home/linuxbrew/.linuxbrew`
+- PostgreSQL `PGDATA` is **not** set
+
+### WSL
+- Treated as Linux; macOS-specific settings (PostgreSQL PGDATA) are skipped
+- Works the same as native Linux otherwise
+
+## Plugin Management
+
+Plugins are declared in `~/.zsh_plugins.txt` (symlinked from this repo).
+To add or remove a plugin, edit `zsh/.zsh_plugins.txt` and reload:
+
 ```bash
-$ brew install zsh
+source ~/.zshrc
 ```
 
-#### Set zsh as default shell
-```bash
-$ sudo sh -c "echo '/usr/local/zsh' > /etc/shells"
-```
-
-#### Run the deploy script
-The script does:
-- puts some symlinks to the appropriate locations
-- Install additional tools using [zplug](https://github.com/zplug/zplug)
-
-```bash
-$ ./deploy.sh
-```
-
-#### Open new shell
-zplug will confirm you to install additional software. Answer it yes.
+Or start a new shell. Antidote handles install/update automatically.

--- a/zsh/deploy.sh
+++ b/zsh/deploy.sh
@@ -29,10 +29,9 @@ ln -fs "${REPO_DIR}/.zsh_plugins.txt" "$HOME/.zsh_plugins.txt"
 ANTIDOTE_HOME="${ANTIDOTE_HOME:-$HOME/.antidote}"
 if [ ! -f "$ANTIDOTE_HOME/antidote.zsh" ]; then
   echo "Installing Antidote plugin manager..."
-  # Remove any broken partial clone before retrying
-  if [ -d "$ANTIDOTE_HOME/.git" ]; then
-    rm -rf "$ANTIDOTE_HOME"
-  fi
+  # Remove any broken/stale directory to allow clean clone
+  # (covers: empty dir, partial clone without .git, half-failed prior runs)
+  rm -rf "$ANTIDOTE_HOME"
   git clone --depth=1 https://github.com/mattmc3/antidote.git "$ANTIDOTE_HOME" || {
     echo "[ERROR] Failed to clone Antidote into $ANTIDOTE_HOME" >&2
     exit 1

--- a/zsh/deploy.sh
+++ b/zsh/deploy.sh
@@ -3,10 +3,29 @@
 REPO_DIR=$(cd "$(dirname "$0")"; pwd)
 
 . "$REPO_DIR/../shared/helpers.sh"
-ensure_command mise "curl https://mise.run | sh" || exit 1
+
+# Check required tools
+ensure_command zsh   "Install zsh via your package manager" || exit 1
+ensure_command git   "Install git via your package manager" || exit 1
+ensure_command curl  "Install curl via your package manager" || exit 1
+
+# Check optional tools (warn only)
+for _tool in rbenv pyenv n mise; do
+  if ! command -v "$_tool" >/dev/null 2>&1; then
+    echo "[WARN] '$_tool' is not installed. Some features in .zshrc will be skipped." >&2
+  fi
+done
+unset _tool
 
 # Copy setting files
-ln -fs ${REPO_DIR}/.zshrc $HOME/.zshrc
+ln -fs "${REPO_DIR}/.zshrc"           "$HOME/.zshrc"
+ln -fs "${REPO_DIR}/.zsh_plugins.txt" "$HOME/.zsh_plugins.txt"
 
-# Install zplug
-curl -sL --proto-redir -all,https https://raw.githubusercontent.com/zplug/installer/master/installer.zsh| zsh
+# Install Antidote
+ANTIDOTE_HOME="${ANTIDOTE_HOME:-$HOME/.antidote}"
+if [ ! -d "$ANTIDOTE_HOME" ]; then
+  echo "Installing Antidote plugin manager..."
+  git clone --depth=1 https://github.com/mattmc3/antidote.git "$ANTIDOTE_HOME"
+else
+  echo "Antidote is already installed at $ANTIDOTE_HOME"
+fi

--- a/zsh/deploy.sh
+++ b/zsh/deploy.sh
@@ -29,9 +29,20 @@ ln -fs "${REPO_DIR}/.zsh_plugins.txt" "$HOME/.zsh_plugins.txt"
 ANTIDOTE_HOME="${ANTIDOTE_HOME:-$HOME/.antidote}"
 if [ ! -f "$ANTIDOTE_HOME/antidote.zsh" ]; then
   echo "Installing Antidote plugin manager..."
-  # Remove any broken/stale directory to allow clean clone
-  # (covers: empty dir, partial clone without .git, half-failed prior runs)
-  rm -rf "$ANTIDOTE_HOME"
+  # Only remove if it looks like a (broken) antidote clone or is empty.
+  if [ -d "$ANTIDOTE_HOME" ]; then
+    if [ -d "$ANTIDOTE_HOME/.git" ]; then
+      # Git repo — likely a prior antidote clone. Safe to remove.
+      rm -rf "$ANTIDOTE_HOME"
+    elif [ -z "$(ls -A "$ANTIDOTE_HOME" 2>/dev/null)" ]; then
+      # Empty directory — safe to remove.
+      rmdir "$ANTIDOTE_HOME"
+    else
+      echo "[ERROR] $ANTIDOTE_HOME exists but is not an Antidote installation." >&2
+      echo "Remove it manually or set ANTIDOTE_HOME to a different path." >&2
+      exit 1
+    fi
+  fi
   git clone --depth=1 https://github.com/mattmc3/antidote.git "$ANTIDOTE_HOME" || {
     echo "[ERROR] Failed to clone Antidote into $ANTIDOTE_HOME" >&2
     exit 1

--- a/zsh/deploy.sh
+++ b/zsh/deploy.sh
@@ -7,15 +7,19 @@ REPO_DIR=$(cd "$(dirname "$0")"; pwd)
 # Check required tools
 ensure_command zsh   "Install zsh via your package manager" || exit 1
 ensure_command git   "Install git via your package manager" || exit 1
-ensure_command curl  "Install curl via your package manager" || exit 1
 
 # Check optional tools (warn only)
-for _tool in rbenv pyenv n mise; do
+for _tool in rbenv pyenv n; do
   if ! command -v "$_tool" >/dev/null 2>&1; then
-    echo "[WARN] '$_tool' is not installed. Some features in .zshrc will be skipped." >&2
+    echo "[WARN] '$_tool' is not installed. Related settings in .zshrc will be skipped." >&2
   fi
 done
 unset _tool
+
+# mise requires a separate message because the install hint differs
+if ! command -v mise >/dev/null 2>&1; then
+  echo "[WARN] 'mise' is not installed. Install: curl https://mise.run | sh" >&2
+fi
 
 # Copy setting files
 ln -fs "${REPO_DIR}/.zshrc"           "$HOME/.zshrc"
@@ -23,9 +27,16 @@ ln -fs "${REPO_DIR}/.zsh_plugins.txt" "$HOME/.zsh_plugins.txt"
 
 # Install Antidote
 ANTIDOTE_HOME="${ANTIDOTE_HOME:-$HOME/.antidote}"
-if [ ! -d "$ANTIDOTE_HOME" ]; then
+if [ ! -f "$ANTIDOTE_HOME/antidote.zsh" ]; then
   echo "Installing Antidote plugin manager..."
-  git clone --depth=1 https://github.com/mattmc3/antidote.git "$ANTIDOTE_HOME"
+  # Remove any broken partial clone before retrying
+  if [ -d "$ANTIDOTE_HOME/.git" ]; then
+    rm -rf "$ANTIDOTE_HOME"
+  fi
+  git clone --depth=1 https://github.com/mattmc3/antidote.git "$ANTIDOTE_HOME" || {
+    echo "[ERROR] Failed to clone Antidote into $ANTIDOTE_HOME" >&2
+    exit 1
+  }
 else
   echo "Antidote is already installed at $ANTIDOTE_HOME"
 fi


### PR DESCRIPTION
## 概要

zplug（メンテナンス停止済み）から Antidote へのプラグインマネージャ移行と、クロスプラットフォーム（macOS/Linux/WSL）対応。

## 変更内容

### zplug → Antidote 移行
- `source ~/.zplug/init.zsh` → `source $ANTIDOTE_HOME/antidote.zsh` + `antidote load`
- プラグイン宣言を `.zsh_plugins.txt` (bundleファイル) に移動
- zplug の curl パイプインストール → Antidote の git clone インストール
- zsh-async 依存削除（zsh 本体にマージ済み）

### バグ修正
- GCloud SDK: `if [ ! -f ... ]` → `if [ -f ... ]`（条件反転バグ）
- GCloud SDK パスを新 Homebrew 形式 `$(brew --prefix google-cloud-sdk)` に更新 + 非 brew フォールバック追加

### クロスプラットフォーム対応
- `/usr/local/bin` ハードコード → OS 条件分岐
- rbenv, pyenv, n, Rust に存在チェック追加（未インストール時はスキップ）
- PostgreSQL PGDATA を macOS のみに制限
- `shared/helpers.sh` に `is_wsl()` 追加

### その他
- README.md: macOS/Linux/WSL の3パターンに書き直し
- deploy.sh: オプショナルツールの存在チェックと警告表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)