### PR TITLE
feat(tmux): クロスプラットフォーム対応とモダン化

### DIFF
--- a/tmux/README.md
+++ b/tmux/README.md
@@ -43,10 +43,10 @@ Prefix: `C-q` (Ctrl+q)
 
 | Key | Action |
 |-----|--------|
-| `Prefix h` / `←` | Select pane left |
-| `Prefix j` / `↓` | Select pane down |
-| `Prefix k` / `↑` | Select pane up |
-| `Prefix l` / `→` | Select pane right |
+| `Prefix h` | Select pane left |
+| `Prefix j` | Select pane down |
+| `Prefix k` | Select pane up |
+| `Prefix l` | Select pane right |
 | `Prefix \|` | Split horizontally |
 | `Prefix -` | Split vertically |
 | `Prefix H` | Resize pane left (+5) |
@@ -63,7 +63,7 @@ Prefix: `C-q` (Ctrl+q)
 | `Ctrl+v` | Block selection (rectangle) |
 | `y` | Copy selection |
 | `Y` | Copy whole line |
-| `Mouse drag` | Copy to system clipboard |
+| `Mouse drag` (in copy mode) | Copy selection to system clipboard (macOS: pbcopy, Linux: xclip/wl-copy) |
 
 ### General
 

--- a/tmux/README.md
+++ b/tmux/README.md
@@ -1,17 +1,80 @@
-# Setup
-## Requirements
-- `tmux`
-  - Install the software with any package manager you want on your system.
+# tmux
 
-## Run the deploy script
-The script will:
-- put some symlinks to the appropriate locations
+Cross-platform tmux configuration with Vim-style keybindings.
+
+## Requirements
+
+- **tmux 3.3+** — older versions may not support the modern mouse and copy-mode syntax.
+
+## Installation
+
+### macOS
 
 ```bash
-$ ./deploy.sh
+brew install tmux
 ```
 
-## Instructions for config file
-The config file are based on this document:
+### Linux (Debian/Ubuntu)
 
