### PR TITLE
feat: 統合デプロイシステムの実装

### DIFF
--- a/deploy-all.sh
+++ b/deploy-all.sh
@@ -26,8 +26,6 @@ FORCE=0
 BACKUP=1
 ONLY_TOOLS=""
 
-AVAILABLE_TOOLS="zsh nvim tmux"
-
 # ── Usage ─────────────────────────────────────────────────────────────
 
 usage() {
@@ -90,7 +88,7 @@ while [ $# -gt 0 ]; do
   shift
 done
 
-# ── Resolve tool list ─────────────────────────────────────────────────
+# ── Resolve tool list (with dedup) ────────────────────────────────────
 
 if [ -n "$ONLY_TOOLS" ]; then
   TOOLS=""
@@ -102,8 +100,11 @@ if [ -n "$ONLY_TOOLS" ]; then
     _found=0
     for _a in $AVAILABLE_TOOLS; do
       if [ "$_t" = "$_a" ]; then
-        TOOLS="$TOOLS $_t"
-        _found=1
+        # Dedup: skip if already in TOOLS
+        case " $TOOLS " in
+          *" $_t "*) _found=1 ;;
+          *) TOOLS="$TOOLS $_t"; _found=1 ;;
+        esac
         break
       fi
     done
@@ -129,14 +130,23 @@ log_info "Platform: $(uname -s) ($(uname -m))"
 if is_wsl; then
   log_info "WSL:      detected"
 fi
-log_info "Tools:    $TOOLS"
+log_info "Tools:   $TOOLS"
 printf '\n'
 
-# ── Confirmation (unless --force) ─────────────────────────────────────
+# ── Confirmation (only in interactive mode, never in dry-run) ─────────
 
-if [ "$FORCE" -eq 0 ]; then
+if [ "$FORCE" -eq 0 ] && [ "$DRY_RUN" -eq 0 ]; then
+  # Refuse to proceed when stdin is not a terminal (pipe / cron / CI).
+  if [ ! -t 0 ]; then
+    log_error "stdin is not a terminal. Use --force to deploy non-interactively."
+    exit 1
+  fi
   printf 'Proceed with deployment? [Y/n] '
-  read -r _answer
+  read -r _answer || {
+    printf '\n'
+    log_warn "Aborted (EOF on stdin)."
+    exit 1
+  }
   case "$_answer" in
     [Nn]|[Nn][Oo])
       log_warn "Aborted."
@@ -161,12 +171,16 @@ for _tool in $TOOLS; do
     continue
   fi
 
-  # Per-tool confirmation in interactive mode
+  # Per-tool confirmation in interactive mode (never in dry-run)
   if [ "$FORCE" -eq 0 ] && [ "$DRY_RUN" -eq 0 ]; then
-    printf 'Deploy %s? [Y/n/skip all/q] ' "$_tool"
-    read -r _answer
+    printf 'Deploy %s? [Y/n/s/q] ' "$_tool"
+    read -r _answer || {
+      printf '\n'
+      log_warn "Aborted (EOF on stdin)."
+      exit 1
+    }
     case "$_answer" in
-      [Ss])
+      [Ss]|[Ss][Kk][Ii][Pp]*)
         log_info "Skipping remaining tools."
         break
         ;;
@@ -196,3 +210,5 @@ if [ "$OVERALL_OK" -eq 0 ]; then
 else
   log_warn "Deployment finished with some errors. Check the output above."
 fi
+
+exit "$OVERALL_OK"

--- a/deploy-all.sh
+++ b/deploy-all.sh
@@ -1,0 +1,198 @@
+#!/bin/sh
+#
+# deploy-all.sh — Unified deployment orchestrator for all dotfile tools.
+#
+# Usage:
+#   ./deploy-all.sh                Interactive mode (asks before each tool)
+#   ./deploy-all.sh --dry-run      Print what would be done, don't do it
+#   ./deploy-all.sh --force        Skip all confirmations
+#   ./deploy-all.sh --only zsh,nvim   Deploy specific tools only
+#   ./deploy-all.sh --backup       Always back up existing files (on by default)
+#   ./deploy-all.sh --no-backup    Skip backing up existing files
+#
+# Options can be combined:
+#   ./deploy-all.sh --dry-run --only tmux
+#   ./deploy-all.sh --force --only zsh,nvim
+
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
+. "$SCRIPT_DIR/shared/helpers.sh"
+
+# ── Defaults ──────────────────────────────────────────────────────────
+
+DRY_RUN=0
+FORCE=0
+BACKUP=1
+ONLY_TOOLS=""
+
+AVAILABLE_TOOLS="zsh nvim tmux"
+
+# ── Usage ─────────────────────────────────────────────────────────────
+
+usage() {
+  cat <<EOF
+Usage: $0 [OPTIONS]
+
+Unified deployment orchestrator for all dotfile tools.
+
+Options:
+  --dry-run         Print what would be done, make no changes.
+  --force           Skip all confirmation prompts.
+  --only <tools>    Comma-separated list of tools to deploy.
+                    Available: $AVAILABLE_TOOLS
+  --backup          Back up existing config files (default).
+  --no-backup       Do NOT back up existing files before overwriting.
+  --help, -h        Show this help message.
+
+Examples:
+  $0                           # Interactive, all tools
+  $0 --dry-run                 # Preview everything
+  $0 --only zsh,nvim           # Deploy only zsh and nvim
+  $0 --force --only tmux       # Deploy tmux without prompts
+EOF
+}
+
+# ── Parse arguments ───────────────────────────────────────────────────
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=1
+      ;;
+    --force)
+      FORCE=1
+      ;;
+    --backup)
+      BACKUP=1
+      ;;
+    --no-backup)
+      BACKUP=0
+      ;;
+    --only)
+      if [ $# -lt 2 ]; then
+        log_error "--only requires a comma-separated list of tools."
+        exit 1
+      fi
+      ONLY_TOOLS="$2"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      log_error "Unknown option: $1"
+      usage >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+# ── Resolve tool list ─────────────────────────────────────────────────
+
+if [ -n "$ONLY_TOOLS" ]; then
+  TOOLS=""
+  _OLDIFS="$IFS"
+  IFS=','
+  for _t in $ONLY_TOOLS; do
+    IFS="$_OLDIFS"
+    _t=$(printf '%s' "$_t" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//') # trim
+    _found=0
+    for _a in $AVAILABLE_TOOLS; do
+      if [ "$_t" = "$_a" ]; then
+        TOOLS="$TOOLS $_t"
+        _found=1
+        break
+      fi
+    done
+    if [ "$_found" -eq 0 ]; then
+      log_error "Unknown tool: '$_t'. Available: $AVAILABLE_TOOLS"
+      exit 1
+    fi
+    IFS=','
+  done
+  IFS="$_OLDIFS"
+else
+  TOOLS="$AVAILABLE_TOOLS"
+fi
+
+# ── Banner ────────────────────────────────────────────────────────────
+
+printf '\n'
+log_hr
+if [ "$DRY_RUN" -eq 1 ]; then
+  log_warn "DRY RUN MODE — no changes will be made."
+fi
+log_info "Platform: $(uname -s) ($(uname -m))"
+if is_wsl; then
+  log_info "WSL:      detected"
+fi
+log_info "Tools:    $TOOLS"
+printf '\n'
+
+# ── Confirmation (unless --force) ─────────────────────────────────────
+
+if [ "$FORCE" -eq 0 ]; then
+  printf 'Proceed with deployment? [Y/n] '
+  read -r _answer
+  case "$_answer" in
+    [Nn]|[Nn][Oo])
+      log_warn "Aborted."
+      exit 0
+      ;;
+  esac
+  printf '\n'
+fi
+
+# ── Run each tool's deploy script ─────────────────────────────────────
+
+export DRY_RUN
+export BACKUP
+
+OVERALL_OK=0
+
+for _tool in $TOOLS; do
+  _deploy_script="$SCRIPT_DIR/$_tool/deploy.sh"
+  if [ ! -x "$_deploy_script" ]; then
+    log_error "Deploy script not found or not executable: $_deploy_script"
+    OVERALL_OK=1
+    continue
+  fi
+
+  # Per-tool confirmation in interactive mode
+  if [ "$FORCE" -eq 0 ] && [ "$DRY_RUN" -eq 0 ]; then
+    printf 'Deploy %s? [Y/n/skip all/q] ' "$_tool"
+    read -r _answer
+    case "$_answer" in
+      [Ss])
+        log_info "Skipping remaining tools."
+        break
+        ;;
+      [Qq])
+        log_warn "Aborted."
+        exit 0
+        ;;
+      [Nn]|[Nn][Oo])
+        log_info "Skipping: $_tool"
+        continue
+        ;;
+    esac
+  fi
+
+  "$_deploy_script" || {
+    log_error "Deploy script for '$_tool' exited with code $?."
+    OVERALL_OK=1
+  }
+done
+
+# ── Summary ───────────────────────────────────────────────────────────
+
+printf '\n'
+log_hr
+if [ "$OVERALL_OK" -eq 0 ]; then
+  log_ok "All deployments finished successfully. 🎉"
+else
+  log_warn "Deployment finished with some errors. Check the output above."
+fi

