### PR TITLE
feat(bin): ocw と claude-ds を dotfiles に移行

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -1,0 +1,109 @@
+# CLI Tools (bin)
+
+## Overview
+
+自作 CLI ツール集。`~/bin/` に symlink して使う。
+
+| Tool | Purpose |
+|---|---|
+| `ocw` | Git worktree 作成・管理。Herdr 連携で commander/implementer/reviewer の三面体制を自動セットアップ |
+| `claude-ds` | Claude Code を DeepSeek API 経由で実行するラッパー |
+
+## 1. Requirements
+
+| Tool | Why | Install |
+|---|---|---|
+| **Git** | worktree 操作 (`ocw`) | Built-in on most systems |
+| **Python 3** | JSON パース (`ocw` Herdr モード) | `mise use python@latest` |
+| **claude** (CLI) | `claude-ds` の実体 | `npm install -g @anthropic-ai/claude-code` |
+| **DeepSeek API key** | `claude-ds` の認証 | `~/.config/deepseek/api_key` に保存 |
+| **Herdr** (optional) | `ocw --herdr` のマルチペイン管理 | Herdr 管理下で提供 |
+
+## 2. Quick Start
+
+```bash
+# 1. Run deploy script
+cd ~/.dotfiles/bin
+./deploy.sh
+
+# 2. Verify
+which ocw
+which claude-ds
+```
+
+The deploy script:
+- Creates `~/bin/` directory if missing
+- Symlinks `ocw` and `claude-ds` into `~/bin/`
+
+## 3. Tools
+
+### 3.1 ocw — Opinionated Claude Worktree
+
+Git worktree を作成し、オプションで Herdr マルチペイン環境をセットアップする。
+
+```bash
+# 基本的な worktree 作成（VS Code で開く）
+ocw my-feature
+
+# Herdr 連携（commander/implementer/reviewer の3ペイン）
+ocw --herdr my-feature
+
+# ベースブランチを指定
+ocw new --herdr my-feature origin/main
+
+# worktree 削除
+ocw rm my-feature
+ocw rm -f my-feature  # 強制削除
+
+# worktree 一覧
+ocw ls
+```
+
+**Herdr モードのペイン構成:**
+- **commander**: 司令塔（デフォルト: `claude`）
+- **implementer**: 実装担当（デフォルト: `claude`）
+- **reviewer**: レビュー担当（デフォルト: `claude`）
+
+### 3.2 claude-ds — Claude Code via DeepSeek API
+
+Claude Code CLI を DeepSeek API に繋ぎ替えて実行する。
+
+```bash
+claude-ds
+# 実体: ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic claude
+```
+
+API キーは `DEEPSEEK_API_KEY_FILE` 環境変数で指定可能（デフォルト: `~/.config/deepseek/api_key`）。
+
+## 4. Customization
+
+### ocw のコマンド差し替え
+
+環境変数で commander / implementer / reviewer の実行コマンドを上書きできる:
+
+```bash
+# DeepSeek を使う場合（旧デフォルト）
+export OCW_COMMANDER_COMMAND=claude-ds
+export OCW_IMPLEMENTER_COMMAND=claude-ds
+
+# 別のツールを指定
+export OCW_REVIEWER_COMMAND=claude
+```
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `OCW_COMMANDER_COMMAND` | `claude` | commander ペインで実行するコマンド |
+| `OCW_IMPLEMENTER_COMMAND` | `claude` | implementer ペインで実行するコマンド |
+| `OCW_REVIEWER_COMMAND` | `claude` | reviewer ペインで実行するコマンド |
+
+### claude-ds の API キー設定
+
+```bash
+# デフォルトのキーファイル
+mkdir -p ~/.config/deepseek
+echo "sk-your-api-key" > ~/.config/deepseek/api_key
+chmod 600 ~/.config/deepseek/api_key
+
+# 別の場所に置く場合
+export DEEPSEEK_API_KEY_FILE=/path/to/your/api_key
+```

--- a/bin/README.md
+++ b/bin/README.md
@@ -18,7 +18,7 @@
 | **claude** (CLI) | `claude-ds` の実体 | `npm install -g @anthropic-ai/claude-code` |
 | **DeepSeek API key** | `claude-ds` の認証 | `~/.config/deepseek/api_key` に保存 |
 | **VS Code** `code` CLI (optional) | `ocw` のデフォルトモードで worktree を開く | `code` コマンドを PATH に通す（macOS: Cmd+Shift+P → "Shell Command: Install 'code' command in PATH"） |
-| **Herdr** (optional) | `ocw --herdr` のマルチペイン管理 | `pip install herdr` または Herdr プロジェクトのインストール手順に従う |
+| **Herdr** (optional) | `ocw --herdr` のマルチペイン管理 | Herdr プロジェクトのインストール手順に従う（スタティックリンクされたバイナリとして配布） |
 
 ## 2. Quick Start
 
@@ -72,7 +72,7 @@ ocw ls
 
 ### 3.2 claude-ds — Claude Code via DeepSeek API
 
