### PR TITLE
孫7: vim/ 削除の後始末

### DIFF
--- a/docs/planning/DOC-001_ai-housekeeping_計画.md
+++ b/docs/planning/DOC-001_ai-housekeeping_計画.md
@@ -13,7 +13,7 @@
 | 4 | `ai/deploy-unified-setup` | 全体デプロイシステム + helpers.sh拡充 | ✅ PR #12 マージ済 |
 | 5 | `ai/ai-tmux-cross-platform` | tmux: クロスプラットフォーム + 設定モダン化 | ✅ PR #13 マージ済 |
 | 6 | `ai/nvim-lazy-migration` | nvim: dein.vim→lazy.nvim移行 + built-in優先 + Lua化 | ✅ PR #14 マージ済 |
-| 7 | `ai/vim-purge` | vim/ 削除の後始末（サブモジュール除去・vim/削除は孫1で完了） | 🔄 PR作成中 |
+| 7 | `ai/vim-purge` | vim/ 削除の後始末（サブモジュール除去・vim/削除は孫1で完了） | 🔄 PR #15 レビュー中 |
 | 8 | `ai/docs-overhaul` | 全README書き直し | ⬜ 待機中 |
 
 ## 孫1用プロンプト:

--- a/docs/planning/DOC-001_ai-housekeeping_計画.md
+++ b/docs/planning/DOC-001_ai-housekeeping_計画.md
@@ -9,7 +9,7 @@
 |---|---|---|---|
 | 1 | `ai/repo-structure-cleanup` | 土台整理: .gitignore更新 + LICENSE追加 + サブモジュール除去 + vim/削除 | ✅ PR #9 マージ済 |
 | 2 | `ai/ai-mise-env-pinning` | miseによる環境固定化 + Brewfile + apt-packages | ✅ PR #10 マージ済 |
-| 3 | `ai/ai-zsh-antidote` | zsh: zplug→Antidote移行 + クロスプラットフォーム + バグ修正 | 🔄 実装中 |
+| 3 | `ai/ai-zsh-antidote` | zsh: zplug→Antidote移行 + クロスプラットフォーム + バグ修正 | ✅ PR #11 マージ済 |
 | 4 | `ai/global-deploy` | 全体デプロイシステム + helpers.sh拡充 | ⬜ 待機中 |
 | 5 | `ai/tmux-cross-platform` | tmux: クロスプラットフォーム + 設定モダン化 | ⬜ 待機中 |
 | 6 | `ai/nvim-lazy` | nvim: dein.vim→lazy.nvim移行 + built-in優先 + Lua化 | ⬜ 待機中 |

--- a/docs/planning/DOC-001_ai-housekeeping_計画.md
+++ b/docs/planning/DOC-001_ai-housekeeping_計画.md
@@ -9,7 +9,7 @@
 |---|---|---|---|
 | 1 | `ai/repo-structure-cleanup` | 土台整理: .gitignore更新 + LICENSE追加 + サブモジュール除去 + vim/削除 | ✅ PR #9 マージ済 |
 | 2 | `ai/ai-mise-env-pinning` | miseによる環境固定化 + Brewfile + apt-packages | ✅ PR #10 マージ済 |
-| 3 | `ai/zsh-antidote` | zsh: zplug→Antidote移行 + クロスプラットフォーム + バグ修正 | ⬜ 待機中 |
+| 3 | `ai/ai-zsh-antidote` | zsh: zplug→Antidote移行 + クロスプラットフォーム + バグ修正 | 🔄 実装中 |
 | 4 | `ai/global-deploy` | 全体デプロイシステム + helpers.sh拡充 | ⬜ 待機中 |
 | 5 | `ai/tmux-cross-platform` | tmux: クロスプラットフォーム + 設定モダン化 | ⬜ 待機中 |
 | 6 | `ai/nvim-lazy` | nvim: dein.vim→lazy.nvim移行 + built-in優先 + Lua化 | ⬜ 待機中 |

--- a/docs/planning/DOC-001_ai-housekeeping_計画.md
+++ b/docs/planning/DOC-001_ai-housekeeping_計画.md
@@ -11,8 +11,8 @@
 | 2 | `ai/ai-mise-env-pinning` | miseによる環境固定化 + Brewfile + apt-packages | ✅ PR #10 マージ済 |
 | 3 | `ai/ai-zsh-antidote` | zsh: zplug→Antidote移行 + クロスプラットフォーム + バグ修正 | ✅ PR #11 マージ済 |
 | 4 | `ai/deploy-unified-setup` | 全体デプロイシステム + helpers.sh拡充 | ✅ PR #12 マージ済 |