--- a/nvim/deploy.sh
+++ b/nvim/deploy.sh
@@ -8,8 +8,16 @@ CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/nvim"
 log_hr
 log_info "Deploying: nvim"
 
+FAIL=0
+
 # --- Required tools ---
-ensure_command mise "curl https://mise.run | sh" || exit 1
+ensure_command curl "Install curl via your package manager" || exit 1
+ensure_command git  "Install git via your package manager"  || exit 1
+
+# --- Optional: mise (warn only — not called by this script) ---
+if ! command -v mise >/dev/null 2>&1; then
+  log_warn "'mise' is not installed. Install: curl https://mise.run | sh"
+fi
 
 # --- Create config directory ---
 if [ "${DRY_RUN:-0}" -eq 0 ]; then
@@ -17,18 +25,32 @@ if [ "${DRY_RUN:-0}" -eq 0 ]; then
 fi
 
 # --- Symlink config files ---
-symlink_backup "$SCRIPT_DIR/init.vim"       "$CONFIG_DIR/init.vim"
-symlink_backup "$SCRIPT_DIR/dein.toml"      "$CONFIG_DIR/dein.toml"
-symlink_backup "$SCRIPT_DIR/dein_lazy.toml" "$CONFIG_DIR/dein_lazy.toml"
+symlink_backup "$SCRIPT_DIR/init.vim"       "$CONFIG_DIR/init.vim"       || FAIL=1
+symlink_backup "$SCRIPT_DIR/dein.toml"      "$CONFIG_DIR/dein.toml"      || FAIL=1
+symlink_backup "$SCRIPT_DIR/dein_lazy.toml" "$CONFIG_DIR/dein_lazy.toml" || FAIL=1
 
 # --- Install dein.vim ---
 if [ "${DRY_RUN:-0}" -eq 1 ]; then
   log_info "[DRY-RUN] Would install dein.vim"
 else
   log_info "Installing dein.vim plugin manager..."
-  curl -fsSL https://raw.githubusercontent.com/Shougo/dein.vim/master/bin/installer.sh > /tmp/dein_installer.sh
-  sh /tmp/dein_installer.sh ~/.cache/dein > /dev/null 2>&1
-  log_ok "dein.vim installed."
+  _installer=$(mktemp "${TMPDIR:-/tmp}/dein_installer.XXXXXX") || {
+    log_error "Failed to create temporary file for dein installer."
+    exit 1
+  }
+  if ! curl -fsSL https://raw.githubusercontent.com/Shougo/dein.vim/master/bin/installer.sh -o "$_installer"; then
+    log_error "Failed to download dein.vim installer."
+    rm -f "$_installer"
+    exit 1
+  fi
+  if sh "$_installer" "$HOME/.cache/dein" >/dev/null 2>&1; then
+    log_ok "dein.vim installed."
+  else
+    log_error "dein.vim installer failed."
+    rm -f "$_installer"
+    exit 1
+  fi
+  rm -f "$_installer"
 fi
 
 # --- Python / Ruby Neovim providers ---
@@ -55,4 +77,8 @@ else
   gem install neovim 2>/dev/null || log_warn "gem install neovim failed (Ruby may not be set up)"
 fi
 
+if [ "$FAIL" -ne 0 ]; then
+  log_error "nvim deployment completed with errors."
+  exit 1
+fi
 log_ok "nvim deployment complete."

--- a/nvim/deploy.sh
+++ b/nvim/deploy.sh
@@ -1,36 +1,58 @@
 #!/bin/sh
 
-REPO_DIR=$(cd "$(dirname "$0")"; pwd)
+SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
+. "$SCRIPT_DIR/../shared/helpers.sh"
+
 CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/nvim"
 
-. "$REPO_DIR/../shared/helpers.sh"
+log_hr
+log_info "Deploying: nvim"
+
+# --- Required tools ---
 ensure_command mise "curl https://mise.run | sh" || exit 1
 
-mkdir -p $CONFIG_DIR
-
-# Copy setting files
-ln -fs ${REPO_DIR}/init.vim $CONFIG_DIR/init.vim
-ln -fs ${REPO_DIR}/dein.toml $CONFIG_DIR/dein.toml
-ln -fs ${REPO_DIR}/dein_lazy.toml $CONFIG_DIR/dein_lazy.toml
-
-# Install dein.vim
-curl https://raw.githubusercontent.com/Shougo/dein.vim/master/bin/installer.sh > /tmp/dein_installer.sh
-sh /tmp/dein_installer.sh ~/.cache/dein > /dev/null 2>&1
-
-# Install necessary software
-if [ -n "$PYENV_VIRTUALENV_INIT " ]; then
-  pyenv install 2.7.16
-  pyenv virtualenv 2.7.16 neovim2
-  pyenv activate neovim2
-  pyenv exec pip install neovim
-  pyenv which python
-
-  pyenv install 3.8.10
-  pyenv virtualenv 3.8.10 neovim3
-  pyenv activate neovim3
-  pyenv exec pip install neovim
-  pyenv which python
-else
-  pip install neovim
+# --- Create config directory ---
+if [ "${DRY_RUN:-0}" -eq 0 ]; then
+  mkdir -p "$CONFIG_DIR"
 fi
-gem install neovim
+
+# --- Symlink config files ---
+symlink_backup "$SCRIPT_DIR/init.vim"       "$CONFIG_DIR/init.vim"
+symlink_backup "$SCRIPT_DIR/dein.toml"      "$CONFIG_DIR/dein.toml"
+symlink_backup "$SCRIPT_DIR/dein_lazy.toml" "$CONFIG_DIR/dein_lazy.toml"
+
+# --- Install dein.vim ---
+if [ "${DRY_RUN:-0}" -eq 1 ]; then
+  log_info "[DRY-RUN] Would install dein.vim"
+else
+  log_info "Installing dein.vim plugin manager..."
+  curl -fsSL https://raw.githubusercontent.com/Shougo/dein.vim/master/bin/installer.sh > /tmp/dein_installer.sh
+  sh /tmp/dein_installer.sh ~/.cache/dein > /dev/null 2>&1
+  log_ok "dein.vim installed."
+fi
+
+# --- Python / Ruby Neovim providers ---
+if [ "${DRY_RUN:-0}" -eq 1 ]; then
+  log_info "[DRY-RUN] Would install neovim Python/Ruby providers"
+else
+  if [ -n "${PYENV_VIRTUALENV_INIT:-}" ]; then
+    log_info "Setting up pyenv-based Neovim Python providers..."
+    pyenv install 2.7.16
+    pyenv virtualenv 2.7.16 neovim2
+    pyenv activate neovim2
+    pyenv exec pip install neovim
+    pyenv which python
+
+    pyenv install 3.8.10
+    pyenv virtualenv 3.8.10 neovim3
+    pyenv activate neovim3
+    pyenv exec pip install neovim
+    pyenv which python
+  else
+    log_info "Installing neovim Python provider via pip..."
+    pip install neovim
+  fi
+  gem install neovim 2>/dev/null || log_warn "gem install neovim failed (Ruby may not be set up)"
+fi
+
+log_ok "nvim deployment complete."