-Claude Code CLI を DeepSeek API に繋ぎ替えて実行する。`exec env` で以下の環境変数を**すべて上書き固定**するため、通常の `claude` のモデル選択（`-p` フラグ等）は効かない:
+Claude Code CLI を DeepSeek API に繋ぎ替えて実行する。`exec env` で以下の環境変数を**すべて上書き固定**する。`claude "$@"` で CLI 引数は素通しされるため `--model` 等のオプションは通常通り指定可能だが、デフォルトモデルは上記の値に固定される:
 
 ```bash
 claude-ds

--- a/bin/README.md
+++ b/bin/README.md
@@ -72,7 +72,7 @@ ocw ls
 
 ### 3.2 claude-ds — Claude Code via DeepSeek API
 
-Claude Code CLI を DeepSeek API に繋ぎ替えて実行する。`exec env` で以下の環境変数を**すべて上書き固定**する。`claude "$@"` で CLI 引数は素通しされるため `--model` 等のオプションは通常通り指定可能だが、デフォルトモデルは上記の値に固定される:
+Claude Code CLI を DeepSeek API に繋ぎ替えて実行する。`exec env` で以下の環境変数を**すべて上書き固定**する。`claude "$@"` で CLI 引数は素通しされるため `--model` 等のオプションは通常通り指定可能だが、デフォルトモデルは以下の値に固定される:
 
 ```bash
 claude-ds

--- a/bin/README.md
+++ b/bin/README.md
@@ -17,7 +17,8 @@
 | **Python 3** | JSON パース (`ocw` Herdr モード) | `mise use python@latest` |
 | **claude** (CLI) | `claude-ds` の実体 | `npm install -g @anthropic-ai/claude-code` |
 | **DeepSeek API key** | `claude-ds` の認証 | `~/.config/deepseek/api_key` に保存 |
-| **Herdr** (optional) | `ocw --herdr` のマルチペイン管理 | Herdr 管理下で提供 |
+| **VS Code** `code` CLI (optional) | `ocw` のデフォルトモードで worktree を開く | `code` コマンドを PATH に通す（macOS: Cmd+Shift+P → "Shell Command: Install 'code' command in PATH"） |
+| **Herdr** (optional) | `ocw --herdr` のマルチペイン管理 | `pip install herdr` または Herdr プロジェクトのインストール手順に従う |
 
 ## 2. Quick Start
 
@@ -26,16 +27,21 @@
 cd ~/.dotfiles/bin
 ./deploy.sh
 
-# 2. Verify
+# 2. Restart your shell (or source ~/.zshrc) so ~/bin is on PATH
+exec $SHELL -l
+
+# 3. Verify
 which ocw
 which claude-ds
 ```
+
+> **Note**: `~/bin` の PATH 追加は `zsh/.zshrc` が担っています。bash 等他のシェルを使う場合は、各自で `~/bin` を PATH に通してください。
 
 The deploy script:
 - Creates `~/bin/` directory if missing
 - Symlinks `ocw` and `claude-ds` into `~/bin/`
 
-## 3. Tools
+## 3. What's Included
 
 ### 3.1 ocw — Opinionated Claude Worktree
 
@@ -66,12 +72,25 @@ ocw ls
 
 ### 3.2 claude-ds — Claude Code via DeepSeek API
 
-Claude Code CLI を DeepSeek API に繋ぎ替えて実行する。
+Claude Code CLI を DeepSeek API に繋ぎ替えて実行する。`exec env` で以下の環境変数を**すべて上書き固定**するため、通常の `claude` のモデル選択（`-p` フラグ等）は効かない:
 
 ```bash
 claude-ds
-# 実体: ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic claude
+# 実体:
+#   ANTHROPIC_BASE_URL="https://api.deepseek.com/anthropic"
+#   ANTHROPIC_AUTH_TOKEN="<キーファイルの中身>"
+#   ANTHROPIC_MODEL="deepseek-v4-pro[1m]"
+#   ANTHROPIC_DEFAULT_OPUS_MODEL="deepseek-v4-pro[1m]"
+#   ANTHROPIC_DEFAULT_SONNET_MODEL="deepseek-v4-pro[1m]"
+#   ANTHROPIC_DEFAULT_HAIKU_MODEL="deepseek-v4-flash"
+#   CLAUDE_CODE_SUBAGENT_MODEL="deepseek-v4-flash"
+#   claude "$@"
 ```
+
+| モデル種別 | 固定値 |
+|---|---|
+| メイン / Opus / Sonnet | `deepseek-v4-pro[1m]` |
+| Haiku / subagent | `deepseek-v4-flash` |
 
 API キーは `DEEPSEEK_API_KEY_FILE` 環境変数で指定可能（デフォルト: `~/.config/deepseek/api_key`）。
 
@@ -107,3 +126,39 @@ chmod 600 ~/.config/deepseek/api_key
 # 別の場所に置く場合
 export DEEPSEEK_API_KEY_FILE=/path/to/your/api_key
 ```