-| 5 | `ai/ai-tmux-cross-platform` | tmux: クロスプラットフォーム + 設定モダン化 | 🔄 実装中 |
-| 6 | `ai/ai-nvim-lazy` | nvim: dein.vim→lazy.nvim移行 + built-in優先 + Lua化 | 🔄 実装中 |
+| 5 | `ai/ai-tmux-cross-platform` | tmux: クロスプラットフォーム + 設定モダン化 | ✅ PR #13 マージ済 |
+| 6 | `ai/nvim-lazy-migration` | nvim: dein.vim→lazy.nvim移行 + built-in優先 + Lua化 | ✅ PR #14 マージ済 |
 | 7 | `ai/vim-purge` | vim/ 削除の後始末（サブモジュール除去・vim/削除は孫1で完了） | ⬜ 待機中 |
 | 8 | `ai/docs-overhaul` | 全README書き直し | ⬜ 待機中 |
 

--- a/docs/planning/DOC-001_ai-housekeeping_計画.md
+++ b/docs/planning/DOC-001_ai-housekeeping_計画.md
@@ -10,7 +10,7 @@
 | 1 | `ai/repo-structure-cleanup` | 土台整理: .gitignore更新 + LICENSE追加 + サブモジュール除去 + vim/削除 | ✅ PR #9 マージ済 |
 | 2 | `ai/ai-mise-env-pinning` | miseによる環境固定化 + Brewfile + apt-packages | ✅ PR #10 マージ済 |
 | 3 | `ai/ai-zsh-antidote` | zsh: zplug→Antidote移行 + クロスプラットフォーム + バグ修正 | ✅ PR #11 マージ済 |
-| 4 | `ai/ai-global-deploy` | 全体デプロイシステム + helpers.sh拡充 | 🔄 実装中 |
+| 4 | `ai/deploy-unified-setup` | 全体デプロイシステム + helpers.sh拡充 | ✅ PR #12 マージ済 |
 | 5 | `ai/tmux-cross-platform` | tmux: クロスプラットフォーム + 設定モダン化 | ⬜ 待機中 |
 | 6 | `ai/nvim-lazy` | nvim: dein.vim→lazy.nvim移行 + built-in優先 + Lua化 | ⬜ 待機中 |
 | 7 | `ai/vim-purge` | vim/ 削除の後始末（サブモジュール除去・vim/削除は孫1で完了） | ⬜ 待機中 |

--- a/docs/planning/DOC-001_ai-housekeeping_計画.md
+++ b/docs/planning/DOC-001_ai-housekeeping_計画.md
@@ -13,7 +13,7 @@
 | 4 | `ai/deploy-unified-setup` | 全体デプロイシステム + helpers.sh拡充 | ✅ PR #12 マージ済 |
 | 5 | `ai/ai-tmux-cross-platform` | tmux: クロスプラットフォーム + 設定モダン化 | ✅ PR #13 マージ済 |
 | 6 | `ai/nvim-lazy-migration` | nvim: dein.vim→lazy.nvim移行 + built-in優先 + Lua化 | ✅ PR #14 マージ済 |
-| 7 | `ai/vim-purge` | vim/ 削除の後始末（サブモジュール除去・vim/削除は孫1で完了） | ⬜ 待機中 |
+| 7 | `ai/vim-purge` | vim/ 削除の後始末（サブモジュール除去・vim/削除は孫1で完了） | 🔄 PR作成中 |
 | 8 | `ai/docs-overhaul` | 全README書き直し | ⬜ 待機中 |
 
 ## 孫1用プロンプト:

--- a/docs/planning/DOC-001_ai-housekeeping_計画.md
+++ b/docs/planning/DOC-001_ai-housekeeping_計画.md
@@ -10,7 +10,7 @@
 | 1 | `ai/repo-structure-cleanup` | 土台整理: .gitignore更新 + LICENSE追加 + サブモジュール除去 + vim/削除 | ✅ PR #9 マージ済 |
 | 2 | `ai/ai-mise-env-pinning` | miseによる環境固定化 + Brewfile + apt-packages | ✅ PR #10 マージ済 |
 | 3 | `ai/ai-zsh-antidote` | zsh: zplug→Antidote移行 + クロスプラットフォーム + バグ修正 | ✅ PR #11 マージ済 |
-| 4 | `ai/global-deploy` | 全体デプロイシステム + helpers.sh拡充 | ⬜ 待機中 |
+| 4 | `ai/ai-global-deploy` | 全体デプロイシステム + helpers.sh拡充 | 🔄 実装中 |
 | 5 | `ai/tmux-cross-platform` | tmux: クロスプラットフォーム + 設定モダン化 | ⬜ 待機中 |
 | 6 | `ai/nvim-lazy` | nvim: dein.vim→lazy.nvim移行 + built-in優先 + Lua化 | ⬜ 待機中 |
 | 7 | `ai/vim-purge` | vim/ 削除の後始末（サブモジュール除去・vim/削除は孫1で完了） | ⬜ 待機中 |