--- a/shared/helpers.sh
+++ b/shared/helpers.sh
@@ -1,38 +1,198 @@
 #!/bin/sh
+#
+# shared/helpers.sh — Unified helpers sourced by every deploy script.
+# Keep functions self-contained and side-effect free where possible.
+# This file uses POSIX sh (no bashisms).
+
+# ── Platform detection ────────────────────────────────────────────────
 
 case "$(uname -s)" in
   Darwin)
-    CURRENT_PLATFORM='Mac'
+    CURRENT_PLATFORM='macos'
     ;;
   Linux*)
-    CURRENT_PLATFORM='Linux'
+    CURRENT_PLATFORM='linux'
     ;;
   MINGW32_NT*)
-    CURRENT_PLATFORM='Cygwin'
+    CURRENT_PLATFORM='cygwin'
     ;;
   *)
-    CURRENT_PLATFORM='Unknown'
+    CURRENT_PLATFORM='unknown'
     ;;
 esac
 
+is_macos() { [ "$CURRENT_PLATFORM" = "macos" ]; }
+is_linux() { [ "$CURRENT_PLATFORM" = "linux" ]; }
+
 # is_wsl
-# Detect if running under Windows Subsystem for Linux (WSL).
-# Returns 0 if WSL, 1 otherwise.
+# Returns 0 if running under Windows Subsystem for Linux, 1 otherwise.
 is_wsl() {
   [ -n "${WSL_DISTRO_NAME:-}" ] && return 0
   grep -qi microsoft /proc/version 2>/dev/null
 }
 
+# ── Logging (colorised when stdout is a terminal) ─────────────────────
+
+_can_color() {
+  [ -t 1 ] && [ -z "${NO_COLOR:-}" ]
+}
+
+log_info() {
+  if _can_color; then
+    printf '\033[36m[INFO]\033[m %s\n' "$*"
+  else
+    printf '[INFO] %s\n' "$*"
+  fi
+}
+
+log_warn() {
+  if _can_color; then
+    printf '\033[33m[WARN]\033[m %s\n' "$*" >&2
+  else
+    printf '[WARN] %s\n' "$*" >&2
+  fi
+}
+
+log_error() {
+  if _can_color; then
+    printf '\033[31m[ERROR]\033[m %s\n' "$*" >&2
+  else
+    printf '[ERROR] %s\n' "$*" >&2
+  fi
+}
+
+log_ok() {
+  if _can_color; then
+    printf '\033[32m[OK]\033[m %s\n' "$*"
+  else
+    printf '[OK] %s\n' "$*"
+  fi
+}
+
+# Print a horizontal rule (useful for section breaks)
+log_hr() {
+  printf '――――――――――――――――――――――――――――――――――――――――――――――――――\n'
+}
+
+# ── Command helpers ───────────────────────────────────────────────────
+
 # ensure_command <cmd> [hint]
-# Check if a command is available, print install instructions if not.
-# Returns 0 if found, 1 if not found.
+# Check if a command is available.  If not, print an error + optional
+# install hint and return 1.
+# In dry-run mode, missing commands are noted but do not cause a failure
+# (so the full plan is visible).
 ensure_command() {
   if command -v "$1" >/dev/null 2>&1; then
     return 0
   fi
-  echo "[ERROR] '$1' is not installed." >&2
-  if [ -n "$2" ]; then
-    echo "Install: $2" >&2
+  if [ "${DRY_RUN:-0}" -eq 1 ]; then
+    log_warn "[DRY-RUN] '$1' is not installed — would fail during real deploy."
+    if [ -n "${2:-}" ]; then
+      printf '        Install: %s\n' "$2" >&2
+    fi
+    return 0
+  fi
+  log_error "'$1' is not installed."
+  if [ -n "${2:-}" ]; then
+    printf '       Install: %s\n' "$2" >&2
   fi
   return 1
+}
+
+# ── Homebrew prefix ───────────────────────────────────────────────────
+
+# get_brew_prefix
+# Print the Homebrew prefix for the current architecture.
+# macOS:  /opt/homebrew (Apple Silicon) or /usr/local (Intel)
+# Linux:  /home/linuxbrew/.linuxbrew
+get_brew_prefix() {
+  if command -v brew >/dev/null 2>&1; then
+    brew --prefix 2>/dev/null && return 0
+  fi
+  # Best guess when brew is not on PATH yet
+  if is_macos; then
+    if [ "$(uname -m)" = "arm64" ]; then
+      printf '/opt/homebrew'
+    else
+      printf '/usr/local'
+    fi
+  elif is_linux; then
+    printf '/home/linuxbrew/.linuxbrew'
+  else
+    printf '/usr/local'
+  fi
+}
+
+# ── Filesystem helpers ────────────────────────────────────────────────
+
+# symlink_backup <src> <dst>
+# Create a symlink dst → src.  If dst already exists (and is not already
+# the correct symlink), move it to dst.backup first.
+# If DRY_RUN is set to 1, only print what would be done.
+symlink_backup() {
+  _src="$1"
+  _dst="$2"
+
+  # Already correct?
+  if [ -L "$_dst" ] && [ "$(readlink "$_dst")" = "$_src" ]; then
+    log_info "Already linked: $_dst → $_src"
+    return 0
+  fi
+
+  if [ "${DRY_RUN:-0}" -eq 1 ]; then
+    if [ -e "$_dst" ] || [ -L "$_dst" ]; then
+      printf '[DRY-RUN] mv %s %s.backup\n' "$_dst" "$_dst"
+    fi
+    printf '[DRY-RUN] ln -fs %s %s\n' "$_src" "$_dst"
+    return 0
+  fi
+
+  # Ensure parent directory exists
+  _parent="$(dirname "$_dst")"
+  if [ ! -d "$_parent" ]; then
+    mkdir -p "$_parent" || {
+      log_error "Failed to create directory: $_parent"
+      return 1
+    }
+  fi
+
+  # Back up existing file / symlink
+  if [ -e "$_dst" ] || [ -L "$_dst" ]; then
+    log_warn "Backing up existing: $_dst → $_dst.backup"
+    mv "$_dst" "$_dst.backup" || {
+      log_error "Failed to back up: $_dst"
+      return 1
+    }
+  fi
+
+  ln -fs "$_src" "$_dst" || {
+    log_error "Failed to symlink: $_src → $_dst"
+    return 1
+  }
+  log_ok "Linked: $_dst → $_src"
+}
+
+# symlink_restore <dst>
+# Remove the symlink at dst and restore from dst.backup if it exists.
+# Used by uninstall.sh.
+symlink_restore() {
+  _dst="$1"
+
+  if [ "${DRY_RUN:-0}" -eq 1 ]; then
+    if [ -L "$_dst" ]; then
+      printf '[DRY-RUN] rm %s\n' "$_dst"
+    fi
+    if [ -e "$_dst.backup" ]; then
+      printf '[DRY-RUN] mv %s.backup %s\n' "$_dst" "$_dst"
+    fi
+    return 0
+  fi
+
+  if [ -L "$_dst" ]; then
+    rm "$_dst" && log_info "Removed symlink: $_dst"
+  fi
+
+  if [ -e "$_dst.backup" ]; then
+    mv "$_dst.backup" "$_dst" && log_ok "Restored backup: $_dst"
+  fi
 }