-[tmuxを必要最低限で入門して使う - Qiita](https://qiita.com/nl0_blu/items/9d207a70ccc8467f7bab)
+```bash
+sudo apt update && sudo apt install -y tmux xclip
+```
+
+> `xclip` provides system clipboard integration. On Wayland, install `wl-copy` instead.
+
+### WSL (Windows Subsystem for Linux)
+
+Same as Linux above. For clipboard passthrough to Windows, install `xclip` and ensure an X server is running, or use Windows Terminal / WSLg which handle clipboard automatically.
+
+### Deploy
+
+```bash
+cd tmux
+./deploy.sh
+```
+
+The script symlinks `tmux.conf` to `~/.tmux.conf` and installs tmux if needed.
+
+## Keybindings
+
+Prefix: `C-q` (Ctrl+q)
+
+### Panes
+
+| Key | Action |
+|-----|--------|
+| `Prefix h` / `←` | Select pane left |
+| `Prefix j` / `↓` | Select pane down |
+| `Prefix k` / `↑` | Select pane up |
+| `Prefix l` / `→` | Select pane right |
+| `Prefix \|` | Split horizontally |
+| `Prefix -` | Split vertically |
+| `Prefix H` | Resize pane left (+5) |
+| `Prefix J` | Resize pane down (+5) |
+| `Prefix K` | Resize pane up (+5) |
+| `Prefix L` | Resize pane right (+5) |
+
+### Copy Mode (Vi-style)
+
+| Key | Action |
+|-----|--------|
+| `v` | Begin selection |
+| `V` | Select whole line |
+| `Ctrl+v` | Block selection (rectangle) |
+| `y` | Copy selection |
+| `Y` | Copy whole line |
+| `Mouse drag` | Copy to system clipboard |
+
+### General
+
+| Key | Action |
+|-----|--------|
+| `Ctrl+p` | Paste buffer |
+
+## Platform-specific behaviour
+
+| Feature | macOS | Linux / WSL |
+|---------|-------|-------------|
+| Wi-Fi SSID in status bar | ✅ `#(wifi)` | — hidden |
+| Battery in status bar | ✅ `#(battery --tmux)` | — hidden |
+| Clipboard copy | `pbcopy` (via reattach-to-user-namespace) | `xclip` / `wl-copy` |

--- a/tmux/deploy.sh
+++ b/tmux/deploy.sh
@@ -11,21 +11,54 @@ FAIL=0
 # --- Symlink config ---
 symlink_backup "$SCRIPT_DIR/tmux.conf" "$HOME/.tmux.conf" || FAIL=1
 
-# --- Install tmux (macOS only via Homebrew) ---
-if is_macos; then
-  if [ "${DRY_RUN:-0}" -eq 1 ]; then
-    log_info "[DRY-RUN] Would run: brew install tmux reattach-to-user-namespace"
+# --- Install tmux ---
+install_tmux_macos() {
+  if command -v tmux >/dev/null 2>&1; then
+    log_info "tmux is already installed ($(tmux -V 2>&1))."
+    return 0
+  fi
+  log_info "Installing tmux via Homebrew..."
+  brew install tmux
+  log_ok "tmux installed."
+}
+
+install_tmux_linux() {
+  if command -v tmux >/dev/null 2>&1; then
+    log_info "tmux is already installed ($(tmux -V 2>&1))."
+    return 0
+  fi
+  # Prefer apt on Debian/Ubuntu; fall back to Homebrew
+  if command -v apt-get >/dev/null 2>&1; then
+    log_info "Installing tmux via apt..."
+    sudo apt-get update -qq && sudo apt-get install -y tmux
+    log_ok "tmux installed via apt."
+  elif command -v brew >/dev/null 2>&1; then
+    log_info "Installing tmux via Homebrew (Linux)..."
+    brew install tmux
+    log_ok "tmux installed via Homebrew."
   else
-    if command -v tmux >/dev/null 2>&1; then
-      log_info "tmux is already installed."
-    else
-      log_info "Installing tmux via Homebrew..."
-      brew install tmux reattach-to-user-namespace
-      log_ok "tmux installed."
+    log_warn "Could not install tmux automatically."
+    log_warn "Install manually: https://github.com/tmux/tmux/wiki/Installing"
+  fi
+}
+
+if [ "${DRY_RUN:-0}" -eq 1 ]; then
+  log_info "[DRY-RUN] Would install tmux for platform: $CURRENT_PLATFORM"
+else
+  if is_macos; then
+    install_tmux_macos
+  elif is_linux; then
+    install_tmux_linux
+    if is_wsl; then
+      log_info "WSL detected: tmux clipboard integration uses xclip or wl-copy."
+      log_info "  Install xclip:  sudo apt install xclip"
+      log_info "  Or use Windows Terminal / WSLg for automatic clipboard passthrough."
+    fi
+  else
+    if ! command -v tmux >/dev/null 2>&1; then
+      log_warn "tmux is not installed. Install via your package manager."
     fi
   fi
-elif ! command -v tmux >/dev/null 2>&1; then
-  log_warn "tmux is not installed. Install via your package manager."
 fi
 
 if [ "$FAIL" -ne 0 ]; then

--- a/tmux/deploy.sh
+++ b/tmux/deploy.sh
@@ -18,7 +18,10 @@ install_tmux_macos() {
     return 0
   fi
   log_info "Installing tmux via Homebrew..."
-  brew install tmux
+  brew install tmux reattach-to-user-namespace || {
+    log_error "Failed to install tmux via Homebrew."
+    return 1
+  }
   log_ok "tmux installed."
 }
 
@@ -30,15 +33,22 @@ install_tmux_linux() {
   # Prefer apt on Debian/Ubuntu; fall back to Homebrew
   if command -v apt-get >/dev/null 2>&1; then
     log_info "Installing tmux via apt..."
-    sudo apt-get update -qq && sudo apt-get install -y tmux
+    sudo apt-get update -qq && sudo apt-get install -y tmux || {
+      log_error "Failed to install tmux via apt."
+      return 1
+    }
     log_ok "tmux installed via apt."
   elif command -v brew >/dev/null 2>&1; then
     log_info "Installing tmux via Homebrew (Linux)..."
-    brew install tmux
+    brew install tmux || {
+      log_error "Failed to install tmux via Homebrew."
+      return 1
+    }
     log_ok "tmux installed via Homebrew."
   else
     log_warn "Could not install tmux automatically."
     log_warn "Install manually: https://github.com/tmux/tmux/wiki/Installing"
+    return 1
   fi
 }
 
@@ -46,13 +56,13 @@ if [ "${DRY_RUN:-0}" -eq 1 ]; then
   log_info "[DRY-RUN] Would install tmux for platform: $CURRENT_PLATFORM"
 else
   if is_macos; then
-    install_tmux_macos
+    install_tmux_macos || FAIL=1
   elif is_linux; then
-    install_tmux_linux
+    install_tmux_linux || FAIL=1
     if is_wsl; then
-      log_info "WSL detected: tmux clipboard integration uses xclip or wl-copy."
-      log_info "  Install xclip:  sudo apt install xclip"
-      log_info "  Or use Windows Terminal / WSLg for automatic clipboard passthrough."
+      log_info "WSL detected: for clipboard integration, install wl-clipboard:"
+      log_info "  sudo apt install wl-clipboard"
+      log_info "  WSLg / Windows Terminal users get automatic clipboard passthrough."
     fi
   else
     if ! command -v tmux >/dev/null 2>&1; then

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -63,9 +63,9 @@ bind -T copy-mode-vi y send -X copy-selection
 bind -T copy-mode-vi Y send -X copy-line
 
 # Paste
-bind-key C-p paste-buffer
+bind C-p paste-buffer
 
 # Copy to system clipboard (macOS: pbcopy, Linux: xclip/wl-copy fallback)
 if-shell 'test "$(uname)" = Darwin' \
-  'bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"' \
-  'bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "xclip -in -selection clipboard 2>/dev/null || wl-copy 2>/dev/null || true"'
+  'bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"' \
+  'bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "xclip -in -selection clipboard 2>/dev/null || wl-copy 2>/dev/null || true"'

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -12,7 +12,7 @@ set-option -g default-terminal "tmux-256color"
 
 # ── Prefix ────────────────────────────────────────────────────────────
 # Use C-q as prefix (C-b is unbound)
-set -g prefix C-q
+set-option -g prefix C-q
 unbind C-b
 
 # ── Status bar ────────────────────────────────────────────────────────

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -1,89 +1,71 @@
-# Use `zsh` as default shll
-set-option -g default-shell /usr/local/bin/zsh
+# ──────────────────────────────────────────────────────────────────────
+# tmux.conf — Cross-platform tmux configuration (tmux 3.3+ required)
+# ──────────────────────────────────────────────────────────────────────
 
-# Enable 8bit colors
-set-option -g default-terminal screen-256color
-set -g terminal-overrides 'xterm:colors=256'
+# ── Shell ─────────────────────────────────────────────────────────────
+# Use the user's default shell dynamically (works on macOS, Linux, WSL)
+set-option -g default-shell "#{SHELL}"
 
-# Use C-q as prefix key
+# ── Terminal ──────────────────────────────────────────────────────────
+# Modern terminal type with true-color support
+set-option -g default-terminal "tmux-256color"
+
+# ── Prefix ────────────────────────────────────────────────────────────
+# Use C-q as prefix (C-b is unbound)
 set -g prefix C-q
-
-# Do not use C-b
 unbind C-b
 
-# Show status bar on top of screens
+# ── Status bar ────────────────────────────────────────────────────────
 set-option -g status-position top
-
-# Set length of left / right status bar
 set-option -g status-left-length 90
 set-option -g status-right-length 90
 
-# #P = Pain No.
-# Show each pain number on left edge
+# Left: hostname and pane number
 set-option -g status-left '#H:[#P]'
 
-# Show basic machine info (Wi-Fi signal, battery status and time)
-# at right of screen
-set-option -g status-right '#(wifi) #(battery --tmux) [%Y-%m-%d(%a) %H:%M]'
+# Right: OS-specific info (Wi-Fi / battery on macOS only) + date/time
+if-shell 'test "$(uname)" = Darwin' \
+  'set-option -g status-right "#(wifi) #(battery --tmux) [%Y-%m-%d(%a) %H:%M]"' \
+  'set-option -g status-right "[%Y-%m-%d(%a) %H:%M]"'
 
-# Update status bar for every second
 set-option -g status-interval 1
-
-# Centerize status indicators
 set-option -g status-justify centre
-
-# Set status bar color
 set-option -g status-bg "colour238"
-
-# Set text color on status bar
 set-option -g status-fg "colour255"
 
-# Use Vim-style key bindings for pane selection
+# ── Pane navigation (Vim-style) ───────────────────────────────────────
 bind h select-pane -L
 bind j select-pane -D
 bind k select-pane -U
 bind l select-pane -R
 
-# Use Vim-style key bindings for resizing panes
+# ── Pane resizing (Vim-style) ─────────────────────────────────────────
 bind -r H resize-pane -L 5
 bind -r J resize-pane -D 5
 bind -r K resize-pane -U 5
 bind -r L resize-pane -R 5
 
-# Use `|` to split panes horizontally
+# ── Pane splitting ────────────────────────────────────────────────────
 bind | split-window -h
-
-# Use `-` to split panes vertically
 bind - split-window -v
 
-# Start pane index from 1
+# ── General ───────────────────────────────────────────────────────────
 set-option -g base-index 1
-
-# Enable mouse to control panes
 set-option -g mouse on
-bind -n WheelUpPane if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" "if -Ft= '#{pane_in_mode}' 'send-keys -M' 'copy-mode -e'"
 
-# Copy mode
-## Use Vim-style key bindings
+# ── Copy mode (Vim-style) ─────────────────────────────────────────────
 setw -g mode-keys vi
 
-# Start selection with `v`
 bind -T copy-mode-vi v send -X begin-selection
-
-# Select whole line with `V`
 bind -T copy-mode-vi V send -X select-line
-
-# Block selection with 'C-v'
 bind -T copy-mode-vi C-v send -X rectangle-toggle
-
-# Yank with 'y'
 bind -T copy-mode-vi y send -X copy-selection
-
-# Yank whole line with 'Y'
 bind -T copy-mode-vi Y send -X copy-line
 
-# Paste with 'C-p`
+# Paste
 bind-key C-p paste-buffer
 
-# Enable mouse to copy / paste
-bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
+# Copy to system clipboard (macOS: pbcopy, Linux: xclip/wl-copy fallback)
+if-shell 'test "$(uname)" = Darwin' \
+  'bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"' \
+  'bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "xclip -in -selection clipboard 2>/dev/null || wl-copy 2>/dev/null || true"'


### PR DESCRIPTION
## 概要
tmux設定をmacOS/Linux/WSLで動作するようクロスプラットフォーム対応し、モダン化しました。

### 変更内容

#### `tmux.conf`
- `default-shell` を `"#{SHELL}"` に変更（動的解決）
- `default-terminal` を `"tmux-256color"` に更新
- ステータスバーの Wi-Fi/バッテリー表示を `if-shell` で macOS のみに制限
- クリップボード連携を OS 判定付きで macOS（pbcopy）/ Linux（xclip/wl-copy）両対応
- 古いマウスホイールバインディング（tmux 3.2以前の `-F -t =` 構文）を削除
- prefix C-q は維持

#### `deploy.sh`
- macOS: `brew install tmux`
- Linux: `apt` 優先 → Homebrew fallback
- WSL 検出時のクリップボード統合ヒント表示

#### `README.md`
- tmux 3.3+ の前提を明記
- macOS / Linux / WSL のインストール手順
- キーバインド一覧表
- プラットフォーム別動作比較表

## 自己レビュー
- **正当性**: プロンプトの全指示を実装済み（default-shell動的解決、terminal更新、OS判定、deploy.shマルチプラットフォーム、README書き直し）
- **エッジケース**: xclip/wl-copy不在時は `|| true` で安全フォールバック。apt不在時はbrew fallback、さらにbrew不在時は警告。未知プラットフォームでも警告表示で停止しない
- **テスト**: dotfilesリポジトリのためスキップ
- **無関係変更**: なし（3ファイルのみ）
- **後方互換性**: C-q prefix、Vimキーバインド、ステータスバー色/位置、base-index 1 すべて維持
- **保守性**: セクションコメント付き、OS固有ロジックが明確に分離
- **スタイル**: シェルスクリプトはPOSIX sh準拠

🤖 Generated with [Claude Code](https://claude.com/claude-code)