+
+## 5. Troubleshooting
+
+### `which ocw` returns nothing
+
+`~/bin` の PATH 追加は `zsh/.zshrc` のシェル起動時チェックに依存しています。`deploy.sh` で `~/bin` を新規作成した直後は、シェルを再起動してください:
+
+```bash
+exec $SHELL -l
+```
+
+bash 等他のシェルを使う場合は、各自で `~/bin` を PATH に通してください。
+
+### `error: Herdr server is not running. Start or attach first with: herdr`
+
+`ocw --herdr` は Herdr サーバーが起動している必要があります。先に `herdr` を実行してサーバーを起動するか、アタッチしてください。
+
+### `Error: DeepSeek API key file not found: ~/.config/deepseek/api_key`
+
+`claude-ds` の API キーが未設定です。以下を実行してください:
+
+```bash
+mkdir -p ~/.config/deepseek
+echo "sk-your-api-key" > ~/.config/deepseek/api_key
+chmod 600 ~/.config/deepseek/api_key
+```
+
+別のパスにキーを置く場合は `DEEPSEEK_API_KEY_FILE` 環境変数で指定してください。
+
+### `error: run ocw from inside a Git worktree`
+
+`ocw` は Git リポジトリの worktree 内で実行する必要があります。カレントディレクトリが Git worktree であることを確認してください。
+
+### `warning: VS Code CLI 'code' was not found`
+
+`ocw` のデフォルトモード（`--herdr` なし）では worktree 作成後に VS Code を開こうとします。`code` CLI がインストールされていない場合、この警告が出ますが worktree 作成自体は成功しています。VS Code をインストールするか、`--herdr` モードを使用してください。

--- a/bin/claude-ds
+++ b/bin/claude-ds
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KEY_FILE="${DEEPSEEK_API_KEY_FILE:-$HOME/.config/deepseek/api_key}"
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "Error: claude command not found in PATH." >&2
+  exit 1
+fi
+
+if [ ! -f "$KEY_FILE" ]; then
+  echo "Error: DeepSeek API key file not found: $KEY_FILE" >&2
+  echo "Create it with:" >&2
+  echo "  mkdir -p ~/.config/deepseek" >&2
+  echo "  nano ~/.config/deepseek/api_key" >&2
+  echo "  chmod 600 ~/.config/deepseek/api_key" >&2
+  exit 1
+fi
+
+DEEPSEEK_API_KEY="$(tr -d '\r\n' < "$KEY_FILE")"
+
+if [ -z "$DEEPSEEK_API_KEY" ]; then
+  echo "Error: DeepSeek API key file is empty: $KEY_FILE" >&2
+  exit 1
+fi
+
+exec env \
+  ANTHROPIC_BASE_URL="https://api.deepseek.com/anthropic" \
+  ANTHROPIC_AUTH_TOKEN="$DEEPSEEK_API_KEY" \
+  ANTHROPIC_MODEL="deepseek-v4-pro[1m]" \
+  ANTHROPIC_DEFAULT_OPUS_MODEL="deepseek-v4-pro[1m]" \
+  ANTHROPIC_DEFAULT_SONNET_MODEL="deepseek-v4-pro[1m]" \
+  ANTHROPIC_DEFAULT_HAIKU_MODEL="deepseek-v4-flash" \
+  CLAUDE_CODE_SUBAGENT_MODEL="deepseek-v4-flash" \
+  claude "$@"

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
+. "$SCRIPT_DIR/../shared/helpers.sh"
+
+log_hr
+log_info "Deploying: bin"
+
+FAIL=0
+
+# --- Ensure ~/bin exists ---
+BIN_DIR="$HOME/bin"
+
+if [ ! -d "$BIN_DIR" ]; then
+  if [ "${DRY_RUN:-0}" -eq 1 ]; then
+    log_info "[DRY-RUN] Would create directory: $BIN_DIR"
+  else
+    log_info "Creating directory: $BIN_DIR"
+    mkdir -p "$BIN_DIR" || {
+      log_error "Failed to create directory: $BIN_DIR"
+      exit 1
+    }
+    log_ok "Created: $BIN_DIR"
+  fi
+fi
+
+# --- Symlink scripts into ~/bin ---
+symlink_backup "$SCRIPT_DIR/ocw"       "$BIN_DIR/ocw"       || FAIL=1
+symlink_backup "$SCRIPT_DIR/claude-ds" "$BIN_DIR/claude-ds" || FAIL=1
+
+if [ "$FAIL" -ne 0 ]; then
+  log_error "bin deployment completed with errors."
+  exit 1
+fi
+log_ok "bin deployment complete."