--- a/shared/helpers.sh
+++ b/shared/helpers.sh
@@ -133,14 +133,14 @@ get_brew_prefix() {
 
 # _backup_dst <dst>
 # Print a safe backup path for dst.  If dst.backup doesn't exist, use it
-# as-is; otherwise append a timestamp to avoid overwriting a previous
-# backup.
+# as-is; otherwise append a timestamp + PID to avoid overwriting a previous
+# backup (PID included to prevent same-second collisions).
 _backup_dst() {
   _bd="$1.backup"
   if [ ! -e "$_bd" ] && [ ! -L "$_bd" ]; then
     printf '%s' "$_bd"
   else
-    printf '%s.%s' "$_bd" "$(date +%Y%m%d%H%M%S)"
+    printf '%s.%s.%s' "$_bd" "$(date +%Y%m%d%H%M%S)" "$$"
   fi
 }
 
@@ -161,7 +161,11 @@ symlink_backup() {
 
   if [ "${DRY_RUN:-0}" -eq 1 ]; then
     if [ -e "$_dst" ] || [ -L "$_dst" ]; then
-      printf '[DRY-RUN] mv %s %s.backup\n' "$_dst" "$_dst"
+      if [ "${BACKUP:-1}" -eq 0 ]; then
+        printf '[DRY-RUN] rm -f %s\n' "$_dst"
+      else
+        printf '[DRY-RUN] mv %s %s.backup\n' "$_dst" "$_dst"
+      fi
     fi
     printf '[DRY-RUN] ln -fs %s %s\n' "$_src" "$_dst"
     return 0
@@ -205,6 +209,8 @@ symlink_backup() {
 # symlink_restore <dst>
 # Remove the symlink at dst and restore from a .backup* file if one exists.
 # If dst is a real file (not a symlink), skip to avoid overwriting user data.
+# Restores the *original* backup (dst.backup without timestamp) if available;
+# otherwise falls back to the oldest timestamped backup.
 # Used by uninstall.sh.
 symlink_restore() {
   _dst="$1"
@@ -212,6 +218,8 @@ symlink_restore() {
   if [ "${DRY_RUN:-0}" -eq 1 ]; then
     if [ -L "$_dst" ]; then
       printf '[DRY-RUN] rm %s\n' "$_dst"
+    elif [ -e "$_dst" ]; then
+      printf '[DRY-RUN] (skip — real file exists at %s)\n' "$_dst"
     fi
     if [ -e "$_dst.backup" ] || [ -L "$_dst.backup" ]; then
       printf '[DRY-RUN] mv %s.backup %s\n' "$_dst" "$_dst"
@@ -219,21 +227,41 @@ symlink_restore() {
     return 0
   fi
 
+  _fail=0
+
   if [ -L "$_dst" ]; then
-    rm "$_dst" && log_info "Removed symlink: $_dst"
+    if rm "$_dst"; then
+      log_info "Removed symlink: $_dst"
+    else
+      log_error "Failed to remove symlink: $_dst"
+      _fail=1
+    fi
   elif [ -e "$_dst" ]; then
     log_warn "Skipping restore — real file exists at $_dst (not a symlink)"
     return 0
   fi
 
-  # Find the latest backup (dst.backup or dst.backup.YYYYmmddHHMMSS)
-  _latest=""
-  for _cand in "$_dst.backup" "$_dst.backup."*; do
-    [ -e "$_cand" ] || continue
-    _latest="$_cand"
-  done
-  if [ -n "$_latest" ]; then
-    mv "$_latest" "$_dst" && log_ok "Restored backup: $_dst (from $_latest)"
+  # Restore the *original* backup (dst.backup) first; if that doesn't exist,
+  # pick the oldest timestamped backup (first in glob order = earliest).
+  _restore=""
+  if [ -e "$_dst.backup" ]; then
+    _restore="$_dst.backup"
+  else
+    for _cand in "$_dst.backup."*; do
+      [ -e "$_cand" ] || continue
+      _restore="$_cand"
+      break
+    done
   fi
-  return 0
+
+  if [ -n "$_restore" ]; then
+    if mv "$_restore" "$_dst"; then
+      log_ok "Restored backup: $_dst (from $_restore)"
+    else
+      log_error "Failed to restore backup: $_restore → $_dst"
+      _fail=1
+    fi
+  fi
+
+  return "$_fail"
 }

--- a/shared/helpers.sh
+++ b/shared/helpers.sh
@@ -31,14 +31,20 @@ is_wsl() {
   grep -qi microsoft /proc/version 2>/dev/null
 }
 
-# ── Logging (colorised when stdout is a terminal) ─────────────────────
+# Canonical list of available tools.  deploy-all.sh and uninstall.sh
+# both source this file, so the list is defined once.
+AVAILABLE_TOOLS="zsh nvim tmux"
 
+# ── Logging (colourised when the output fd is a terminal) ─────────────
+
+# _can_color <fd>
+# Returns 0 if fd is a terminal and NO_COLOR is unset.
 _can_color() {
-  [ -t 1 ] && [ -z "${NO_COLOR:-}" ]
+  [ -t "$1" ] && [ -z "${NO_COLOR:-}" ]
 }
 
 log_info() {
-  if _can_color; then
+  if _can_color 1; then
     printf '\033[36m[INFO]\033[m %s\n' "$*"
   else
     printf '[INFO] %s\n' "$*"
@@ -46,7 +52,7 @@ log_info() {
 }
 
 log_warn() {
-  if _can_color; then
+  if _can_color 2; then
     printf '\033[33m[WARN]\033[m %s\n' "$*" >&2
   else
     printf '[WARN] %s\n' "$*" >&2
@@ -54,7 +60,7 @@ log_warn() {
 }
 
 log_error() {
-  if _can_color; then
+  if _can_color 2; then
     printf '\033[31m[ERROR]\033[m %s\n' "$*" >&2
   else
     printf '[ERROR] %s\n' "$*" >&2
@@ -62,16 +68,16 @@ log_error() {
 }
 
 log_ok() {
-  if _can_color; then
+  if _can_color 1; then
     printf '\033[32m[OK]\033[m %s\n' "$*"
   else
     printf '[OK] %s\n' "$*"
   fi
 }
 
-# Print a horizontal rule (useful for section breaks)
+# Print a horizontal rule (ASCII for portability, 50 chars wide).
 log_hr() {
-  printf '――――――――――――――――――――――――――――――――――――――――――――――――――\n'
+  printf '%s\n' '--------------------------------------------------'
 }
 
 # ── Command helpers ───────────────────────────────────────────────────
@@ -125,10 +131,24 @@ get_brew_prefix() {
 
 # ── Filesystem helpers ────────────────────────────────────────────────
 
+# _backup_dst <dst>
+# Print a safe backup path for dst.  If dst.backup doesn't exist, use it
+# as-is; otherwise append a timestamp to avoid overwriting a previous
+# backup.
+_backup_dst() {
+  _bd="$1.backup"
+  if [ ! -e "$_bd" ] && [ ! -L "$_bd" ]; then
+    printf '%s' "$_bd"
+  else
+    printf '%s.%s' "$_bd" "$(date +%Y%m%d%H%M%S)"
+  fi
+}
+
 # symlink_backup <src> <dst>
 # Create a symlink dst → src.  If dst already exists (and is not already
-# the correct symlink), move it to dst.backup first.
+# the correct symlink), move it to a backup path first.
 # If DRY_RUN is set to 1, only print what would be done.
+# If BACKUP is set to 0, existing files are removed instead of backed up.
 symlink_backup() {
   _src="$1"
   _dst="$2"
@@ -156,13 +176,22 @@ symlink_backup() {
     }
   fi
 
-  # Back up existing file / symlink
+  # Handle existing file / symlink
   if [ -e "$_dst" ] || [ -L "$_dst" ]; then
-    log_warn "Backing up existing: $_dst → $_dst.backup"
-    mv "$_dst" "$_dst.backup" || {
-      log_error "Failed to back up: $_dst"
-      return 1
-    }
+    if [ "${BACKUP:-1}" -eq 0 ]; then
+      log_warn "Removing existing (backup disabled): $_dst"
+      rm -f "$_dst" || {
+        log_error "Failed to remove: $_dst"
+        return 1
+      }
+    else
+      _backup_path="$(_backup_dst "$_dst")"
+      log_warn "Backing up existing: $_dst → $_backup_path"
+      mv "$_dst" "$_backup_path" || {
+        log_error "Failed to back up: $_dst"
+        return 1
+      }
+    fi
   fi
 
   ln -fs "$_src" "$_dst" || {
@@ -170,10 +199,12 @@ symlink_backup() {
     return 1
   }
   log_ok "Linked: $_dst → $_src"
+  return 0
 }
 
 # symlink_restore <dst>
-# Remove the symlink at dst and restore from dst.backup if it exists.
+# Remove the symlink at dst and restore from a .backup* file if one exists.
+# If dst is a real file (not a symlink), skip to avoid overwriting user data.
 # Used by uninstall.sh.
 symlink_restore() {
   _dst="$1"
@@ -182,7 +213,7 @@ symlink_restore() {
     if [ -L "$_dst" ]; then
       printf '[DRY-RUN] rm %s\n' "$_dst"
     fi
-    if [ -e "$_dst.backup" ]; then
+    if [ -e "$_dst.backup" ] || [ -L "$_dst.backup" ]; then
       printf '[DRY-RUN] mv %s.backup %s\n' "$_dst" "$_dst"
     fi
     return 0
@@ -190,9 +221,19 @@ symlink_restore() {
 
   if [ -L "$_dst" ]; then
     rm "$_dst" && log_info "Removed symlink: $_dst"
+  elif [ -e "$_dst" ]; then
+    log_warn "Skipping restore — real file exists at $_dst (not a symlink)"
+    return 0
   fi
 
-  if [ -e "$_dst.backup" ]; then
-    mv "$_dst.backup" "$_dst" && log_ok "Restored backup: $_dst"
+  # Find the latest backup (dst.backup or dst.backup.YYYYmmddHHMMSS)
+  _latest=""
+  for _cand in "$_dst.backup" "$_dst.backup."*; do
+    [ -e "$_cand" ] || continue
+    _latest="$_cand"
+  done
+  if [ -n "$_latest" ]; then
+    mv "$_latest" "$_dst" && log_ok "Restored backup: $_dst (from $_latest)"
   fi
+  return 0
 }

--- a/shared/helpers.sh
+++ b/shared/helpers.sh
@@ -164,7 +164,7 @@ symlink_backup() {
       if [ "${BACKUP:-1}" -eq 0 ]; then
         printf '[DRY-RUN] rm -f %s\n' "$_dst"
       else
-        printf '[DRY-RUN] mv %s %s.backup\n' "$_dst" "$_dst"
+        printf '[DRY-RUN] mv %s %s\n' "$_dst" "$(_backup_dst "$_dst")"
       fi
     fi
     printf '[DRY-RUN] ln -fs %s %s\n' "$_src" "$_dst"
@@ -243,12 +243,13 @@ symlink_restore() {
 
   # Restore the *original* backup (dst.backup) first; if that doesn't exist,
   # pick the oldest timestamped backup (first in glob order = earliest).
+  # Use -e || -L to also match backup files that are symlinks or broken symlinks.
   _restore=""
-  if [ -e "$_dst.backup" ]; then
+  if [ -e "$_dst.backup" ] || [ -L "$_dst.backup" ]; then
     _restore="$_dst.backup"
   else
     for _cand in "$_dst.backup."*; do
-      [ -e "$_cand" ] || continue
+      [ -e "$_cand" ] || [ -L "$_cand" ] || continue
       _restore="$_cand"
       break
     done

--- a/tmux/deploy.sh
+++ b/tmux/deploy.sh
@@ -6,8 +6,10 @@ SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
 log_hr
 log_info "Deploying: tmux"
 
+FAIL=0
+
 # --- Symlink config ---
-symlink_backup "$SCRIPT_DIR/tmux.conf" "$HOME/.tmux.conf"
+symlink_backup "$SCRIPT_DIR/tmux.conf" "$HOME/.tmux.conf" || FAIL=1
 
 # --- Install tmux (macOS only via Homebrew) ---
 if is_macos; then
@@ -26,4 +28,8 @@ elif ! command -v tmux >/dev/null 2>&1; then
   log_warn "tmux is not installed. Install via your package manager."
 fi
 
+if [ "$FAIL" -ne 0 ]; then
+  log_error "tmux deployment completed with errors."
+  exit 1
+fi
 log_ok "tmux deployment complete."

--- a/tmux/deploy.sh
+++ b/tmux/deploy.sh
@@ -1,16 +1,29 @@
 #!/bin/sh
 
-REPO_DIR=$(cd "$(dirname "$0")"; pwd)
-CONFIG_DIR=$HOME
+SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
+. "$SCRIPT_DIR/../shared/helpers.sh"
 
-. "$REPO_DIR/../shared/helpers.sh"
+log_hr
+log_info "Deploying: tmux"
 
-# Copy setting files
-ln -fs ${REPO_DIR}/tmux.conf $CONFIG_DIR/.tmux.conf
+# --- Symlink config ---
+symlink_backup "$SCRIPT_DIR/tmux.conf" "$HOME/.tmux.conf"
 
-# Install necessary software
-case $CURRENT_PLATFORM in
-  "Mac")
-    brew install tmux reattach-to-user-namespace
-    ;;
-esac
+# --- Install tmux (macOS only via Homebrew) ---
+if is_macos; then
+  if [ "${DRY_RUN:-0}" -eq 1 ]; then
+    log_info "[DRY-RUN] Would run: brew install tmux reattach-to-user-namespace"
+  else
+    if command -v tmux >/dev/null 2>&1; then
+      log_info "tmux is already installed."
+    else
+      log_info "Installing tmux via Homebrew..."
+      brew install tmux reattach-to-user-namespace
+      log_ok "tmux installed."
+    fi
+  fi
+elif ! command -v tmux >/dev/null 2>&1; then
+  log_warn "tmux is not installed. Install via your package manager."
+fi
+
+log_ok "tmux deployment complete."

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,156 @@
+#!/bin/sh
+#
+# uninstall.sh — Remove symlinks created by deploy scripts and restore backups.
+#
+# Usage:
+#   ./uninstall.sh                 Interactive mode
+#   ./uninstall.sh --dry-run       Print what would be done
+#   ./uninstall.sh --force         Skip all confirmations
+#   ./uninstall.sh --only zsh,nvim  Uninstall specific tools
+
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
+. "$SCRIPT_DIR/shared/helpers.sh"
+
+# ── Defaults ──────────────────────────────────────────────────────────
+
+DRY_RUN=0
+FORCE=0
+ONLY_TOOLS=""
+AVAILABLE_TOOLS="zsh nvim tmux"
+
+# ── Known symlinks per tool (dst only — src is inferred from the link target) ──
+# Each tool entry lists the symlink destinations that deploy creates.
+KNOWN_LINKS_zsh="
+$HOME/.zshrc
+$HOME/.zsh_plugins.txt
+"
+
+KNOWN_LINKS_nvim="
+${XDG_CONFIG_HOME:-$HOME/.config}/nvim/init.vim
+${XDG_CONFIG_HOME:-$HOME/.config}/nvim/dein.toml
+${XDG_CONFIG_HOME:-$HOME/.config}/nvim/dein_lazy.toml
+"
+
+KNOWN_LINKS_tmux="
+$HOME/.tmux.conf
+"
+
+# ── Usage ─────────────────────────────────────────────────────────────
+
+usage() {
+  cat <<EOF
+Usage: $0 [OPTIONS]
+
+Remove dotfile symlinks and restore any .backup files.
+
+Options:
+  --dry-run         Print what would be done, make no changes.
+  --force           Skip all confirmation prompts.
+  --only <tools>    Comma-separated list of tools to uninstall.
+                    Available: $AVAILABLE_TOOLS
+  --help, -h        Show this help message.
+EOF
+}
+
+# ── Parse arguments ───────────────────────────────────────────────────
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run)    DRY_RUN=1 ;;
+    --force)      FORCE=1 ;;
+    --only)
+      ONLY_TOOLS="$2"; shift ;;
+    --help|-h)    usage; exit 0 ;;
+    *)
+      log_error "Unknown option: $1"
+      usage >&2; exit 1 ;;
+  esac
+  shift
+done
+
+# ── Resolve tool list ─────────────────────────────────────────────────
+
+if [ -n "$ONLY_TOOLS" ]; then
+  TOOLS=""
+  _OLDIFS="$IFS"
+  IFS=','
+  for _t in $ONLY_TOOLS; do
+    IFS="$_OLDIFS"
+    _t=$(printf '%s' "$_t" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+    _found=0
+    for _a in $AVAILABLE_TOOLS; do
+      if [ "$_t" = "$_a" ]; then
+        TOOLS="$TOOLS $_t"
+        _found=1; break
+      fi
+    done
+    if [ "$_found" -eq 0 ]; then
+      log_error "Unknown tool: '$_t'. Available: $AVAILABLE_TOOLS"
+      exit 1
+    fi
+    IFS=','
+  done
+  IFS="$_OLDIFS"
+else
+  TOOLS="$AVAILABLE_TOOLS"
+fi
+
+# ── Banner ────────────────────────────────────────────────────────────
+
+printf '\n'
+log_hr
+if [ "$DRY_RUN" -eq 1 ]; then
+  log_warn "DRY RUN MODE — no changes will be made."
+fi
+log_info "Uninstalling tools: $TOOLS"
+printf '\n'
+
+# ── Confirmation ──────────────────────────────────────────────────────
+
+if [ "$FORCE" -eq 0 ]; then
+  printf 'Proceed with uninstall? [y/N] '
+  read -r _answer
+  case "$_answer" in
+    [Yy]|[Yy][Ee][Ss]) ;;
+    *) log_warn "Aborted."; exit 0 ;;
+  esac
+  printf '\n'
+fi
+
+# ── Process each tool ─────────────────────────────────────────────────
+
+export DRY_RUN
+
+for _tool in $TOOLS; do
+  log_hr
+  log_info "Uninstalling: $_tool"
+
+  # Get the list of known links for this tool via eval
+  _links_var="KNOWN_LINKS_$_tool"
+  eval "_links=\$$_links_var"
+
+  for _dst in $_links; do
+    if [ -L "$_dst" ]; then
+      symlink_restore "$_dst"
+    elif [ -e "$_dst.backup" ]; then
+      # Link gone but backup exists — restore anyway
+      if [ "${DRY_RUN:-0}" -eq 1 ]; then
+        printf '[DRY-RUN] mv %s.backup %s\n' "$_dst" "$_dst"
+      else
+        mv "$_dst.backup" "$_dst" && log_ok "Restored backup: $_dst"
+      fi
+    else
+      log_info "Nothing to do for: $_dst"
+    fi
+  done
+done
+
+# ── Summary ───────────────────────────────────────────────────────────
+
+printf '\n'
+log_hr
+log_ok "Uninstall complete."
+log_warn "Note: Installed packages (zsh, tmux, etc.) were not removed."
+log_warn "Note: Plugin managers (Antidote, dein.vim) were not removed."

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -18,24 +18,24 @@ SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
 DRY_RUN=0
 FORCE=0
 ONLY_TOOLS=""
-AVAILABLE_TOOLS="zsh nvim tmux"
 
-# ── Known symlinks per tool (dst only — src is inferred from the link target) ──
-# Each tool entry lists the symlink destinations that deploy creates.
-KNOWN_LINKS_zsh="
-$HOME/.zshrc
-$HOME/.zsh_plugins.txt
-"
+# ── Known symlinks per tool (dst only) ────────────────────────────────
+# Each tool entry lists one symlink destination per line.
+# Use printf so the trailing-newline line-continuation works portably.
+KNOWN_LINKS_zsh=$(printf '%s\n' \
+  "$HOME/.zshrc" \
+  "$HOME/.zsh_plugins.txt" \
+)
 
-KNOWN_LINKS_nvim="
-${XDG_CONFIG_HOME:-$HOME/.config}/nvim/init.vim
-${XDG_CONFIG_HOME:-$HOME/.config}/nvim/dein.toml
-${XDG_CONFIG_HOME:-$HOME/.config}/nvim/dein_lazy.toml
-"
+KNOWN_LINKS_nvim=$(printf '%s\n' \
+  "${XDG_CONFIG_HOME:-$HOME/.config}/nvim/init.vim" \
+  "${XDG_CONFIG_HOME:-$HOME/.config}/nvim/dein.toml" \
+  "${XDG_CONFIG_HOME:-$HOME/.config}/nvim/dein_lazy.toml" \
+)
 
-KNOWN_LINKS_tmux="
-$HOME/.tmux.conf
-"
+KNOWN_LINKS_tmux=$(printf '%s\n' \
+  "$HOME/.tmux.conf" \
+)
 
 # ── Usage ─────────────────────────────────────────────────────────────
 
@@ -61,6 +61,10 @@ while [ $# -gt 0 ]; do
     --dry-run)    DRY_RUN=1 ;;
     --force)      FORCE=1 ;;
     --only)
+      if [ $# -lt 2 ]; then
+        log_error "--only requires a comma-separated list of tools."
+        exit 1
+      fi
       ONLY_TOOLS="$2"; shift ;;
     --help|-h)    usage; exit 0 ;;
     *)
@@ -70,7 +74,7 @@ while [ $# -gt 0 ]; do
   shift
 done
 
-# ── Resolve tool list ─────────────────────────────────────────────────
+# ── Resolve tool list (with dedup) ────────────────────────────────────
 
 if [ -n "$ONLY_TOOLS" ]; then
   TOOLS=""
@@ -82,8 +86,11 @@ if [ -n "$ONLY_TOOLS" ]; then
     _found=0
     for _a in $AVAILABLE_TOOLS; do
       if [ "$_t" = "$_a" ]; then
-        TOOLS="$TOOLS $_t"
-        _found=1; break
+        case " $TOOLS " in
+          *" $_t "*) _found=1 ;;
+          *) TOOLS="$TOOLS $_t"; _found=1 ;;
+        esac
+        break
       fi
     done
     if [ "$_found" -eq 0 ]; then
@@ -104,14 +111,22 @@ log_hr
 if [ "$DRY_RUN" -eq 1 ]; then
   log_warn "DRY RUN MODE — no changes will be made."
 fi
-log_info "Uninstalling tools: $TOOLS"
+log_info "Uninstalling tools:$TOOLS"
 printf '\n'
 
-# ── Confirmation ──────────────────────────────────────────────────────
+# ── Confirmation (only in interactive mode, never in dry-run) ─────────
 
-if [ "$FORCE" -eq 0 ]; then
+if [ "$FORCE" -eq 0 ] && [ "$DRY_RUN" -eq 0 ]; then
+  if [ ! -t 0 ]; then
+    log_error "stdin is not a terminal. Use --force to uninstall non-interactively."
+    exit 1
+  fi
   printf 'Proceed with uninstall? [y/N] '
-  read -r _answer
+  read -r _answer || {
+    printf '\n'
+    log_warn "Aborted (EOF on stdin)."
+    exit 1
+  }
   case "$_answer" in
     [Yy]|[Yy][Ee][Ss]) ;;
     *) log_warn "Aborted."; exit 0 ;;
@@ -122,35 +137,44 @@ fi
 # ── Process each tool ─────────────────────────────────────────────────
 
 export DRY_RUN
+OVERALL_OK=0
 
 for _tool in $TOOLS; do
   log_hr
   log_info "Uninstalling: $_tool"
 
-  # Get the list of known links for this tool via eval
+  # Get the list of known links for this tool
   _links_var="KNOWN_LINKS_$_tool"
-  eval "_links=\$$_links_var"
+  eval "_links=\${$_links_var:-}"
+  if [ -z "$_links" ]; then
+    log_warn "No link list defined for '$_tool'. Skipping."
+    continue
+  fi
 
+  # Iterate over links, one per line (IFS=newline to handle whitespace paths)
+  _OLDIFS="$IFS"
+  IFS='
+'
   for _dst in $_links; do
-    if [ -L "$_dst" ]; then
-      symlink_restore "$_dst"
-    elif [ -e "$_dst.backup" ]; then
-      # Link gone but backup exists — restore anyway
-      if [ "${DRY_RUN:-0}" -eq 1 ]; then
-        printf '[DRY-RUN] mv %s.backup %s\n' "$_dst" "$_dst"
-      else
-        mv "$_dst.backup" "$_dst" && log_ok "Restored backup: $_dst"
-      fi
-    else
-      log_info "Nothing to do for: $_dst"
-    fi
+    IFS="$_OLDIFS"
+    [ -z "$_dst" ] && continue  # skip blank lines
+    symlink_restore "$_dst" || OVERALL_OK=1
+    IFS='
+'
   done
+  IFS="$_OLDIFS"
 done
 
 # ── Summary ───────────────────────────────────────────────────────────
 
 printf '\n'
 log_hr
-log_ok "Uninstall complete."
+if [ "$OVERALL_OK" -eq 0 ]; then
+  log_ok "Uninstall complete."
+else
+  log_warn "Uninstall finished with some errors. Check the output above."
+fi
 log_warn "Note: Installed packages (zsh, tmux, etc.) were not removed."
 log_warn "Note: Plugin managers (Antidote, dein.vim) were not removed."
+
+exit "$OVERALL_OK"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -9,15 +9,13 @@ DOTFILES_DIR="${_ZSHRC_PATH:h:h}"
 unset _ZSHRC_PATH
 
 # =============================================================================
-# Source shared helpers (CURRENT_PLATFORM, is_wsl, ensure_command)
-# Note: only CURRENT_PLATFORM is actively used in this file.
-# is_wsl and ensure_command are available for interactive use but not called here.
+# Source shared helpers (CURRENT_PLATFORM, is_macos, is_linux, is_wsl, etc.)
 # =============================================================================
 if [ -f "$DOTFILES_DIR/shared/helpers.sh" ]; then
   source "$DOTFILES_DIR/shared/helpers.sh"
 fi
 
-# Fallback platform detection if helpers.sh didn't set CURRENT_PLATFORM
+# Fallback platform detection and helpers if shared/helpers.sh is unavailable.
 if [ -z "${CURRENT_PLATFORM:-}" ]; then
   case "$(uname -s)" in
     Darwin)  CURRENT_PLATFORM='macos' ;;
