### PR TITLE
docs: README更新、全体統合確認、実マシンデプロイテスト — 孫4

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Easily deployable, cross-platform dotfiles managed with [mise](https://mise.jdx.
 | **Zsh** | Shell | [Antidote](https://github.com/mattmc3/antidote) |
 | **NeoVim** | Editor | [lazy.nvim](https://github.com/folke/lazy.nvim) |
 | **tmux** | Terminal multiplexer | — (built-in) |
+| **bin** | Custom CLI tools (ocw, claude-ds) | — (standalone scripts) |
+| **claude** | Claude Code config & skills | — (built-in) |
 
 ## Supported Platforms
 
@@ -78,6 +80,18 @@ Options can be combined:
 │   └── planning/
 ├── shared/
 │   └── helpers.sh             # Shared shell functions (logging, symlinks, platform detection)
+├── bin/
+│   ├── ocw                    # Git worktree manager with Herdr integration
+│   ├── claude-ds              # Claude Code via DeepSeek API wrapper
+│   ├── deploy.sh              # bin deployment script
+│   └── README.md
+├── claude/
+│   ├── CLAUDE.md              # Claude Code global personal instructions
+│   ├── settings.json          # Claude Code base settings (no machine-specific config)
+│   ├── settings.machine.json.example  # Template for machine-specific overrides
+│   ├── deploy.sh              # claude deployment script
+│   ├── skills/                # Claude Code custom skills (auto-detected)
+│   └── README.md
 ├── zsh/
 │   ├── .zshrc                 # Shell configuration
 │   ├── .zsh_plugins.txt       # Antidote plugin declarations
@@ -114,6 +128,8 @@ See each tool's deploy script for the full list of files it creates.
 
 See each tool's README for detailed configuration and troubleshooting:
 
+- [bin/README.md](bin/README.md) — CLI tools (ocw worktree manager, claude-ds DeepSeek wrapper)
+- [claude/README.md](claude/README.md) — Claude Code config, skills, machine-specific customization
 - [zsh/README.md](zsh/README.md) — shell setup, plugin management, aliases, version managers
 - [nvim/README.md](nvim/README.md) — editor setup, LSP servers, keybindings, plugins
 - [tmux/README.md](tmux/README.md) — multiplexer setup, Vim-style keybindings, clipboard


### PR DESCRIPTION
## 概要

孫4（docs+test）フェーズの実装です。全孫マージ後に着手する最終フェーズ。

## 変更内容

### README.md
- **Supported Tools テーブル** に `bin` と `claude` の行を追加
- **Directory Structure** ツリーに `bin/` と `claude/` のサブツリーを追加
- **Next Steps** に `bin/README.md` と `claude/README.md` へのリンクを追加

## 検証結果

### deploy-all.sh 統合確認（全 dry-run）
- [x] `--only bin` 正常動作
- [x] `--only claude` 正常動作
- [x] `--only bin,claude` 正常動作
- [x] `--only zsh,nvim,tmux` 従来通り動作（bin/claude追加で壊れていない）
- [x] 全ツール一括デプロイ正常完了（zsh nvim tmux bin claude）

### 実マシンデプロイテスト（`--force` で実実行）
- [x] `~/bin/ocw` 実行可能、デフォルトコマンドが `claude`
- [x] `~/bin/claude-ds` 実行可能
- [x] `~/.claude/CLAUDE.md` が正しい symlink
- [x] `~/.claude/settings.json` が生成された実ファイル（allow リストなし）
- [x] `~/.claude/skills/pr-review-loop/` symlink 存在
- [x] `~/.claude/skills/umbrella-orchestrator/` symlink 存在
- [x] `~/.claude/skills/herdr/` 手付かずで生存（削除されていない）

### ドキュメント整合性
- [x] 全READMEフォーマット統一確認
- [x] リンク切れなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)