--- a/bin/ocw
+++ b/bin/ocw
@@ -1,0 +1,704 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+USE_HERDR=false
+
+COMMANDER_COMMAND="${OCW_COMMANDER_COMMAND:-claude}"
+IMPLEMENTER_COMMAND="${OCW_IMPLEMENTER_COMMAND:-claude}"
+REVIEWER_COMMAND="${OCW_REVIEWER_COMMAND:-claude}"
+
+HERDR_SETUP_WORKSPACE_ID=""
+HERDR_SETUP_COMMANDER_PANE_ID=""
+HERDR_SETUP_IMPLEMENTER_PANE_ID=""
+HERDR_SETUP_REVIEWER_PANE_ID=""
+
+usage() {
+  cat <<'USAGE'
+usage:
+  ocw [-H|--herdr] <worktree-name> [base-ref]
+  ocw [-H|--herdr] new <worktree-name> [base-ref]
+  ocw new [-H|--herdr] <worktree-name> [base-ref]
+  ocw rm <worktree-name>
+  ocw rm -f <worktree-name>
+  ocw ls
+
+create behavior:
+  default
+    create a worktree and open it in VS Code
+
+  -H, --herdr
+    create a worktree
+    register it in Herdr
+    create commander/implementer/reviewer panes
+    start claude / claude / claude
+    focus the Herdr workspace
+    open VS Code
+
+examples:
+  ocw dataset-importer
+  ocw --herdr optimize-generation
+  ocw new --herdr caption-parser origin/main
+  ocw rm dataset-importer
+  ocw rm -f failed-experiment
+  ocw ls
+
+environment:
+  OCW_COMMANDER_COMMAND
+    default: claude
+
+  OCW_IMPLEMENTER_COMMAND
+    default: claude
+
+  OCW_REVIEWER_COMMAND
+    default: claude
+USAGE
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+warn() {
+  echo "warning: $*" >&2
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 ||
+    die "required command not found: $1"
+}
+
+normalize_name() {
+  printf '%s\n' "$1" |
+    tr '[:upper:]' '[:lower:]' |
+    sed -E 's/[^a-z0-9._-]+/-/g' |
+    sed -E 's/^-+|-+$//g'
+}
+
+json_nested_field() {
+  local json="$1"
+  local container="$2"
+  local field="$3"
+
+  python3 - "$container" "$field" 3<<<"$json" <<'PY'
+import json
+import os
+import sys
+
+container = sys.argv[1]
+field = sys.argv[2]
+
+with os.fdopen(3) as stream:
+    data = json.load(stream)
+
+
+def walk(value):
+    if isinstance(value, dict):
+        candidate = value.get(container)
+
+        if isinstance(candidate, dict):
+            result = candidate.get(field)
+
+            if result is not None:
+                print(result)
+                return True
+
+        for child in value.values():
+            if walk(child):
+                return True
+
+    elif isinstance(value, list):
+        for child in value:
+            if walk(child):
+                return True
+
+    return False
+
+
+if not walk(data):
+    raise SystemExit(1)
+PY
+}
+
+
+herdr_server_running() {
+  command -v herdr >/dev/null 2>&1 &&
+    herdr status server >/dev/null 2>&1
+}
+
+require_herdr_ready() {
+  require_command herdr
+  require_command python3
+
+  herdr_server_running ||
+    die "Herdr server is not running. Start or attach first with: herdr"
+}
+
+invocation_root=""
+repo_root=""
+project_dir=""
+repo_name=""
+
+init_repo_context() {
+  invocation_root="$(
+    git rev-parse --show-toplevel 2>/dev/null
+  )" || die "run ocw from inside a Git worktree"
+
+  repo_root="$(
+    git -C "$invocation_root" worktree list --porcelain |
+      awk '
+        /^worktree / {
+          sub(/^worktree /, "")
+          print
+          exit
+        }
+      '
+  )"
+
+  [ -n "$repo_root" ] ||
+    die "could not determine the main worktree"
+
+  project_dir="$(dirname "$repo_root")"
+  repo_name="$(basename "$project_dir")"
+}
+
+open_vscode() {
+  local worktree_dir="$1"
+
+  if ! command -v code >/dev/null 2>&1; then
+    warn "VS Code CLI 'code' was not found"
+    return 0
+  fi
+
+  code "$worktree_dir" ||
+    warn "failed to open VS Code"
+}
+
+setup_herdr_workspace() {
+  local worktree_dir="$1"
+  local workspace_label="$2"
+
+  local open_json=""
+  local split_json=""
+  local tab_id=""
+
+  HERDR_SETUP_WORKSPACE_ID=""
+  HERDR_SETUP_COMMANDER_PANE_ID=""
+  HERDR_SETUP_IMPLEMENTER_PANE_ID=""
+  HERDR_SETUP_REVIEWER_PANE_ID=""
+
+  open_json="$(
+  herdr workspace create \
+    --cwd "$worktree_dir" \
+    --label "$workspace_label" \
+    --no-focus
+  )" || return 1
+
+  HERDR_SETUP_WORKSPACE_ID="$(
+    json_nested_field \
+      "$open_json" \
+      workspace \
+      workspace_id
+  )" || {
+    echo "error: could not read workspace_id from Herdr response" >&2
+    echo "$open_json" >&2
+    return 1
+  }
+
+  HERDR_SETUP_COMMANDER_PANE_ID="$(
+    json_nested_field \
+      "$open_json" \
+      root_pane \
+      pane_id
+  )" || {
+    echo "error: could not read root pane ID from Herdr response" >&2
+    echo "$open_json" >&2
+    return 1
+  }
+
+  tab_id="$(
+    json_nested_field \
+      "$open_json" \
+      tab \
+      tab_id
+  )" || {
+    echo "error: could not read tab ID from Herdr response" >&2
+    echo "$open_json" >&2
+    return 1
+  }
+
+  herdr tab rename "$tab_id" agents >/dev/null ||
+    return 1
+
+  herdr pane rename \
+    "$HERDR_SETUP_COMMANDER_PANE_ID" \
+    commander \
+    >/dev/null ||
+    return 1
+
+  # Split commander right → implementer
+  split_json="$(
+    herdr pane split \
+      "$HERDR_SETUP_COMMANDER_PANE_ID" \
+      --direction right \
+      --cwd "$worktree_dir" \
+      --no-focus
+  )" || return 1
+
+  HERDR_SETUP_IMPLEMENTER_PANE_ID="$(
+    json_nested_field \
+      "$split_json" \
+      pane \
+      pane_id
+  )" || {
+    echo "error: could not read implementer pane ID from Herdr response" >&2
+    echo "$split_json" >&2
+    return 1
+  }
+
+  herdr pane rename \
+    "$HERDR_SETUP_IMPLEMENTER_PANE_ID" \
+    implementer \
+    >/dev/null ||
+    return 1
+
+  # Split implementer right → reviewer
+  split_json="$(
+    herdr pane split \
+      "$HERDR_SETUP_IMPLEMENTER_PANE_ID" \
+      --direction right \
+      --cwd "$worktree_dir" \
+      --no-focus
+  )" || return 1
+
+  HERDR_SETUP_REVIEWER_PANE_ID="$(
+    json_nested_field \
+      "$split_json" \
+      pane \
+      pane_id
+  )" || {
+    echo "error: could not read reviewer pane ID from Herdr response" >&2
+    echo "$split_json" >&2
+    return 1
+  }
+
+  herdr pane rename \
+    "$HERDR_SETUP_REVIEWER_PANE_ID" \
+    reviewer \
+    >/dev/null ||
+    return 1
+
+  herdr pane run \
+    "$HERDR_SETUP_COMMANDER_PANE_ID" \
+    "$COMMANDER_COMMAND" \
+    >/dev/null ||
+    return 1
+
+  herdr pane run \
+    "$HERDR_SETUP_IMPLEMENTER_PANE_ID" \
+    "$IMPLEMENTER_COMMAND" \
+    >/dev/null ||
+    return 1
+
+  herdr pane run \
+    "$HERDR_SETUP_REVIEWER_PANE_ID" \
+    "$REVIEWER_COMMAND" \
+    >/dev/null ||
+    return 1
+
+  herdr workspace focus \
+    "$HERDR_SETUP_WORKSPACE_ID" \
+    >/dev/null ||
+    return 1
+}
+
+rollback_created_worktree() {
+  local worktree_dir="$1"
+  local branch="$2"
+
+  echo "error: Herdr setup failed; rolling back" >&2
+
+  set +e
+
+  if [ -n "$HERDR_SETUP_WORKSPACE_ID" ] &&
+    herdr_server_running
+  then
+    herdr workspace close \
+      "$HERDR_SETUP_WORKSPACE_ID" \
+      >/dev/null 2>&1
+  fi
+
+  if git -C "$repo_root" worktree list --porcelain |
+    grep -Fqx "worktree ${worktree_dir}"
+  then
+    git -C "$repo_root" \
+      worktree remove --force "$worktree_dir" \
+      >/dev/null 2>&1
+  fi
+
+  if git -C "$repo_root" \
+    show-ref --verify --quiet "refs/heads/${branch}"
+  then
+    git -C "$repo_root" \
+      branch -D "$branch" \
+      >/dev/null 2>&1
+  fi
+
+  set -e
+}
+
+create_worktree() {
+  local task_name="${1:-}"
+  local base_ref="${2:-}"
+
+  if [ -z "$base_ref" ]; then
+    base_ref="$(
+      git -C "$repo_root" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null |
+        sed 's|.*/||'
+    )"
+    [ -n "$base_ref" ] || base_ref="main"
+  fi
+
+  [ -n "$task_name" ] || {
+    usage
+    exit 1
+  }
+
+  [ "$#" -le 2 ] ||
+    die "too many arguments for create"
+
+  local slug=""
+  local branch=""
+  local worktree_dir=""
+  local workspace_label=""
+
+  slug="$(normalize_name "$task_name")"
+
+  [ -n "$slug" ] ||
+    die "worktree name became empty"
+
+  branch="ai/${slug}"
+  worktree_dir="${project_dir}/${slug}"
+  workspace_label="${repo_name} / ${slug}"
+
+  echo "repo:        ${repo_name}"
+  echo "main dir:    ${repo_root}"
+  echo "branch:      ${branch}"
+  echo "worktree:    ${worktree_dir}"
+  echo "base:        ${base_ref}"
+  echo "herdr:       ${USE_HERDR}"
+
+  if git -C "$repo_root" \
+    show-ref --verify --quiet "refs/heads/${branch}"
+  then
+    die "branch already exists: ${branch}"
+  fi
+
+  [ ! -e "$worktree_dir" ] ||
+    die "worktree dir already exists: ${worktree_dir}"
+
+  if [ "$USE_HERDR" = "true" ]; then
+    require_herdr_ready
+  fi
+
+  git -C "$repo_root" \
+    worktree add \
+    -b "$branch" \
+    "$worktree_dir" \
+    "$base_ref"
+
+  if [ "$USE_HERDR" = "true" ]; then
+    local setup_status=0
+
+    set +e
+    setup_herdr_workspace \
+      "$worktree_dir" \
+      "$workspace_label"
+    setup_status="$?"
+    set -e
+
+    if [ "$setup_status" -ne 0 ]; then
+      rollback_created_worktree \
+        "$worktree_dir" \
+        "$branch"
+
+      exit "$setup_status"
+    fi
+
+    echo "workspace:   ${HERDR_SETUP_WORKSPACE_ID}"
+    echo "commander:   ${HERDR_SETUP_COMMANDER_PANE_ID}"
+    echo "implementer: ${HERDR_SETUP_IMPLEMENTER_PANE_ID}"
+    echo "reviewer:    ${HERDR_SETUP_REVIEWER_PANE_ID}"
+  else
+    open_vscode "$worktree_dir"
+  fi
+}
+
+json_workspace_ids() {
+  local json="$1"
+
+  python3 - 3<<<"$json" <<'PY'
+import json
+import os
+
+with os.fdopen(3) as stream:
+    data = json.load(stream)
+
+
+def walk(value):
+    if isinstance(value, dict):
+        workspaces = value.get("workspaces")
+
+        if isinstance(workspaces, list):
+            for workspace in workspaces:
+                if isinstance(workspace, dict):
+                    workspace_id = workspace.get("workspace_id")
+
+                    if workspace_id:
+                        print(workspace_id)
+            return True
+
+        for child in value.values():
+            if walk(child):
+                return True
+
+    elif isinstance(value, list):
+        for child in value:
+            if walk(child):
+                return True
+
+    return False
+
+
+if not walk(data):
+    raise SystemExit(1)
+PY
+}
+
+json_has_pane_cwd() {
+  local json="$1"
+  local target_path="$2"
+
+  python3 - "$target_path" 3<<<"$json" <<'PY'
+import json
+import os
+import sys
+
+target = os.path.realpath(sys.argv[1])
+
+with os.fdopen(3) as stream:
+    data = json.load(stream)
+
+
+def walk(value):
+    if isinstance(value, dict):
+        pane_id = value.get("pane_id")
+        cwd = value.get("cwd")
+
+        if (
+            pane_id
+            and cwd
+            and os.path.realpath(cwd) == target
+        ):
+            return True
+
+        for child in value.values():
+            if walk(child):
+                return True
+
+    elif isinstance(value, list):
+        for child in value:
+            if walk(child):
+                return True
+
+    return False
+
+
+raise SystemExit(0 if walk(data) else 1)
+PY
+}
+
+close_herdr_workspaces_for_checkout() {
+  local worktree_dir="$1"
+
+  herdr_server_running ||
+    return 0
+
+  require_command python3
+
+  local workspace_json=""
+  local workspace_ids=""
+
+  if ! workspace_json="$(
+    herdr workspace list
+  )"; then
+    warn "could not query Herdr workspaces; continuing with Git removal"
+    return 0
+  fi
+
+  if ! workspace_ids="$(
+    json_workspace_ids "$workspace_json"
+  )"; then
+    warn "could not parse Herdr workspace list"
+    return 0
+  fi
+
+  while IFS= read -r workspace_id; do
+    [ -n "$workspace_id" ] ||
+      continue
+
+    local pane_json=""
+
+    if ! pane_json="$(
+      herdr pane list \
+        --workspace "$workspace_id"
+    )"; then
+      warn "could not inspect Herdr workspace: ${workspace_id}"
+      continue
+    fi
+
+    if json_has_pane_cwd \
+      "$pane_json" \
+      "$worktree_dir"
+    then
+      echo "closing Herdr workspace: ${workspace_id}"
+
+      herdr workspace close \
+        "$workspace_id" \
+        >/dev/null ||
+        warn "failed to close Herdr workspace: ${workspace_id}"
+    fi
+  done <<<"$workspace_ids"
+}
+
+remove_worktree() {
+  local force="false"
+
+  if [ "${1:-}" = "-f" ] ||
+    [ "${1:-}" = "--force" ]
+  then
+    force="true"
+    shift
+  fi
+
+  local task_name="${1:-}"
+
+  [ -n "$task_name" ] || {
+    usage
+    exit 1
+  }
+
+  [ "$#" -le 1 ] ||
+    die "too many arguments for remove"
+
+  local slug=""
+  local branch=""
+  local worktree_dir=""
+
+  slug="$(normalize_name "$task_name")"
+
+  [ -n "$slug" ] ||
+    die "worktree name became empty"
+
+  branch="ai/${slug}"
+  worktree_dir="${project_dir}/${slug}"
+
+  echo "repo:      ${repo_name}"
+  echo "remove:    ${worktree_dir}"
+  echo "branch:    ${branch}"
+  echo "force:     ${force}"
+
+  if [[ "$(realpath -m "$invocation_root")" == "$(realpath -m "$worktree_dir")" ]]; then
+    echo "error: do not remove the current worktree" >&2
+    echo "move to main first:" >&2
+    echo "  cd ${repo_root}" >&2
+    echo "  ocw rm ${slug}" >&2
+    exit 1
+  fi
+
+  [ -d "$worktree_dir" ] ||
+    die "worktree dir does not exist: ${worktree_dir}"
+
+  if [ "$force" = "false" ]; then
+    if [ -n "$(git -C "$worktree_dir" status --porcelain)" ]; then
+      die "worktree has uncommitted or untracked changes: ${worktree_dir}"
+    fi
+
+    if ! git -C "$repo_root" \
+      merge-base --is-ancestor "$branch" HEAD
+    then
+      die "branch is not merged into the current main checkout: ${branch}"
+    fi
+  fi
+
+  close_herdr_workspaces_for_checkout "$worktree_dir"
+
+  if [ "$force" = "true" ]; then
+    git -C "$repo_root" \
+      worktree remove --force "$worktree_dir"
+
+    git -C "$repo_root" \
+      branch -D "$branch"
+  else
+    git -C "$repo_root" \
+      worktree remove "$worktree_dir"
+
+    git -C "$repo_root" \
+      branch -d "$branch"
+  fi
+}
+
+while [ "${1:-}" = "-H" ] ||
+  [ "${1:-}" = "--herdr" ]
+do
+  USE_HERDR=true
+  shift
+done
+
+cmd="${1:-}"
+
+[ -n "$cmd" ] || {
+  usage
+  exit 1
+}
+
+case "$cmd" in
+  ls)
+    shift
+
+    [ "$#" -eq 0 ] ||
+      die "ocw ls does not accept arguments"
+
+    init_repo_context
+    git -C "$repo_root" worktree list
+    ;;
+
+  new)
+    shift
+
+    while [ "${1:-}" = "-H" ] ||
+      [ "${1:-}" = "--herdr" ]
+    do
+      USE_HERDR=true
+      shift
+    done
+
+    init_repo_context
+    create_worktree "$@"
+    ;;
+
+  rm | remove)
+    shift
+    init_repo_context
+    remove_worktree "$@"
+    ;;
+
+  help | -h | --help)
+    usage
+    ;;
+
+  *)
+    init_repo_context
+    create_worktree "$@"
+    ;;
+esac