@@ -25,6 +23,15 @@ if [ -z "${CURRENT_PLATFORM:-}" ]; then
     *)       CURRENT_PLATFORM='unknown' ;;
   esac
 fi
+
+# Fallback functions (defined only when helpers.sh didn't provide them)
+if ! command -v is_macos >/dev/null 2>&1; then
+  is_macos() { [ "$CURRENT_PLATFORM" = "macos" ]; }
+  is_linux() { [ "$CURRENT_PLATFORM" = "linux" ]; }
+fi
+
+# helpers.sh exports AVAILABLE_TOOLS which we don't need in an interactive shell.
+unset AVAILABLE_TOOLS 2>/dev/null || true
 
 # =============================================================================
 # Antidote Plugin Manager
@@ -78,9 +85,6 @@ fi
 # one-liner httpd
 alias webrick="ruby -rwebrick -e 'WEBrick::HTTPServer.new(:DocumentRoot => \"./\", :Port => 8000).start'"
 
-# =============================================================================
-# Platform-specific Homebrew PATH
-# =============================================================================
 # =============================================================================
 # Platform-specific Homebrew PATH
 # =============================================================================

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -20,9 +20,9 @@ fi
 # Fallback platform detection if helpers.sh didn't set CURRENT_PLATFORM
 if [ -z "${CURRENT_PLATFORM:-}" ]; then
   case "$(uname -s)" in