--- a/docs/planning/DOC-001_ai-housekeeping_計画.md
+++ b/docs/planning/DOC-001_ai-housekeeping_計画.md
@@ -11,8 +11,8 @@
 | 2 | `ai/ai-mise-env-pinning` | miseによる環境固定化 + Brewfile + apt-packages | ✅ PR #10 マージ済 |
 | 3 | `ai/ai-zsh-antidote` | zsh: zplug→Antidote移行 + クロスプラットフォーム + バグ修正 | ✅ PR #11 マージ済 |
 | 4 | `ai/deploy-unified-setup` | 全体デプロイシステム + helpers.sh拡充 | ✅ PR #12 マージ済 |
-| 5 | `ai/tmux-cross-platform` | tmux: クロスプラットフォーム + 設定モダン化 | ⬜ 待機中 |
-| 6 | `ai/nvim-lazy` | nvim: dein.vim→lazy.nvim移行 + built-in優先 + Lua化 | ⬜ 待機中 |
+| 5 | `ai/ai-tmux-cross-platform` | tmux: クロスプラットフォーム + 設定モダン化 | 🔄 実装中 |
+| 6 | `ai/ai-nvim-lazy` | nvim: dein.vim→lazy.nvim移行 + built-in優先 + Lua化 | 🔄 実装中 |
 | 7 | `ai/vim-purge` | vim/ 削除の後始末（サブモジュール除去・vim/削除は孫1で完了） | ⬜ 待機中 |
 | 8 | `ai/docs-overhaul` | 全README書き直し | ⬜ 待機中 |
 

--- a/docs/planning/DOC-001_ai-housekeeping_計画.md
+++ b/docs/planning/DOC-001_ai-housekeeping_計画.md
@@ -13,7 +13,7 @@
 | 4 | `ai/deploy-unified-setup` | 全体デプロイシステム + helpers.sh拡充 | ✅ PR #12 マージ済 |
 | 5 | `ai/ai-tmux-cross-platform` | tmux: クロスプラットフォーム + 設定モダン化 | ✅ PR #13 マージ済 |
 | 6 | `ai/nvim-lazy-migration` | nvim: dein.vim→lazy.nvim移行 + built-in優先 + Lua化 | ✅ PR #14 マージ済 |
-| 7 | `ai/vim-purge` | vim/ 削除の後始末（サブモジュール除去・vim/削除は孫1で完了） | 🔄 PR #15 レビュー中 |
+| 7 | `ai/vim-purge` | vim/ 削除の後始末（サブモジュール除去・vim/削除は孫1で完了） | ✅ PR #15 承認済（マージ待ち） |
 | 8 | `ai/docs-overhaul` | 全README書き直し | ⬜ 待機中 |
 
 ## 孫1用プロンプト:

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -28,9 +28,9 @@ KNOWN_LINKS_zsh=$(printf '%s\n' \
 )
 
 KNOWN_LINKS_nvim=$(printf '%s\n' \
-  "${XDG_CONFIG_HOME:-$HOME/.config}/nvim/init.vim" \
-  "${XDG_CONFIG_HOME:-$HOME/.config}/nvim/dein.toml" \
-  "${XDG_CONFIG_HOME:-$HOME/.config}/nvim/dein_lazy.toml" \
+  "${XDG_CONFIG_HOME:-$HOME/.config}/nvim/init.lua" \
+  "${XDG_CONFIG_HOME:-$HOME/.config}/nvim/lua" \
+  "${XDG_CONFIG_HOME:-$HOME/.config}/nvim/lazy-lock.json" \
 )
 
 KNOWN_LINKS_tmux=$(printf '%s\n' \
@@ -175,6 +175,6 @@ else
   log_warn "Uninstall finished with some errors. Check the output above."
 fi
 log_warn "Note: Installed packages (zsh, tmux, etc.) were not removed."
-log_warn "Note: Plugin managers (Antidote, dein.vim) were not removed."
+log_warn "Note: Plugin managers (Antidote, lazy.nvim) were not removed."
 
 exit "$OVERALL_OK"


### PR DESCRIPTION
## 概要
孫1で削除された vim/ ディレクトリと neobundle サブモジュールの後始末。

## やったこと
- `uninstall.sh` の古いnvim参照を修正（孫6のlazy.nvim移行時に取り残されていた）
  - `init.vim` → `init.lua`
  - `dein.toml`, `dein_lazy.toml` → `lua/`, `lazy-lock.json`
- `uninstall.sh` の警告文言: `dein.vim` → `lazy.nvim`
- 計画書の孫7ステータスを更新

## 検証結果
| チェック項目 | 結果 |
|-------------|------|
| `neobundle`/`NeoBundle` 参照（計画書以外） | ✅ なし |
| `vim/` パス参照（`nvim/` 除外） | ✅ なし |
| `.gitignore` の `!.vim/bundle/neobundle.vim` | ✅ 既に除去済み |
| README Supported tools の Vim | ✅ 既に削除済み |

## 備考
vim/本体とneobundleサブモジュールは孫1で完全に除去済み。今回は取り残しの確認と`uninstall.sh`の同期ズレ修正のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)