--- a/docs/planning/DOC-002_ai-dotfiles-add-tools_計画.md
+++ b/docs/planning/DOC-002_ai-dotfiles-add-tools_計画.md
@@ -235,7 +235,7 @@ AVAILABLE_TOOLS="zsh nvim tmux bin claude"
 ## 孫4用プロンプト:
 
 ```
-## タスク: README 更新と全体統合確認
+## タスク: README 更新、全体統合確認、実マシンデプロイテスト
 
 ### やること
 
@@ -254,6 +254,43 @@ AVAILABLE_TOOLS="zsh nvim tmux bin claude"
 - 全READMEのフォーマット統一
 - リンク切れがないこと
 - 手順の正確性
+
+#### 4. 実マシンデプロイテスト（最重要）
+**PRマージ前に、このマシンで実際にデプロイを試して動作確認する。**
+
+a) **事前バックアップ**:
+```bash
+# 既存のファイルをバックアップ
+mkdir -p ~/dotfiles-backup-$(date +%Y%m%d)
+cp ~/bin/ocw ~/dotfiles-backup-$(date +%Y%m%d)/ 2>/dev/null
+cp ~/bin/claude-ds ~/dotfiles-backup-$(date +%Y%m%d)/ 2>/dev/null
+cp ~/.claude/CLAUDE.md ~/dotfiles-backup-$(date +%Y%m%d)/ 2>/dev/null
+cp ~/.claude/settings.json ~/dotfiles-backup-$(date +%Y%m%d)/ 2>/dev/null
+cp -r ~/.claude/skills/ ~/dotfiles-backup-$(date +%Y%m%d)/skills/ 2>/dev/null
+```
+
+b) **デプロイ実行**:
+```bash
+./deploy-all.sh --only bin,claude --force
+```
+
+c) **動作確認項目**:
+- [ ] `~/bin/ocw` が実行可能で `claude` がデフォルトコマンドになっている
+- [ ] `~/bin/claude-ds` が実行可能
+- [ ] `~/.claude/CLAUDE.md` が symlink で内容が正しい
+- [ ] `~/.claude/settings.json` が symlink で汎用設定のみ含まれている
+- [ ] `~/.claude/skills/pr-review-loop/SKILL.md` が symlink で存在
+- [ ] `~/.claude/skills/umbrella-orchestrator/SKILL.md` が symlink で存在
+- [ ] `~/.claude/skills/herdr/` が手付かずで残っている（削除されてない）
+- [ ] `deploy-all.sh --only zsh,nvim,tmux` が従来通り動作（bin/claude追加で壊れてない）
+- [ ] `deploy-all.sh` 全ツール一括が正常完了
+
+d) **問題があれば修正**:
+- 動作確認で問題が見つかったら、このブランチで修正する
+- 修正後、再度デプロイテストを行う
+- すべてのチェック項目がパスするまで繰り返す
+
+e) **バックアップからの復元手順もREADMEに記載**（万一のため）
 
 ### 重要なファイル（変更）
 - `README.md` — Supported Tools テーブル更新

--- a/docs/planning/DOC-002_ai-dotfiles-add-tools_計画.md
+++ b/docs/planning/DOC-002_ai-dotfiles-add-tools_計画.md
@@ -14,19 +14,25 @@
 |---|---|---|---|
 | 0 | `ai/ph-00-bin` | `bin/` ディレクトリ追加。ocw（デフォルトコマンドを claude に修正）、claude-ds、deploy.sh、README.md | 🔄 実装中 |
 | 1 | `ai/ph-01-claude-config` | `claude/` ディレクトリ追加。CLAUDE.md、settings.json（汎用設定のみ）、deploy.sh、README.md | ⬜ 待機中 |
-| 2 | `ai/ph-02-claude-skills` | `claude/skills/` に pr-review-loop と umbrella-orchestrator を移行 | ⬜ 待機中 |
-| 3 | `ai/ph-03-shared-update` | `shared/helpers.sh` の AVAILABLE_TOOLS に `bin claude` を追加 | ⬜ 待機中 |
-| 4 | `ai/ph-04-docs` | README.md 更新、deploy-all.sh での統合確認 | ⬜ 待機中 |
+| 2 | `ai/ph-02-claude-skills` | `claude/skills/` に pr-review-loop と umbrella-orchestrator を移行（**孫1マージ後に着手**） | ⬜ 待機中 |
+| 3 | `ai/ph-03-shared-update` | `shared/helpers.sh` の AVAILABLE_TOOLS に `bin claude` を追加 | ⬜ 待機中（孫0,1,2マージ待ち） |
+| 4 | `ai/ph-04-docs` | README.md 更新、deploy-all.sh での統合確認、実マシンデプロイテスト | ⬜ 待機中（全孫マージ待ち） |
 
-## 依存関係
+## 依存関係と実行順序
 
 ```