-    Darwin)  CURRENT_PLATFORM='Mac' ;;
-    Linux*)  CURRENT_PLATFORM='Linux' ;;
-    *)       CURRENT_PLATFORM='Unknown' ;;
+    Darwin)  CURRENT_PLATFORM='macos' ;;
+    Linux*)  CURRENT_PLATFORM='linux' ;;
+    *)       CURRENT_PLATFORM='unknown' ;;
   esac
 fi
 
@@ -81,24 +81,24 @@ alias webrick="ruby -rwebrick -e 'WEBrick::HTTPServer.new(:DocumentRoot => \"./\
 # =============================================================================
 # Platform-specific Homebrew PATH
 # =============================================================================
-case "$CURRENT_PLATFORM" in
-  Mac)
-    if [ -d /opt/homebrew/bin ]; then
-      # Apple Silicon
-      export PATH="/opt/homebrew/bin:$PATH"
-    elif [ -d /usr/local/bin ]; then
-      # Intel Mac
-      export PATH="/usr/local/bin:$PATH"
-    fi
-    ;;
-  Linux)
-    if [ -d /home/linuxbrew/.linuxbrew/bin ]; then
-      export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
-    elif [ -d /usr/local/bin ]; then
-      export PATH="/usr/local/bin:$PATH"
-    fi
-    ;;
-esac
+# =============================================================================
+# Platform-specific Homebrew PATH
+# =============================================================================
+if is_macos; then
+  if [ -d /opt/homebrew/bin ]; then
+    # Apple Silicon
+    export PATH="/opt/homebrew/bin:$PATH"
+  elif [ -d /usr/local/bin ]; then
+    # Intel Mac
+    export PATH="/usr/local/bin:$PATH"
+  fi
+elif is_linux; then
+  if [ -d /home/linuxbrew/.linuxbrew/bin ]; then
+    export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
+  elif [ -d /usr/local/bin ]; then
+    export PATH="/usr/local/bin:$PATH"
+  fi
+fi
 
 # =============================================================================
 # rbenv (Ruby) - skip if not installed
