### PR TITLE
feat: AVAILABLE_TOOLS に bin claude を追加

### DIFF
--- a/shared/helpers.sh
+++ b/shared/helpers.sh
@@ -33,7 +33,7 @@ is_wsl() {
 
 # Canonical list of available tools.  deploy-all.sh and uninstall.sh
 # both source this file, so the list is defined once.
-AVAILABLE_TOOLS="zsh nvim tmux"
+AVAILABLE_TOOLS="zsh nvim tmux bin claude"
 
 # resolve_tools <only_tools> <var_name>
 # Resolves a comma-separated tool filter against AVAILABLE_TOOLS.


### PR DESCRIPTION
## 概要

`shared/helpers.sh` の `AVAILABLE_TOOLS` に `bin` と `claude` を追加し、
`deploy-all.sh --only bin,claude` でデプロイ可能にしました。

## 変更内容

- `shared/helpers.sh`: `AVAILABLE_TOOLS` を `"zsh nvim tmux"` → `"zsh nvim tmux bin claude"` に変更（1行）

## 確認済み

- [x] `resolve_tools "bin,claude"` → `TOOLS=bin claude` 正しく解決
- [x] `resolve_tools ""` → `TOOLS=zsh nvim tmux bin claude` 全ツール列挙
- [x] `resolve_tools "zsh,nvim,tmux"` → `TOOLS=zsh nvim tmux` 既存動作に影響なし
- [x] `resolve_tools "nonexistent"` → 正しくエラー
- [x] `deploy-all.sh --dry-run --only bin,claude` → bin/claude 両方のデプロイスクリプトが実行される

## 計画書

DOC-002 孫3: `shared/helpers.sh` の `AVAILABLE_TOOLS` に `bin claude` を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)