-ph-00-bin ─────────────────────┐
-ph-01-claude-config ──┬────────┼── ph-03-shared-update ── ph-04-docs
-ph-02-claude-skills ──┘        │   (孫2 は孫1 の claude/deploy.sh を拡張するため、
-                               │    マージ順は 孫1→孫2 であること)
-                               │
-                               └── (孫0 と孫1/孫2 は独立)
+フェーズ1（並列可）:
+  孫0 (bin/)     ← 独立。~/bin/ の ocw, claude-ds をコピー
+  孫1 (claude/)  ← 独立。~/.claude/ の CLAUDE.md, settings.json をコピー
+
+フェーズ2（孫1マージ後に着手）:
+  孫2 (skills)   ← 孫1 の claude/deploy.sh を拡張するため、孫1マージ必須
+
+フェーズ3（孫0,1,2 全マージ後に着手）:
+  孫3 (shared)   ← AVAILABLE_TOOLS に bin claude 追加
+
+フェーズ4（全孫マージ後に着手）:
+  孫4 (docs+test) ← ドキュメント更新 + 実マシンデプロイテスト
 ```
 
 ## 除外するもの
@@ -260,7 +266,6 @@ AVAILABLE_TOOLS="zsh nvim tmux bin claude"
 
 a) **事前バックアップ**:
 ```bash