@@ -137,7 +137,7 @@ fi
 # =============================================================================
 # PostgreSQL (macOS only — WSL and Linux skip)
 # =============================================================================
-if [ "$CURRENT_PLATFORM" = "Mac" ] && [ -d /usr/local/var/postgres ]; then
+if is_macos && [ -d /usr/local/var/postgres ]; then
   export PGDATA=/usr/local/var/postgres
 fi
 

--- a/zsh/deploy.sh
+++ b/zsh/deploy.sh
@@ -1,52 +1,57 @@
 #!/bin/sh
 
-REPO_DIR=$(cd "$(dirname "$0")"; pwd)
+SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
+. "$SCRIPT_DIR/../shared/helpers.sh"
 
-. "$REPO_DIR/../shared/helpers.sh"
+log_hr
+log_info "Deploying: zsh"
 
-# Check required tools
-ensure_command zsh   "Install zsh via your package manager" || exit 1
-ensure_command git   "Install git via your package manager" || exit 1
+# --- Required tools ---
+ensure_command zsh "Install zsh via your package manager" || exit 1
+ensure_command git "Install git via your package manager" || exit 1
 
-# Check optional tools (warn only)
+# --- Optional tools (warn only) ---
 for _tool in rbenv pyenv n; do
   if ! command -v "$_tool" >/dev/null 2>&1; then
-    echo "[WARN] '$_tool' is not installed. Related settings in .zshrc will be skipped." >&2
+    log_warn "'$_tool' is not installed. Related settings in .zshrc will be skipped."
   fi
 done
 unset _tool
 
-# mise requires a separate message because the install hint differs
 if ! command -v mise >/dev/null 2>&1; then
-  echo "[WARN] 'mise' is not installed. Install: curl https://mise.run | sh" >&2
+  log_warn "'mise' is not installed. Install: curl https://mise.run | sh"
 fi
 
-# Copy setting files
-ln -fs "${REPO_DIR}/.zshrc"           "$HOME/.zshrc"
-ln -fs "${REPO_DIR}/.zsh_plugins.txt" "$HOME/.zsh_plugins.txt"
+# --- Symlink config files ---
+symlink_backup "$SCRIPT_DIR/.zshrc"           "$HOME/.zshrc"
+symlink_backup "$SCRIPT_DIR/.zsh_plugins.txt" "$HOME/.zsh_plugins.txt"
 
-# Install Antidote
+# --- Install Antidote plugin manager ---
 ANTIDOTE_HOME="${ANTIDOTE_HOME:-$HOME/.antidote}"
 if [ ! -f "$ANTIDOTE_HOME/antidote.zsh" ]; then
-  echo "Installing Antidote plugin manager..."
-  # Only remove if it looks like a (broken) antidote clone or is empty.
-  if [ -d "$ANTIDOTE_HOME" ]; then
-    if [ -d "$ANTIDOTE_HOME/.git" ]; then
-      # Git repo — likely a prior antidote clone. Safe to remove.
-      rm -rf "$ANTIDOTE_HOME"
-    elif [ -z "$(ls -A "$ANTIDOTE_HOME" 2>/dev/null)" ]; then
-      # Empty directory — safe to remove.
-      rmdir "$ANTIDOTE_HOME"
-    else
-      echo "[ERROR] $ANTIDOTE_HOME exists but is not an Antidote installation." >&2
-      echo "Remove it manually or set ANTIDOTE_HOME to a different path." >&2
-      exit 1
+  if [ "${DRY_RUN:-0}" -eq 1 ]; then
+    log_info "[DRY-RUN] Would install Antidote to $ANTIDOTE_HOME"
+  else
+    log_info "Installing Antidote plugin manager..."
+    if [ -d "$ANTIDOTE_HOME" ]; then
+      if [ -d "$ANTIDOTE_HOME/.git" ]; then
+        rm -rf "$ANTIDOTE_HOME"
+      elif [ -z "$(ls -A "$ANTIDOTE_HOME" 2>/dev/null)" ]; then
+        rmdir "$ANTIDOTE_HOME"
+      else
+        log_error "$ANTIDOTE_HOME exists but is not an Antidote installation."
+        log_error "Remove it manually or set ANTIDOTE_HOME to a different path."
+        exit 1
+      fi
     fi
+    git clone --depth=1 https://github.com/mattmc3/antidote.git "$ANTIDOTE_HOME" || {
+      log_error "Failed to clone Antidote into $ANTIDOTE_HOME"
+      exit 1
+    }
+    log_ok "Antidote installed to $ANTIDOTE_HOME"
   fi
-  git clone --depth=1 https://github.com/mattmc3/antidote.git "$ANTIDOTE_HOME" || {
-    echo "[ERROR] Failed to clone Antidote into $ANTIDOTE_HOME" >&2
-    exit 1
-  }
 else
-  echo "Antidote is already installed at $ANTIDOTE_HOME"
+  log_info "Antidote is already installed at $ANTIDOTE_HOME"
 fi
+
+log_ok "zsh deployment complete."

--- a/zsh/deploy.sh
+++ b/zsh/deploy.sh
@@ -6,6 +6,8 @@ SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
 log_hr
 log_info "Deploying: zsh"
 
+FAIL=0
+
 # --- Required tools ---
 ensure_command zsh "Install zsh via your package manager" || exit 1
 ensure_command git "Install git via your package manager" || exit 1
@@ -23,8 +25,8 @@ if ! command -v mise >/dev/null 2>&1; then
 fi
 
 # --- Symlink config files ---
-symlink_backup "$SCRIPT_DIR/.zshrc"           "$HOME/.zshrc"
-symlink_backup "$SCRIPT_DIR/.zsh_plugins.txt" "$HOME/.zsh_plugins.txt"
+symlink_backup "$SCRIPT_DIR/.zshrc"           "$HOME/.zshrc"           || FAIL=1
+symlink_backup "$SCRIPT_DIR/.zsh_plugins.txt" "$HOME/.zsh_plugins.txt" || FAIL=1
 
 # --- Install Antidote plugin manager ---
 ANTIDOTE_HOME="${ANTIDOTE_HOME:-$HOME/.antidote}"
@@ -54,4 +56,8 @@ else
   log_info "Antidote is already installed at $ANTIDOTE_HOME"
 fi
 
+if [ "$FAIL" -ne 0 ]; then
+  log_error "zsh deployment completed with errors."
+  exit 1
+fi
 log_ok "zsh deployment complete."


### PR DESCRIPTION
## 概要

リポジトリ全体を統一的にセットアップできる仕組みを実装しました。

## 変更内容

### 1. `shared/helpers.sh` の拡充
- カラー付きログ出力: `log_info`, `log_warn`, `log_error`, `log_ok`
- プラットフォーム判定: `is_macos`, `is_linux`, `is_wsl`
- コマンド存在チェック: `ensure_command`（ドライラン対応強化）
- シンボリックリンク管理: `symlink_backup`, `symlink_restore`
- Homebrewプレフィックス: `get_brew_prefix`

### 2. `deploy-all.sh` 新規作成（ルート直下）
- `--dry-run`: 変更なしで実行計画を表示
- `--only <tools>`: 特定ツールのみデプロイ（例: `--only zsh,nvim`）
- `--force`: 確認プロンプトをスキップ
- `--backup` / `--no-backup`: バックアップ制御
- デフォルトは対話的に進行

### 3. `uninstall.sh` 新規作成
- シンボリックリンクの削除
- `.backup` からの復元
- `--dry-run`, `--force`, `--only` オプション対応

### 4. 各ツール `deploy.sh` の統一
- `zsh/deploy.sh`, `nvim/deploy.sh`, `tmux/deploy.sh` を helpers.sh 統一インターフェースに移行
- `symlink_backup` による安全なシンボリックリンク作成
- カラーログ出力
- ドライランモード対応

## 動作確認

```bash
# ドライラン（全ツールの計画表示）
./deploy-all.sh --force --dry-run

# 特定ツールのみ
./deploy-all.sh --force --dry-run --only tmux

# アンインストールのドライラン
./uninstall.sh --dry-run
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)