-# 既存のファイルをバックアップ
 mkdir -p ~/dotfiles-backup-$(date +%Y%m%d)
 cp ~/bin/ocw ~/dotfiles-backup-$(date +%Y%m%d)/ 2>/dev/null
 cp ~/bin/claude-ds ~/dotfiles-backup-$(date +%Y%m%d)/ 2>/dev/null
@@ -274,14 +279,14 @@ b) **デプロイ実行**:
 ./deploy-all.sh --only bin,claude --force
 ```
 
-c) **動作確認項目**:
+c) **動作確認チェックリスト**:
 - [ ] `~/bin/ocw` が実行可能で `claude` がデフォルトコマンドになっている
 - [ ] `~/bin/claude-ds` が実行可能
 - [ ] `~/.claude/CLAUDE.md` が symlink で内容が正しい
-- [ ] `~/.claude/settings.json` が symlink で汎用設定のみ含まれている
+- [ ] `~/.claude/settings.json` が symlink で汎用設定のみ含まれている（allowリストがない）
 - [ ] `~/.claude/skills/pr-review-loop/SKILL.md` が symlink で存在
 - [ ] `~/.claude/skills/umbrella-orchestrator/SKILL.md` が symlink で存在
-- [ ] `~/.claude/skills/herdr/` が手付かずで残っている（削除されてない）
+- [ ] `~/.claude/skills/herdr/` が手付かずで残っている（削除されていない）
 - [ ] `deploy-all.sh --only zsh,nvim,tmux` が従来通り動作（bin/claude追加で壊れてない）
 - [ ] `deploy-all.sh` 全ツール一括が正常完了
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -37,6 +37,11 @@ KNOWN_LINKS_tmux=$(printf '%s\n' \
   "$HOME/.tmux.conf" \
 )
 
+KNOWN_LINKS_bin=$(printf '%s\n' \
+  "$HOME/bin/ocw" \
+  "$HOME/bin/claude-ds" \
+)
+
 # ── Usage ─────────────────────────────────────────────────────────────
 
 usage() {


### PR DESCRIPTION
## 概要

孫0: `bin/` ディレクトリを追加し、自作ツール（ocw, claude-ds）を dotfiles に移行。

## 変更内容

| ファイル | 内容 |
|---|---|
| `bin/ocw` | `~/bin/ocw` から移行。デフォルトの `OCW_COMMANDER_COMMAND` / `OCW_IMPLEMENTER_COMMAND` を `claude-ds` → `claude` に変更 |
| `bin/claude-ds` | `~/bin/claude-ds` から移行。現状維持 |
| `bin/deploy.sh` | `shared/helpers.sh` を使い `~/bin/` に symlink を作成 |
| `bin/README.md` | セットアップ手順、環境変数によるカスタマイズ方法を記載 |

## 自己レビュー

- **正当性**: 計画書の全項目を実装済み。ocw のデフォルトコマンド変更、claude-ds 現状維持、deploy.sh のパターン準拠、README のフォーマット統一
- **エッジケース**: DRY_RUNモード、~/bin 不在時の自動作成、symlink_backup による既存ファイル保護、APIキー不在時のエラーハンドリング
- **テスト**: シェルスクリプト中心のため自動lint/testはなし
- **無関係変更**: 計画書DOC-002に孫4の実マシンデプロイテスト計画が追記されている（umbrella-orchestratorによる計画書更新）
- **後方互換性**: 環境変数 `OCW_COMMANDER_COMMAND` / `OCW_IMPLEMENTER_COMMAND` で上書き可能。deploy.sh は既存の deploy-all.sh フレームワークに影響なし
- **保守性**: 既存の deploy.sh パターンに完全準拠
- **スタイル**: 元コードのスタイルを維持

## 関連計画書

[DOC-002_ai-dotfiles-add-tools_計画.md](https://github.com/manemone/dotfiles/blob/ai/dotfiles-add-tools/docs/planning/DOC-002_ai-dotfiles-add-tools_%E8%A8%88%E7%94%BB.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)