### PR TITLE
feat: ocw / pr-review-loop に工程イベント計測を埋め込み (孫2)

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -71,6 +71,22 @@ ocw ls
 - **implementer**: 実装担当（デフォルト: `claude`）
 - **reviewer**: レビュー担当（デフォルト: `claude`）
 
+**工程計測（`ocw-meter` 連携。fail-open）:**
+
+worktree作成のたびに `run_id` を採番し、標準出力に `run:` 行として表示する。
+`run_id` は worktree の git管理領域（`git -C <worktree> rev-parse --absolute-git-dir` が指す
+`.git/worktrees/<slug>/ocw-run-id`。git worktreeの削除時に自動で掃除される、リポジトリには一切入らない場所）
+に保存され、`ocw rm` 実行時にそこから読み戻されて `run.end` イベントの記録に使われる。
+
+Herdrモードでは、commander/implementer/reviewer の各ペイン起動時に環境変数
+`OCW_ROLE`（`commander`/`implementer`/`reviewer`）と `OCW_RUN_ID` が `herdr workspace create --env` /
+`herdr pane split --env` 経由で自動的に渡される。`ocw-meter event` はこれらの環境変数を
+自動的に読み取り役割・runを紐付けるため、呼び出し側で明示的に指定する必要はない。
+
+`ocw-meter` が PATH に無い場合、`run:` 行と `.git/worktrees/<slug>/ocw-run-id` の保存は変わらず行われる
+（純粋なgit/bashロジックのため）が、`ocw-meter event` 呼び出しは `command -v` ガードにより静かにスキップされ、
+`ocw` 自体の動作・終了コードには一切影響しない。
+
 ### 3.2 claude-ds — Claude Code via DeepSeek API
 
 Claude Code CLI を DeepSeek API に繋ぎ替えて実行する。`exec env` で以下の環境変数を**すべて上書き固定**する。`claude "$@"` で CLI 引数は素通しされるため `--model` 等のオプションは通常通り指定可能だが、デフォルトモデルは以下の値に固定される:

--- a/bin/README.md
+++ b/bin/README.md
@@ -83,9 +83,28 @@ Herdrモードでは、commander/implementer/reviewer の各ペイン起動時�
 `herdr pane split --env` 経由で自動的に渡される。`ocw-meter event` はこれらの環境変数を
 自動的に読み取り役割・runを紐付けるため、呼び出し側で明示的に指定する必要はない。
 
-`ocw-meter` が PATH に無い場合、`run:` 行と `.git/worktrees/<slug>/ocw-run-id` の保存は変わらず行われる
+**非Herdrモード（`ocw <name>`、VS Codeを開く既定モード）では `OCW_RUN_ID` は自動では渡らない。**
+`run_id` は `run:` 行と `ocw-run-id` ファイルには保存されるが、それを読んで環境変数へ載せる主体が
+Herdrのペイン起動以外に存在しないため、そのworktree内で動く `ocw-meter event`（`pr-review-loop` の
+工程イベント等）は明示的にexportしない限り `run_id: null` として記録される。紐付けたい場合は
+worktree内で以下を実行してから作業を始めること:
+
+```bash
+export OCW_RUN_ID="$(cat "$(git rev-parse --absolute-git-dir)/ocw-run-id" 2>/dev/null)"
+```
+
+`ocw-meter` が PATH に無い場合、`run:` 行と `ocw-run-id` の保存は変わらず行われる
 （純粋なgit/bashロジックのため）が、`ocw-meter event` 呼び出しは `command -v` ガードにより静かにスキップされ、
-`ocw` 自体の動作・終了コードには一切影響しない。
+`ocw` 自体の動作・終了コードには一切影響しない。`ocw-meter` はあるがそのイベントの書き込みだけが失敗する場合
+（例: `OCW_METER_HOME` が読み取り専用）も、`run_id` の採番・`run:` 出力・`ocw-run-id` の保存・`ocw` 自体の
+終了コードは影響を受けない（fail-open）。ただし `ocw-meter` 自身は書き込み失敗を stderr に1行warnとして出す
+設計（`bin/ocw-meter` 自身の既知の限界。誤りを隠さない方針のため）であり、これは `ocw` の出力への追加として
+現れうる。
+
+**`run.end` が記録されない run が存在しうる**（best-effort の限界）: `ocw rm` は「未マージ」「未コミット
+変更あり」等で `die` して停止する経路が複数あり、そこに到達する前に停止した場合は `run.end` が一切
+記録されない。`ocw rm -f` は完了時に必ず記録するが、その `outcome` は `failure`（`-f` は「未マージ・未コミット
+のまま強制的に捨てる」経路であり、通常の `rm` の `success` と区別する）になる。
 
 ### 3.2 claude-ds — Claude Code via DeepSeek API
 

--- a/bin/ocw
+++ b/bin/ocw
@@ -1,11 +1,27 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Full original invocation, captured before any arg-shifting below, for the
+# run.start `--command` payload (docs/planning/DOC-003_..._計画.md §8.4-adjacent
+# 孫2 prompt). Display-only string; never re-executed.
+ORIGINAL_INVOCATION="ocw $*"
+
 USE_HERDR=false
 
 COMMANDER_COMMAND="${OCW_COMMANDER_COMMAND:-claude}"
 IMPLEMENTER_COMMAND="${OCW_IMPLEMENTER_COMMAND:-claude}"
 REVIEWER_COMMAND="${OCW_REVIEWER_COMMAND:-claude}"
+
+# Observability (docs/planning/DOC-003_..._計画.md §7.4, 孫2 prompt). Always
+# fail-open: ocw-meter being entirely absent from PATH, or failing internally,
+# must never affect ocw's own exit code or output beyond the `run:` line.
+ocw_meter_event() {
+  command -v ocw-meter >/dev/null 2>&1 && ocw-meter event "$@" || true
+}
+
+generate_run_id() {
+  printf '%s-%x%x\n' "$(date +%s)" "$RANDOM" "$RANDOM"
+}
 
 HERDR_SETUP_WORKSPACE_ID=""
 HERDR_SETUP_COMMANDER_PANE_ID=""
@@ -177,6 +193,7 @@ open_vscode() {
 setup_herdr_workspace() {
   local worktree_dir="$1"
   local workspace_label="$2"
+  local run_id="$3"
 
   local open_json=""
   local split_json=""
@@ -191,6 +208,8 @@ setup_herdr_workspace() {
   herdr workspace create \
     --cwd "$worktree_dir" \
     --label "$workspace_label" \
+    --env "OCW_ROLE=commander" \
+    --env "OCW_RUN_ID=${run_id}" \
     --no-focus
   )" || return 1
 
@@ -242,6 +261,8 @@ setup_herdr_workspace() {
       "$HERDR_SETUP_COMMANDER_PANE_ID" \
       --direction right \
       --cwd "$worktree_dir" \
+      --env "OCW_ROLE=implementer" \
+      --env "OCW_RUN_ID=${run_id}" \
       --no-focus
   )" || return 1
 
@@ -268,6 +289,8 @@ setup_herdr_workspace() {
       "$HERDR_SETUP_IMPLEMENTER_PANE_ID" \
       --direction right \
       --cwd "$worktree_dir" \
+      --env "OCW_ROLE=reviewer" \
+      --env "OCW_RUN_ID=${run_id}" \
       --no-focus
   )" || return 1
 
@@ -315,8 +338,16 @@ setup_herdr_workspace() {
 rollback_created_worktree() {
   local worktree_dir="$1"
   local branch="$2"
+  local run_id="${3:-}"
 
   echo "error: Herdr setup failed; rolling back" >&2
+
+  if [ -n "$run_id" ]; then
+    ocw_meter_event run.end \
+      --run-id "$run_id" \
+      --source ocw \
+      --outcome failure
+  fi
 
   set +e
 
@@ -407,20 +438,42 @@ create_worktree() {
     "$worktree_dir" \
     "$base_ref"
 
+  local run_id=""
+  local worktree_git_dir=""
+
+  run_id="$(generate_run_id)"
+  # `.git` inside a linked worktree is a *file* pointing at the private
+  # metadata dir under the main repo's `.git/worktrees/<slug>/` — not a
+  # directory we can drop a file into directly. That metadata dir is the
+  # actual git-managed, never-committed, auto-pruned-on-removal location, so
+  # store the run-id file there instead of literally at "<worktree>/.git/".
+  worktree_git_dir="$(git -C "$worktree_dir" rev-parse --absolute-git-dir)"
+  printf '%s\n' "$run_id" >"${worktree_git_dir}/ocw-run-id"
+
+  echo "run:         ${run_id}"
+
+  ocw_meter_event run.start \
+    --run-id "$run_id" \
+    --source ocw \
+    --base-ref "$base_ref" \
+    --command "$ORIGINAL_INVOCATION"
+
   if [ "$USE_HERDR" = "true" ]; then
     local setup_status=0
 
     set +e
     setup_herdr_workspace \
       "$worktree_dir" \
-      "$workspace_label"
+      "$workspace_label" \
+      "$run_id"
     setup_status="$?"
     set -e
 
     if [ "$setup_status" -ne 0 ]; then
       rollback_created_worktree \
         "$worktree_dir" \
-        "$branch"
+        "$branch" \
+        "$run_id"
 
       exit "$setup_status"
     fi
@@ -619,6 +672,15 @@ remove_worktree() {
   [ -d "$worktree_dir" ] ||
     die "worktree dir does not exist: ${worktree_dir}"
 
+  local run_id=""
+  local worktree_git_dir=""
+
+  worktree_git_dir="$(git -C "$worktree_dir" rev-parse --absolute-git-dir 2>/dev/null)" || true
+
+  if [ -n "$worktree_git_dir" ] && [ -f "${worktree_git_dir}/ocw-run-id" ]; then
+    run_id="$(cat "${worktree_git_dir}/ocw-run-id")"
+  fi
+
   if [ "$force" = "false" ]; then
     if [ -n "$(git -C "$worktree_dir" status --porcelain)" ]; then
       die "worktree has uncommitted or untracked changes: ${worktree_dir}"
@@ -645,6 +707,13 @@ remove_worktree() {
 
     git -C "$repo_root" \
       branch -d "$branch"
+  fi
+
+  if [ -n "$run_id" ]; then
+    ocw_meter_event run.end \
+      --run-id "$run_id" \
+      --source ocw \
+      --outcome success
   fi
 }
 

--- a/bin/ocw
+++ b/bin/ocw
@@ -457,7 +457,12 @@ create_worktree() {
   # emitted just below still went out.
   worktree_git_dir="$(git -C "$worktree_dir" rev-parse --absolute-git-dir 2>/dev/null)" || worktree_git_dir=""
   if [ -n "$worktree_git_dir" ]; then
-    printf '%s\n' "$run_id" >"${worktree_git_dir}/ocw-run-id" 2>/dev/null || true
+    # Redirections apply left-to-right: `2>/dev/null` must come BEFORE the
+    # `>file` redirect, or a failure to open `>file` (permission denied,
+    # disk full) is reported by bash before stderr is silenced, leaking a
+    # raw bash error onto ocw's real stderr despite the trailing `|| true`
+    # protecting the exit code.
+    printf '%s\n' "$run_id" 2>/dev/null >"${worktree_git_dir}/ocw-run-id" || true
   fi
 
   echo "run:         ${run_id}"

--- a/bin/ocw
+++ b/bin/ocw
@@ -447,8 +447,18 @@ create_worktree() {
   # directory we can drop a file into directly. That metadata dir is the
   # actual git-managed, never-committed, auto-pruned-on-removal location, so
   # store the run-id file there instead of literally at "<worktree>/.git/".
-  worktree_git_dir="$(git -C "$worktree_dir" rev-parse --absolute-git-dir)"
-  printf '%s\n' "$run_id" >"${worktree_git_dir}/ocw-run-id"
+  #
+  # This is best-effort/fail-open like every other ocw-meter-adjacent call
+  # here: a `rev-parse` failure or an unwritable git dir (disk full, RO
+  # mount) must not take down `ocw` itself (which already succeeded at the
+  # one thing that matters, `git worktree add`) or leave an orphaned
+  # worktree with no rollback. Losing the persisted run_id only means
+  # `ocw rm` later won't find one to emit run.end with — the run.start
+  # emitted just below still went out.
+  worktree_git_dir="$(git -C "$worktree_dir" rev-parse --absolute-git-dir 2>/dev/null)" || worktree_git_dir=""
+  if [ -n "$worktree_git_dir" ]; then
+    printf '%s\n' "$run_id" >"${worktree_git_dir}/ocw-run-id" 2>/dev/null || true
+  fi
 
   echo "run:         ${run_id}"
 
@@ -695,7 +705,16 @@ remove_worktree() {
 
   close_herdr_workspaces_for_checkout "$worktree_dir"
 
+  # -f discards a worktree without requiring it merged or clean (usage's own
+  # "ocw rm -f failed-experiment" example) — that's a run that didn't reach
+  # a mergeable result, so record it as failure rather than success. A
+  # plain `rm` only ever gets here after the merged+clean checks above pass,
+  # so it's always a successful run.end.
+  local run_end_outcome="success"
+
   if [ "$force" = "true" ]; then
+    run_end_outcome="failure"
+
     git -C "$repo_root" \
       worktree remove --force "$worktree_dir"
 
@@ -713,7 +732,7 @@ remove_worktree() {
     ocw_meter_event run.end \
       --run-id "$run_id" \
       --source ocw \
-      --outcome success
+      --outcome "$run_end_outcome"
   fi
 }
 

--- a/bin/tests/test_ocw.py
+++ b/bin/tests/test_ocw.py
@@ -1,0 +1,295 @@
+"""Tests for bin/ocw's ocw-meter instrumentation.
+
+孫2 (docs/planning/DOC-003_ai-llm-cost-observability_計画.md §11/孫2 prompt):
+ocw now issues a run_id per worktree, persists it under the worktree's
+private git metadata dir, and emits run.start/run.end via ocw-meter
+(fail-open). This file is black-box (subprocess, matching
+test_ocw_meter.py's style): each test builds a throwaway git repo under a
+tempdir and invokes the real bin/ocw executable against it, so nothing
+here touches this repo or its worktrees.
+
+Coverage:
+  - run_id is generated, printed as a `run:` line, and persisted at
+    the linked worktree's `<gitdir>/ocw-run-id` (NOT literally
+    "<worktree>/.git/ocw-run-id" — `.git` in a linked worktree is a
+    *file*, not a directory; see the comment in bin/ocw)
+  - run.start / run.end are recorded via the real ocw-meter with the
+    expected fields (T07-adjacent: run_id ties the two together)
+  - T18 (meter absent from PATH): ocw's own output/exit codes for
+    create and remove are unaffected
+  - T19 (ocw-meter storage unwritable): same
+  - pre-existing error paths (missing args, duplicate branch, `ocw ls`,
+    unmerged-branch removal without -f) are unaffected by instrumentation
+
+Herdr-mode env var passing (`--env OCW_ROLE=...` / `--env OCW_RUN_ID=...`
+on `herdr workspace create` / `herdr pane split`) is not covered here: it
+requires a running Herdr server and would spawn real terminal panes,
+which is out of scope for a hermetic, no-side-effect unit suite. It was
+verified manually against a live Herdr server (see PR description): a
+throwaway workspace was created with `--env FOO=bar`, and `herdr pane run
+... "echo $FOO"` confirmed the value reached the pane's shell.
+"""
+
+import json
+import os
+import pathlib
+import re
+import subprocess
+import tempfile
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+OCW = REPO_ROOT / "bin" / "ocw"
+
+# Standard-tool PATH only; deliberately excludes REPO_ROOT/bin so ocw-meter
+# is absent unless a test opts in via meter_on_path=True. Non-Herdr ocw
+# paths never shell out to python3, so it doesn't need to be on PATH here.
+BASE_PATH_DIRS = ("/usr/bin", "/bin", "/usr/local/bin")
+
+RUN_LINE_RE = re.compile(r"^run:\s+(\S+)$", re.MULTILINE)
+
+
+def _git(args, cwd):
+    result = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"git {args} failed in {cwd}: {result.stderr}")
+    return result
+
+
+def make_repo(root):
+    """A minimal git repo at <root>/main with one commit on branch `main`,
+    plus a local bare "origin" remote with its HEAD symref set.
+
+    ocw resolves the *main* worktree's parent directory as where sibling
+    worktrees get created (repo_root = git worktree list's first entry;
+    worktree_dir = dirname(repo_root)/<slug>) — mirroring how this repo's
+    own worktrees sit next to `master/` under `.../dotfiles/`.
+
+    The origin remote isn't optional scaffolding: ocw's own base_ref
+    fallback (`git symbolic-ref refs/remotes/origin/HEAD`) is a real git
+    command run under `set -euo pipefail`. Every real checkout ocw is
+    used against has an origin with a HEAD symref (that's what `git
+    clone` sets up), so without reproducing it here, these tests would be
+    exercising a bare-repo shape ocw was never meant to run against,
+    rather than the instrumentation this file is actually testing.
+    """
+    origin_dir = pathlib.Path(root) / "origin.git"
+    _git(["init", "-q", "--bare", "-b", "main", str(origin_dir)], root)
+
+    main_dir = pathlib.Path(root) / "main"
+    main_dir.mkdir(parents=True)
+    _git(["init", "-q", "-b", "main"], main_dir)
+    _git(["config", "user.email", "test@example.invalid"], main_dir)
+    _git(["config", "user.name", "Test"], main_dir)
+    (main_dir / "README.md").write_text("test\n", encoding="utf-8")
+    _git(["add", "README.md"], main_dir)
+    _git(["commit", "-q", "-m", "initial"], main_dir)
+    _git(["remote", "add", "origin", str(origin_dir)], main_dir)
+    _git(["push", "-q", "-u", "origin", "main"], main_dir)
+    _git(["remote", "set-head", "origin", "main"], main_dir)
+    return main_dir
+
+
+def run_ocw(args, cwd, meter_on_path=False, meter_home=None, extra_env=None, timeout=30):
+    path_dirs = list(BASE_PATH_DIRS)
+    if meter_on_path:
+        path_dirs.insert(0, str(REPO_ROOT / "bin"))
+    env = {
+        "PATH": ":".join(path_dirs),
+        "HOME": os.environ.get("HOME", "/root"),
+    }
+    if meter_home is not None:
+        env["OCW_METER_HOME"] = str(meter_home)
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [str(OCW), *args],
+        cwd=str(cwd),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def read_events(home):
+    events = []
+    events_dir = pathlib.Path(home) / "events"
+    if not events_dir.exists():
+        return events
+    for path in sorted(events_dir.glob("*.jsonl")):
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                events.append(json.loads(line))
+    return events
+
+
+def extract_run_id(stdout):
+    match = RUN_LINE_RE.search(stdout)
+    assert match, f"no 'run:' line found in stdout:\n{stdout}"
+    return match.group(1)
+
+
+class OcwTestCase(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.repo_root = make_repo(self.tmpdir.name)
+        self.meter_home = pathlib.Path(self.tmpdir.name) / "ocw-meter-home"
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+
+class RunIdAndMeterEventsTests(OcwTestCase):
+    """run_id issuance/persistence + real ocw-meter recording (run.start/end)."""
+
+    def test_create_prints_and_persists_run_id(self):
+        result = run_ocw(["widget-maker"], self.repo_root)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        run_id = extract_run_id(result.stdout)
+        self.assertRegex(run_id, r"^\d+-[0-9a-f]+$")
+
+        worktree_dir = self.repo_root.parent / "widget-maker"
+        self.assertTrue(worktree_dir.is_dir())
+
+        git_dir = _git(["rev-parse", "--absolute-git-dir"], worktree_dir).stdout.strip()
+        run_id_file = pathlib.Path(git_dir) / "ocw-run-id"
+        self.assertTrue(run_id_file.is_file())
+        self.assertEqual(run_id_file.read_text(encoding="utf-8").strip(), run_id)
+
+    def test_create_then_remove_records_run_start_and_run_end(self):
+        create = run_ocw(
+            ["widget-maker"], self.repo_root, meter_on_path=True, meter_home=self.meter_home
+        )
+        self.assertEqual(create.returncode, 0, create.stderr)
+        run_id = extract_run_id(create.stdout)
+
+        events = read_events(self.meter_home)
+        starts = [e for e in events if e["event_type"] == "run.start" and e["run_id"] == run_id]
+        self.assertEqual(len(starts), 1, events)
+        self.assertEqual(starts[0]["source"], "ocw")
+        self.assertEqual(starts[0]["base_ref"], "main")
+        self.assertIn("widget-maker", starts[0]["command"])
+
+        remove = run_ocw(
+            ["rm", "widget-maker"],
+            self.repo_root,
+            meter_on_path=True,
+            meter_home=self.meter_home,
+        )
+        self.assertEqual(remove.returncode, 0, remove.stderr)
+
+        events = read_events(self.meter_home)
+        ends = [e for e in events if e["event_type"] == "run.end" and e["run_id"] == run_id]
+        self.assertEqual(len(ends), 1, events)
+        self.assertEqual(ends[0]["source"], "ocw")
+        self.assertEqual(ends[0]["outcome"], "success")
+
+
+class MeterAbsentRegressionTests(OcwTestCase):
+    """T18: ocw-meter entirely absent from PATH must not change ocw's behavior."""
+
+    def test_create_and_remove_succeed_without_ocw_meter_on_path(self):
+        create = run_ocw(["widget-maker"], self.repo_root, meter_on_path=False)
+        self.assertEqual(create.returncode, 0, create.stderr)
+        self.assertRegex(create.stdout, RUN_LINE_RE)
+
+        worktree_dir = self.repo_root.parent / "widget-maker"
+        self.assertTrue(worktree_dir.is_dir())
+
+        remove = run_ocw(["rm", "widget-maker"], self.repo_root, meter_on_path=False)
+        self.assertEqual(remove.returncode, 0, remove.stderr)
+        self.assertFalse(worktree_dir.exists())
+
+    def test_stderr_has_no_ocw_meter_noise_when_absent(self):
+        # `command -v` failing should be silent — no "command not found"
+        # noise should leak onto stderr just because ocw-meter is missing.
+        create = run_ocw(["widget-maker"], self.repo_root, meter_on_path=False)
+        self.assertEqual(create.returncode, 0, create.stderr)
+        self.assertNotIn("ocw-meter", create.stderr)
+
+
+class MeterStorageUnwritableTests(OcwTestCase):
+    """T19: ocw-meter present but unable to write must not affect ocw."""
+
+    def test_create_and_remove_succeed_when_meter_storage_is_read_only(self):
+        ro_parent = pathlib.Path(self.tmpdir.name) / "ro-parent"
+        ro_parent.mkdir()
+        os.chmod(ro_parent, 0o500)
+        unwritable_home = ro_parent / "ocw-meter-home"
+        try:
+            create = run_ocw(
+                ["widget-maker"],
+                self.repo_root,
+                meter_on_path=True,
+                meter_home=unwritable_home,
+            )
+            self.assertEqual(create.returncode, 0, create.stderr)
+            self.assertRegex(create.stdout, RUN_LINE_RE)
+
+            remove = run_ocw(
+                ["rm", "widget-maker"],
+                self.repo_root,
+                meter_on_path=True,
+                meter_home=unwritable_home,
+            )
+            self.assertEqual(remove.returncode, 0, remove.stderr)
+        finally:
+            os.chmod(ro_parent, 0o700)
+
+
+class ExistingBehaviorRegressionTests(OcwTestCase):
+    """Pre-existing ocw error paths/subcommands must be untouched."""
+
+    def test_create_missing_task_name_exits_nonzero(self):
+        result = run_ocw([], self.repo_root)
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_duplicate_branch_dies(self):
+        first = run_ocw(["widget-maker"], self.repo_root)
+        self.assertEqual(first.returncode, 0, first.stderr)
+
+        second = run_ocw(["widget-maker"], self.repo_root)
+        self.assertNotEqual(second.returncode, 0)
+        self.assertIn("branch already exists", second.stderr)
+
+    def test_ls_lists_worktrees(self):
+        create = run_ocw(["widget-maker"], self.repo_root)
+        self.assertEqual(create.returncode, 0, create.stderr)
+
+        result = run_ocw(["ls"], self.repo_root)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("widget-maker", result.stdout)
+
+    def test_remove_nonexistent_worktree_dies(self):
+        result = run_ocw(["rm", "does-not-exist"], self.repo_root)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("worktree dir does not exist", result.stderr)
+
+    def test_remove_unmerged_branch_without_force_dies(self):
+        create = run_ocw(["widget-maker"], self.repo_root)
+        self.assertEqual(create.returncode, 0, create.stderr)
+
+        worktree_dir = self.repo_root.parent / "widget-maker"
+        (worktree_dir / "extra.txt").write_text("unmerged change\n", encoding="utf-8")
+        _git(["add", "extra.txt"], worktree_dir)
+        _git(["commit", "-q", "-m", "unmerged commit"], worktree_dir)
+
+        remove = run_ocw(["rm", "widget-maker"], self.repo_root)
+        self.assertNotEqual(remove.returncode, 0)
+        self.assertIn("branch is not merged", remove.stderr)
+
+        # Force-remove so this test doesn't leak a dangling worktree.
+        force_remove = run_ocw(["rm", "-f", "widget-maker"], self.repo_root)
+        self.assertEqual(force_remove.returncode, 0, force_remove.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bin/tests/test_ocw.py
+++ b/bin/tests/test_ocw.py
@@ -192,6 +192,35 @@ class RunIdAndMeterEventsTests(OcwTestCase):
         self.assertEqual(ends[0]["source"], "ocw")
         self.assertEqual(ends[0]["outcome"], "success")
 
+    def test_force_remove_records_run_end_with_failure_outcome(self):
+        # `ocw rm -f` discards a worktree without requiring it merged/clean
+        # (usage's own "ocw rm -f failed-experiment" example) — a run that
+        # didn't reach a mergeable result, so it must be distinguishable
+        # from the successful-completion `run.end` above.
+        create = run_ocw(
+            ["widget-maker"], self.repo_root, meter_on_path=True, meter_home=self.meter_home
+        )
+        self.assertEqual(create.returncode, 0, create.stderr)
+        run_id = extract_run_id(create.stdout)
+
+        worktree_dir = self.repo_root.parent / "widget-maker"
+        (worktree_dir / "extra.txt").write_text("unmerged change\n", encoding="utf-8")
+        _git(["add", "extra.txt"], worktree_dir)
+        _git(["commit", "-q", "-m", "unmerged commit"], worktree_dir)
+
+        remove = run_ocw(
+            ["rm", "-f", "widget-maker"],
+            self.repo_root,
+            meter_on_path=True,
+            meter_home=self.meter_home,
+        )
+        self.assertEqual(remove.returncode, 0, remove.stderr)
+
+        events = read_events(self.meter_home)
+        ends = [e for e in events if e["event_type"] == "run.end" and e["run_id"] == run_id]
+        self.assertEqual(len(ends), 1, events)
+        self.assertEqual(ends[0]["outcome"], "failure")
+
 
 class MeterAbsentRegressionTests(OcwTestCase):
     """T18: ocw-meter entirely absent from PATH must not change ocw's behavior."""
@@ -217,30 +246,59 @@ class MeterAbsentRegressionTests(OcwTestCase):
 
 
 class MeterStorageUnwritableTests(OcwTestCase):
-    """T19: ocw-meter present but unable to write must not affect ocw."""
+    """T19: ocw-meter present but unable to write must not affect ocw.
 
-    def test_create_and_remove_succeed_when_meter_storage_is_read_only(self):
+    ocw-meter's own contract (bin/ocw-meter's design + bin/README.md) is to
+    print a one-line stderr warning on a write failure rather than stay
+    silent about it ("never silent about failures" — verified directly
+    below). So "ocw's behavior is unaffected" is checked on stdout, which
+    is exactly what ocw itself prints; it deliberately is NOT checked by
+    asserting stderr is empty, since a warning there is by design, not a
+    regression.
+    """
+
+    def test_stdout_is_unaffected_when_storage_is_read_only(self):
         ro_parent = pathlib.Path(self.tmpdir.name) / "ro-parent"
         ro_parent.mkdir()
         os.chmod(ro_parent, 0o500)
         unwritable_home = ro_parent / "ocw-meter-home"
+        working_home = pathlib.Path(self.tmpdir.name) / "working-home"
         try:
+            baseline_create = run_ocw(
+                ["widget-maker"], self.repo_root, meter_on_path=True, meter_home=working_home
+            )
+            self.assertEqual(baseline_create.returncode, 0, baseline_create.stderr)
+            baseline_run_id = extract_run_id(baseline_create.stdout)
+            baseline_remove = run_ocw(
+                ["rm", "widget-maker"], self.repo_root, meter_on_path=True, meter_home=working_home
+            )
+            self.assertEqual(baseline_remove.returncode, 0, baseline_remove.stderr)
+
             create = run_ocw(
-                ["widget-maker"],
-                self.repo_root,
-                meter_on_path=True,
-                meter_home=unwritable_home,
+                ["widget-maker"], self.repo_root, meter_on_path=True, meter_home=unwritable_home
             )
             self.assertEqual(create.returncode, 0, create.stderr)
-            self.assertRegex(create.stdout, RUN_LINE_RE)
+            create_run_id = extract_run_id(create.stdout)
+            # Confirms the failure path was actually exercised (not a
+            # silent no-op that would make the stdout comparison vacuous).
+            self.assertIn("ocw-meter", create.stderr)
+
+            # stdout identical modulo the run_id token (a fresh random
+            # value each run) proves the read-only storage didn't add,
+            # drop, or reorder a single line of ocw's own output.
+            self.assertEqual(
+                baseline_create.stdout.replace(baseline_run_id, "<RUN_ID>"),
+                create.stdout.replace(create_run_id, "<RUN_ID>"),
+            )
 
             remove = run_ocw(
-                ["rm", "widget-maker"],
-                self.repo_root,
-                meter_on_path=True,
-                meter_home=unwritable_home,
+                ["rm", "widget-maker"], self.repo_root, meter_on_path=True, meter_home=unwritable_home
             )
             self.assertEqual(remove.returncode, 0, remove.stderr)
+            self.assertEqual(
+                baseline_remove.stdout,
+                remove.stdout,
+            )
         finally:
             os.chmod(ro_parent, 0o700)
 

--- a/bin/tests/test_ocw.py
+++ b/bin/tests/test_ocw.py
@@ -34,6 +34,8 @@ import json
 import os
 import pathlib
 import re
+import shlex
+import shutil
 import subprocess
 import tempfile
 import unittest
@@ -96,10 +98,12 @@ def make_repo(root):
     return main_dir
 
 
-def run_ocw(args, cwd, meter_on_path=False, meter_home=None, extra_env=None, timeout=30):
+def run_ocw(args, cwd, meter_on_path=False, meter_home=None, extra_env=None, path_prepend=None, timeout=30):
     path_dirs = list(BASE_PATH_DIRS)
     if meter_on_path:
         path_dirs.insert(0, str(REPO_ROOT / "bin"))
+    if path_prepend:
+        path_dirs = list(path_prepend) + path_dirs
     env = {
         "PATH": ":".join(path_dirs),
         "HOME": os.environ.get("HOME", "/root"),
@@ -134,6 +138,36 @@ def extract_run_id(stdout):
     match = RUN_LINE_RE.search(stdout)
     assert match, f"no 'run:' line found in stdout:\n{stdout}"
     return match.group(1)
+
+
+def write_git_shim_failing_absolute_git_dir(shim_dir, worktree_dir):
+    """A `git` wrapper that fails only `-C <worktree_dir> rev-parse
+    --absolute-git-dir` (exactly bin/ocw's run_id-persistence lookup for
+    that one worktree) and delegates everything else — including that
+    same rev-parse for any *other* path, and every other subcommand ocw
+    itself needs (worktree add/remove, show-ref, branch, symbolic-ref,
+    merge-base, status) — to the real system git. This exercises the
+    `|| worktree_git_dir=""` fail-open fallback in bin/ocw without a real
+    disk-full/read-only-mount setup, which isn't reproducible from a
+    plain user-permission test.
+    """
+    real_git_path = next(
+        (p for p in ("/usr/bin/git", "/bin/git") if pathlib.Path(p).exists()),
+        shutil.which("git"),
+    )
+    assert real_git_path, "no real git found to delegate to"
+    target = shlex.quote(str(worktree_dir))
+    shim = pathlib.Path(shim_dir) / "git"
+    shim.write_text(
+        "#!/usr/bin/env bash\n"
+        f'if [ "$1" = "-C" ] && [ "$2" = {target} ] && '
+        '[ "$3" = "rev-parse" ] && [ "$4" = "--absolute-git-dir" ]; then\n'
+        "  exit 1\n"
+        "fi\n"
+        f'exec "{real_git_path}" "$@"\n',
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
 
 
 class OcwTestCase(unittest.TestCase):
@@ -220,6 +254,29 @@ class RunIdAndMeterEventsTests(OcwTestCase):
         ends = [e for e in events if e["event_type"] == "run.end" and e["run_id"] == run_id]
         self.assertEqual(len(ends), 1, events)
         self.assertEqual(ends[0]["outcome"], "failure")
+
+
+class RunIdPersistenceFailOpenTests(OcwTestCase):
+    """The run_id persistence step itself (rev-parse + printf into the
+    worktree's private git dir) must be fail-open: a failure there is not
+    an ocw-meter failure (T18/T19 above), it's `bin/ocw`'s own git/bash
+    logic, and it ran into the exact `set -euo pipefail` trap ocw-meter's
+    own design notes warn about elsewhere in this codebase."""
+
+    def test_create_succeeds_when_git_rev_parse_absolute_git_dir_fails(self):
+        worktree_dir = self.repo_root.parent / "widget-maker"
+        shim_dir = pathlib.Path(self.tmpdir.name) / "git-shim"
+        shim_dir.mkdir()
+        write_git_shim_failing_absolute_git_dir(shim_dir, worktree_dir)
+
+        create = run_ocw(["widget-maker"], self.repo_root, path_prepend=[str(shim_dir)])
+        self.assertEqual(create.returncode, 0, create.stderr)
+        self.assertRegex(create.stdout, RUN_LINE_RE)
+        self.assertTrue(worktree_dir.is_dir())
+
+        remove = run_ocw(["rm", "widget-maker"], self.repo_root, path_prepend=[str(shim_dir)])
+        self.assertEqual(remove.returncode, 0, remove.stderr)
+        self.assertFalse(worktree_dir.exists())
 
 
 class MeterAbsentRegressionTests(OcwTestCase):

--- a/bin/tests/test_ocw.py
+++ b/bin/tests/test_ocw.py
@@ -170,6 +170,35 @@ def write_git_shim_failing_absolute_git_dir(shim_dir, worktree_dir):
     shim.chmod(0o755)
 
 
+def write_git_shim_redirecting_absolute_git_dir(shim_dir, worktree_dir, redirect_to):
+    """A `git` wrapper that makes `-C <worktree_dir> rev-parse
+    --absolute-git-dir` *succeed*, but answer with `redirect_to` instead
+    of the real git dir — everything else delegates to real git. Used to
+    make bin/ocw's run-id `printf` target a caller-controlled (e.g.
+    read-only) directory without needing a real disk-full/RO-mount, which
+    isn't reproducible from a plain user-permission test.
+    """
+    real_git_path = next(
+        (p for p in ("/usr/bin/git", "/bin/git") if pathlib.Path(p).exists()),
+        shutil.which("git"),
+    )
+    assert real_git_path, "no real git found to delegate to"
+    target = shlex.quote(str(worktree_dir))
+    redirect = shlex.quote(str(redirect_to))
+    shim = pathlib.Path(shim_dir) / "git"
+    shim.write_text(
+        "#!/usr/bin/env bash\n"
+        f'if [ "$1" = "-C" ] && [ "$2" = {target} ] && '
+        '[ "$3" = "rev-parse" ] && [ "$4" = "--absolute-git-dir" ]; then\n'
+        f"  printf '%s\\n' {redirect}\n"
+        "  exit 0\n"
+        "fi\n"
+        f'exec "{real_git_path}" "$@"\n',
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+
+
 class OcwTestCase(unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.TemporaryDirectory()
@@ -277,6 +306,46 @@ class RunIdPersistenceFailOpenTests(OcwTestCase):
         remove = run_ocw(["rm", "widget-maker"], self.repo_root, path_prepend=[str(shim_dir)])
         self.assertEqual(remove.returncode, 0, remove.stderr)
         self.assertFalse(worktree_dir.exists())
+
+    def test_create_succeeds_and_leaks_no_bash_error_when_run_id_write_fails(self):
+        # Distinct from the rev-parse-failure case above: here rev-parse
+        # *succeeds* (as it always does in real use — worktree add just
+        # created that git dir), but the actual `printf >file` write into
+        # it fails (permission denied). Left-to-right redirect ordering
+        # (`2>/dev/null` before `>file`) is what's under test here.
+        baseline = run_ocw(["baseline-widget"], self.repo_root)
+        self.assertEqual(baseline.returncode, 0, baseline.stderr)
+        baseline_run_id = extract_run_id(baseline.stdout)
+
+        worktree_dir = self.repo_root.parent / "widget-maker"
+        shim_dir = pathlib.Path(self.tmpdir.name) / "git-shim"
+        shim_dir.mkdir()
+        ro_dir = pathlib.Path(self.tmpdir.name) / "ro-git-dir"
+        ro_dir.mkdir()
+        os.chmod(ro_dir, 0o500)
+        try:
+            write_git_shim_redirecting_absolute_git_dir(shim_dir, worktree_dir, ro_dir)
+
+            create = run_ocw(["widget-maker"], self.repo_root, path_prepend=[str(shim_dir)])
+            self.assertEqual(create.returncode, 0, create.stderr)
+            create_run_id = extract_run_id(create.stdout)
+            self.assertFalse((ro_dir / "ocw-run-id").exists())
+
+            # stderr identical (modulo the differing worktree slug, which
+            # git's own "Preparing worktree" message echoes) to a fully-
+            # working run proves the write failure produced no raw bash
+            # diagnostic ("Permission denied" / its localized equivalent)
+            # on ocw's real stderr.
+            self.assertEqual(
+                baseline.stderr.replace("baseline-widget", "widget-maker"),
+                create.stderr,
+            )
+            self.assertEqual(
+                baseline.stdout.replace(baseline_run_id, "<RUN_ID>").replace("baseline-widget", "widget-maker"),
+                create.stdout.replace(create_run_id, "<RUN_ID>"),
+            )
+        finally:
+            os.chmod(ro_dir, 0o700)
 
 
 class MeterAbsentRegressionTests(OcwTestCase):

--- a/bin/tests/test_ocw_meter.py
+++ b/bin/tests/test_ocw_meter.py
@@ -509,16 +509,6 @@ class ConcurrencyTests(OcwMeterTestCase):
         self.assertEqual(len(keys), n)
 
 
-class NoAccidentalCouplingTests(unittest.TestCase):
-    def test_ocw_does_not_reference_ocw_meter_yet(self):
-        # Regression guard for this PR's stated scope: instrumentation of
-        # `ocw` itself is a later phase. If this starts failing, it means
-        # someone wired ocw-meter into ocw here — that integration needs
-        # its own review focused on non-regression of ocw's behavior.
-        ocw_source = (REPO_ROOT / "bin" / "ocw").read_text(encoding="utf-8")
-        self.assertNotIn("ocw-meter", ocw_source)
-
-
 class HomeUnsetTests(unittest.TestCase):
     """`set -u` under bash means expanding an unset $HOME while computing
     the default OCW_METER_HOME kills the process before python is ever

--- a/claude/README.md
+++ b/claude/README.md
@@ -82,6 +82,10 @@ Claude Code のカスタムスキル。`claude/skills/` 配下の各スキルデ
 | `pr-review-loop` | PRレビューサイクルを自動化。Herdr の reviewer エージェントと連携し、レビュー→修正→再レビューを承認まで繰り返す |
 | `umbrella-orchestrator` | 傘ブランチの孫ライフサイクル管理。計画書の読み取り、孫ブランチの spawn、マージ検出と検証、計画書更新を自動化 |
 
+`pr-review-loop` は各Phaseの境界で `ocw-meter event`（工程計測。`docs/planning/DOC-003_ai-llm-cost-observability_計画.md` 参照）を呼び出す。
+すべて `command -v ocw-meter >/dev/null && ... || true` 形式の fail-open 呼び出しで、
+レビュー規約・判定基準・停止条件には一切変更が無く、`ocw-meter` が存在しない環境でもスキルは完全に動作する。
+
 **デプロイの仕組み:**
 
 - **ディレクトリ全体 symlink は禁止。** `~/.claude/skills` をまとめて symlink すると、Herdr 管理の `herdr` スキルやユーザー独自スキルが消えるため。

--- a/claude/skills/pr-review-loop/SKILL.md
+++ b/claude/skills/pr-review-loop/SKILL.md
@@ -7,6 +7,10 @@ description: "PRレビューサイクルを自動化。Herdrワークスペー�
 
 Herdrワークスペース内の `reviewer` Claude Codeペインと連携してPRレビューサイクルを自動化する。
 
+本スキルには工程計測用の `ocw-meter` 呼び出しが含まれる。すべて fail-open であり、
+`ocw-meter` が存在しない環境でも本スキルは完全に動作する。
+計測はレビュー判定に一切影響しない。
+
 ## 前提条件
 
 Herdr内で実行されていること。確認:
@@ -116,10 +120,27 @@ fi
 
 サイクル開始時に1回だけ実行:
 
+工程計測（サイクル全体で1回だけ。レビューラウンドは `$ROUND` に保持し、以降のPhaseで使う）:
+
+```bash
+ROUND=1
+command -v ocw-meter >/dev/null && ocw-meter event phase.start --phase pr_create || true
+```
+
 1. PR番号、タイトル、URL、base/head ref、stateを取得:
 
 ```bash
 gh pr view $PR --json number,title,url,baseRefName,headRefName,state
+```
+
+PR番号が確定したら、`run_id` を後付けbindする（`OCW_RUN_ID` が環境にあれば）:
+
+```bash
+command -v ocw-meter >/dev/null && ocw-meter bind-pr --run "$OCW_RUN_ID" --pr "$PR" --url "$URL" || true
+```
+
+```bash
+command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase pr_create || true
 ```
 
 2. 現在のHEAD SHAを取得:
@@ -143,6 +164,12 @@ ls docs/ 2>/dev/null || echo "NO_DOCS_DIR"
 **実装が完了したら、レビュワーに依頼する前に、自分で自分をレビューする。**
 このステップをスキップしてレビュー依頼するな。
 
+工程計測:
+
+```bash
+command -v ocw-meter >/dev/null && ocw-meter event phase.start --phase self_review --round "$ROUND" || true
+```
+
 ### なぜ必要か
 
 レビュワーと同じ AI なのに、実装者が「作る脳」のままだとエッジケースに気づけない。
@@ -165,8 +192,10 @@ ls docs/ 2>/dev/null || echo "NO_DOCS_DIR"
 
 3. **コードを実行して確認する**（コマンドが設定されている場合のみ）:
    ```bash
+   command -v ocw-meter >/dev/null && ocw-meter event phase.start --phase lint_test --round "$ROUND" || true
    # LINT_CMD が設定されていれば実行
    # TEST_CMD が設定されていれば実行
+   command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase lint_test --round "$ROUND" || true
    ```
 
 4. **自分で見つけた問題は、レビュー前に自分で直す。**
@@ -191,7 +220,19 @@ ls docs/ 2>/dev/null || echo "NO_DOCS_DIR"
 このフェーズを通過してから Phase 2 へ進む。**通過せずにレビュー依頼した場合、
 往復の全責任は実装者にある。**
 
+工程計測:
+
+```bash
+command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase self_review --round "$ROUND" || true
+```
+
 ## Phase 2: レビュー依頼
+
+工程計測:
+
+```bash
+command -v ocw-meter >/dev/null && ocw-meter event phase.start --phase review_request --round "$ROUND" || true
+```
 
 レビュー指示をファイルに書き出し、短いコマンドでレビュワーに読ませる。**長文を pane run に詰め込むとペースト確認が入って2往復になるため絶対にやらない。**
 
@@ -336,7 +377,19 @@ herdr pane read "$REVIEWER_PANE" --source detection --lines 3
 
 依頼テキストが表示されていなければ、`herdr pane get "$REVIEWER_PANE"` で状態を確認。
 
+工程計測:
+
+```bash
+command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase review_request --round "$ROUND" || true
+```
+
 ## Phase 3: レビュワーの完了を待つ
+
+工程計測:
+
+```bash
+command -v ocw-meter >/dev/null && ocw-meter event phase.start --phase review_wait --round "$ROUND" || true
+```
 
 ### 作業開始を待つ
 
@@ -373,7 +426,19 @@ STATUS=$(herdr pane get "$REVIEWER_PANE" | python3 -c "import json,sys; d=json.l
 - `working`（継続中）→ レビューに時間がかかっている。ペイン出力を読む。
 - それ以外 → Phase 3bへ。
 
+工程計測:
+
+```bash
+command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase review_wait --round "$ROUND" || true
+```
+
 ### Phase 3b: 結果の収集
+
+工程計測:
+
+```bash
+command -v ocw-meter >/dev/null && ocw-meter event phase.start --phase review_collect --round "$ROUND" || true
+```
 
 エージェントがidleに達したらレビュー完了。全内容（レビュー本文＋インラインコメント）はGitHubに投稿済み。以下両方で確認:
 
@@ -392,6 +457,12 @@ herdr pane read "$REVIEWER_PANE" --source recent-unwrapped --lines 120
 
 画面上の出力だけをレビュー結果として扱うな。GitHub投稿だけが本物。
 
+工程計測:
+
+```bash
+command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase review_collect --round "$ROUND" || true
+```
+
 ## Phase 4: レビュー状態の判定
 
 `CONVENTION_DOCS` が設定されていればその規約を、なければ以下のデフォルト判定基準を使う。
@@ -409,6 +480,13 @@ herdr pane read "$REVIEWER_PANE" --source recent-unwrapped --lines 120
 変更要求 → Phase 5（修正）。
 
 ## Phase 5: 修正
+
+工程計測（Phase 4の判定結果を記録。`$FINDINGS_COUNT` はPhase 3bで収集した未解決指摘の件数、`$HEAD_SHA` はレビュー対象のHEAD）:
+
+```bash
+command -v ocw-meter >/dev/null && ocw-meter event review.round --round "$ROUND" --verdict changes_requested --findings-count "$FINDINGS_COUNT" --reviewed-head-sha "$HEAD_SHA" || true
+command -v ocw-meter >/dev/null && ocw-meter event phase.start --phase fix --round "$ROUND" || true
+```
 
 ### Step 0: 修正前の必須チェック（毎ラウンド実行）
 
@@ -461,7 +539,19 @@ Co-Authored-By: Claude <noreply@anthropic.com>"
 git push origin HEAD
 ```
 
+工程計測:
+
+```bash
+command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase fix --round "$ROUND" || true
+```
+
 ## Phase 6: 返信と再依頼
+
+工程計測:
+
+```bash
+command -v ocw-meter >/dev/null && ocw-meter event phase.start --phase reply --round "$ROUND" || true
+```
 
 1. 各指摘にGitHub上で `{{REPLY_MARKER}}` で返信。各返信にコミットSHAを含める。
    - **返信は十分な詳細さで書く。** どのファイルの何行目をどう修正したか、検証コマンドとその結果を記載する。
@@ -474,6 +564,13 @@ git push origin HEAD
 git rev-parse HEAD
 ```
 
+工程計測:
+
+```bash
+command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase reply --round "$ROUND" || true
+command -v ocw-meter >/dev/null && ocw-meter event phase.start --phase rereview_request --round "$ROUND" || true
+```
+
 4. **最小限の**再レビュー依頼を送信。修正内容を列挙するな。レビュワーはGitHubのコメントを読む:
 
 ```bash
@@ -481,6 +578,14 @@ herdr pane run "$REVIEWER_PANE" "PR #$PR 再レビュー依頼。全指摘に対
 ```
 
 5. 配信確認（Phase 2 Step 3と同様）。
+
+工程計測（次のラウンドへ。Phase 3に戻る前に実行する）:
+
+```bash
+command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase rereview_request --round "$ROUND" || true
+ROUND=$((ROUND + 1))
+```
+
 6. レビュワーの作業開始を待ち、Phase 3に戻る。
 
 ### アンチパターン: 冗長な再レビュープロンプト
@@ -488,6 +593,12 @@ herdr pane run "$REVIEWER_PANE" "PR #$PR 再レビュー依頼。全指摘に対
 修正内容とテスト結果を列挙した再レビュープロンプトを送るな。レビュワーはGitHubコメントを読む。長いプロンプトはトークンを浪費し本質を埋没させる。プロンプトは厳密に1行。
 
 ## Phase 7: 完了報告
+
+工程計測（Phase 4の判定結果を記録。承認は未解決指摘0件を意味する）:
+
+```bash
+command -v ocw-meter >/dev/null && ocw-meter event review.round --round "$ROUND" --verdict approved --findings-count 0 --reviewed-head-sha "$HEAD_SHA" || true
+```
 
 承認に達したら:
 
@@ -505,6 +616,12 @@ herdr pane run "$REVIEWER_PANE" "PR #$PR 再レビュー依頼。全指摘に対
 - 未解決の非ブロッキング項目
 - 承認条件をどう満たしたか
 - マージは実行していないこと
+
+工程計測:
+
+```bash
+command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase done --outcome success --round "$ROUND" || true
+```
 
 ## 安全制約
 
@@ -537,3 +654,10 @@ herdr pane run "$REVIEWER_PANE" "PR #$PR 再レビュー依頼。全指摘に対
 - GitHubへの投稿・取得が不能
 - 6サイクルを超えても承認されない
 - HERDR_ENVが設定されていない
+
+上記いずれかに該当して停止する場合、ユーザーへの報告と合わせて以下を実行する
+（`--reason` には該当条件を表す短い識別子を入れる。理由の説明文そのものは記録しない）:
+
+```bash
+command -v ocw-meter >/dev/null && ocw-meter event human.intervention --reason "<該当条件の短い識別子>" || true
+```

--- a/claude/skills/pr-review-loop/SKILL.md
+++ b/claude/skills/pr-review-loop/SKILL.md
@@ -120,30 +120,28 @@ fi
 
 サイクル開始時に1回だけ実行:
 
-工程計測（サイクル全体で1回だけ。レビューラウンドは `$ROUND` に保持し、以降のPhaseで使う）:
+**工程計測についての注記（このPhase以降で共通）**: `$ROUND` はシェル変数ではない。本スキルの各コードブロックは独立したBashツール呼び出しとして実行され、シェル変数は呼び出しをまたいで保持されない。`$ROUND` は「エージェントが追跡している現在のレビューサイクル数（1始まり。Phase 7の報告項目にある『レビューサイクル数』と同じ値、安全制約の『6サイクル』のカウントと同じ値）」を指す記法であり、`--round` を実行する際は、この時点のサイクル数をリテラルな整数値として埋めること。`$PR` / `$HEAD_SHA` / `$FINDINGS_COUNT` / `$URL` / `$OCW_RUN_ID` も同様に、直前に取得・保持した実際の値をその場でリテラルに埋め込む記法であり、新しいシェル変数を宣言する意味ではない。
+
+工程計測（サイクル1周目の開始）:
 
 ```bash
-ROUND=1
-command -v ocw-meter >/dev/null && ocw-meter event phase.start --phase pr_create || true
+command -v ocw-meter >/dev/null && ocw-meter event phase.start --phase pr_create --source pr-review-loop --round "$ROUND" || true
 ```
 
-1. PR番号、タイトル、URL、base/head ref、stateを取得:
+1. PR番号、タイトル、URL、base/head ref、stateを取得。取得した `url` を `$URL` として以降で参照する:
 
 ```bash
 gh pr view $PR --json number,title,url,baseRefName,headRefName,state
 ```
 
-PR番号が確定したら、`run_id` を後付けbindする（`OCW_RUN_ID` が環境にあれば）:
+PR番号が確定したら、`run_id` を後付けbindする（`OCW_RUN_ID` が環境にあれば。`bind-pr` は `--source` を受け付けないため、同じ情報を汎用の `event pr.bind` で発行し `--source` を明示する）:
 
 ```bash
-command -v ocw-meter >/dev/null && ocw-meter bind-pr --run "$OCW_RUN_ID" --pr "$PR" --url "$URL" || true
+command -v ocw-meter >/dev/null && ocw-meter event pr.bind --run-id "$OCW_RUN_ID" --pr-number "$PR" --pr-url "$URL" --source pr-review-loop --idempotency-key "bind:$OCW_RUN_ID:$PR" || true
+command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase pr_create --source pr-review-loop --round "$ROUND" || true
 ```
 
-```bash
-command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase pr_create || true
-```
-
-2. 現在のHEAD SHAを取得:
+2. 現在のHEAD SHAを取得。この値を `$HEAD_SHA` として、以降このサイクルでレビュー対象とするHEADの参照に使う:
 
 ```bash
 git rev-parse HEAD
@@ -167,7 +165,7 @@ ls docs/ 2>/dev/null || echo "NO_DOCS_DIR"
 工程計測:
 
 ```bash
-command -v ocw-meter >/dev/null && ocw-meter event phase.start --phase self_review --round "$ROUND" || true
+command -v ocw-meter >/dev/null && ocw-meter event phase.start --phase self_review --source pr-review-loop --round "$ROUND" || true
 ```
 
 ### なぜ必要か
@@ -192,10 +190,10 @@ command -v ocw-meter >/dev/null && ocw-meter event phase.start --phase self_revi
 
 3. **コードを実行して確認する**（コマンドが設定されている場合のみ）:
    ```bash
-   command -v ocw-meter >/dev/null && ocw-meter event phase.start --phase lint_test --round "$ROUND" || true
+   command -v ocw-meter >/dev/null && ocw-meter event phase.start --phase lint_test --source pr-review-loop --round "$ROUND" || true
    # LINT_CMD が設定されていれば実行
    # TEST_CMD が設定されていれば実行
-   command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase lint_test --round "$ROUND" || true
+   command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase lint_test --source pr-review-loop --round "$ROUND" || true
    ```
 
 4. **自分で見つけた問題は、レビュー前に自分で直す。**
@@ -223,7 +221,7 @@ command -v ocw-meter >/dev/null && ocw-meter event phase.start --phase self_revi
 工程計測:
 
 ```bash
-command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase self_review --round "$ROUND" || true
+command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase self_review --source pr-review-loop --round "$ROUND" || true
 ```
 
 ## Phase 2: レビュー依頼
@@ -231,7 +229,7 @@ command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase self_review
 工程計測:
 
 ```bash
-command -v ocw-meter >/dev/null && ocw-meter event phase.start --phase review_request --round "$ROUND" || true
+command -v ocw-meter >/dev/null && ocw-meter event phase.start --phase review_request --source pr-review-loop --round "$ROUND" || true
 ```
 
 レビュー指示をファイルに書き出し、短いコマンドでレビュワーに読ませる。**長文を pane run に詰め込むとペースト確認が入って2往復になるため絶対にやらない。**
@@ -380,7 +378,7 @@ herdr pane read "$REVIEWER_PANE" --source detection --lines 3
 工程計測:
 
 ```bash
-command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase review_request --round "$ROUND" || true
+command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase review_request --source pr-review-loop --round "$ROUND" || true
 ```
 
 ## Phase 3: レビュワーの完了を待つ
@@ -388,7 +386,7 @@ command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase review_requ
 工程計測:
 
 ```bash
-command -v ocw-meter >/dev/null && ocw-meter event phase.start --phase review_wait --round "$ROUND" || true
+command -v ocw-meter >/dev/null && ocw-meter event phase.start --phase review_wait --source pr-review-loop --round "$ROUND" || true
 ```
 
 ### 作業開始を待つ
@@ -429,7 +427,7 @@ STATUS=$(herdr pane get "$REVIEWER_PANE" | python3 -c "import json,sys; d=json.l
 工程計測:
 
 ```bash
-command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase review_wait --round "$ROUND" || true
+command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase review_wait --source pr-review-loop --round "$ROUND" || true
 ```
 
 ### Phase 3b: 結果の収集
@@ -437,7 +435,7 @@ command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase review_wait
 工程計測:
 
 ```bash
-command -v ocw-meter >/dev/null && ocw-meter event phase.start --phase review_collect --round "$ROUND" || true
+command -v ocw-meter >/dev/null && ocw-meter event phase.start --phase review_collect --source pr-review-loop --round "$ROUND" || true
 ```
 
 エージェントがidleに達したらレビュー完了。全内容（レビュー本文＋インラインコメント）はGitHubに投稿済み。以下両方で確認:
@@ -457,10 +455,12 @@ herdr pane read "$REVIEWER_PANE" --source recent-unwrapped --lines 120
 
 画面上の出力だけをレビュー結果として扱うな。GitHub投稿だけが本物。
 
+収集したインラインコメント・レビュー本文中の修正要求のうち、未解決のものの件数を数え、`$FINDINGS_COUNT` として保持する（Phase 4 末尾の工程計測で使う）。
+
 工程計測:
 
 ```bash
-command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase review_collect --round "$ROUND" || true
+command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase review_collect --source pr-review-loop --round "$ROUND" || true
 ```
 
 ## Phase 4: レビュー状態の判定
@@ -479,13 +479,20 @@ command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase review_coll
 承認 → Phase 7（報告）。
 変更要求 → Phase 5（修正）。
 
-## Phase 5: 修正
-
-工程計測（Phase 4の判定結果を記録。`$FINDINGS_COUNT` はPhase 3bで収集した未解決指摘の件数、`$HEAD_SHA` はレビュー対象のHEAD）:
+工程計測（この判定の直後、Phase 5/6/7のいずれに進む場合も1回だけ実行する。`--verdict` には確定した判定を
+`approved` / `changes_requested` / `ambiguous` のいずれかでリテラルに入れる。`$FINDINGS_COUNT` はPhase 3bで
+保持した未解決指摘の件数（承認なら0）、`$HEAD_SHA` はレビュー対象のHEAD）:
 
 ```bash
-command -v ocw-meter >/dev/null && ocw-meter event review.round --round "$ROUND" --verdict changes_requested --findings-count "$FINDINGS_COUNT" --reviewed-head-sha "$HEAD_SHA" || true
-command -v ocw-meter >/dev/null && ocw-meter event phase.start --phase fix --round "$ROUND" || true
+command -v ocw-meter >/dev/null && ocw-meter event review.round --round "$ROUND" --verdict <approved|changes_requested|ambiguous> --findings-count "$FINDINGS_COUNT" --reviewed-head-sha "$HEAD_SHA" --source pr-review-loop || true
+```
+
+## Phase 5: 修正
+
+工程計測:
+
+```bash
+command -v ocw-meter >/dev/null && ocw-meter event phase.start --phase fix --source pr-review-loop --round "$ROUND" || true
 ```
 
 ### Step 0: 修正前の必須チェック（毎ラウンド実行）
@@ -542,7 +549,7 @@ git push origin HEAD
 工程計測:
 
 ```bash
-command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase fix --round "$ROUND" || true
+command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase fix --source pr-review-loop --round "$ROUND" || true
 ```
 
 ## Phase 6: 返信と再依頼
@@ -550,7 +557,7 @@ command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase fix --round
 工程計測:
 
 ```bash
-command -v ocw-meter >/dev/null && ocw-meter event phase.start --phase reply --round "$ROUND" || true
+command -v ocw-meter >/dev/null && ocw-meter event phase.start --phase reply --source pr-review-loop --round "$ROUND" || true
 ```
 
 1. 各指摘にGitHub上で `{{REPLY_MARKER}}` で返信。各返信にコミットSHAを含める。
@@ -567,8 +574,8 @@ git rev-parse HEAD
 工程計測:
 
 ```bash
-command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase reply --round "$ROUND" || true
-command -v ocw-meter >/dev/null && ocw-meter event phase.start --phase rereview_request --round "$ROUND" || true
+command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase reply --source pr-review-loop --round "$ROUND" || true
+command -v ocw-meter >/dev/null && ocw-meter event phase.start --phase rereview_request --source pr-review-loop --round "$ROUND" || true
 ```
 
 4. **最小限の**再レビュー依頼を送信。修正内容を列挙するな。レビュワーはGitHubのコメントを読む:
@@ -579,26 +586,19 @@ herdr pane run "$REVIEWER_PANE" "PR #$PR 再レビュー依頼。全指摘に対
 
 5. 配信確認（Phase 2 Step 3と同様）。
 
-工程計測（次のラウンドへ。Phase 3に戻る前に実行する）:
+工程計測:
 
 ```bash
-command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase rereview_request --round "$ROUND" || true
-ROUND=$((ROUND + 1))
+command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase rereview_request --source pr-review-loop --round "$ROUND" || true
 ```
 
-6. レビュワーの作業開始を待ち、Phase 3に戻る。
+6. レビュワーの作業開始を待ち、Phase 3に戻る。次のサイクルに入るため、`$ROUND` が指すサイクル数を1つ進める（次にPhase 1.5以降で `--round` を発行するときは、この進めた後の値をリテラルに使う）。
 
 ### アンチパターン: 冗長な再レビュープロンプト
 
 修正内容とテスト結果を列挙した再レビュープロンプトを送るな。レビュワーはGitHubコメントを読む。長いプロンプトはトークンを浪費し本質を埋没させる。プロンプトは厳密に1行。
 
 ## Phase 7: 完了報告
-
-工程計測（Phase 4の判定結果を記録。承認は未解決指摘0件を意味する）:
-
-```bash
-command -v ocw-meter >/dev/null && ocw-meter event review.round --round "$ROUND" --verdict approved --findings-count 0 --reviewed-head-sha "$HEAD_SHA" || true
-```
 
 承認に達したら:
 
@@ -620,7 +620,7 @@ command -v ocw-meter >/dev/null && ocw-meter event review.round --round "$ROUND"
 工程計測:
 
 ```bash
-command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase done --outcome success --round "$ROUND" || true
+command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase done --outcome success --source pr-review-loop --round "$ROUND" || true
 ```
 
 ## 安全制約
@@ -659,5 +659,5 @@ command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase done --outc
 （`--reason` には該当条件を表す短い識別子を入れる。理由の説明文そのものは記録しない）:
 
 ```bash
-command -v ocw-meter >/dev/null && ocw-meter event human.intervention --reason "<該当条件の短い識別子>" || true
+command -v ocw-meter >/dev/null && ocw-meter event human.intervention --reason "<該当条件の短い識別子>" --source pr-review-loop || true
 ```

--- a/claude/skills/pr-review-loop/SKILL.md
+++ b/claude/skills/pr-review-loop/SKILL.md
@@ -128,24 +128,28 @@ fi
 command -v ocw-meter >/dev/null && ocw-meter event phase.start --phase pr_create --source pr-review-loop --round "$ROUND" || true
 ```
 
-1. PR番号、タイトル、URL、base/head ref、stateを取得。取得した `url` を `$URL` として以降で参照する:
+1. PR番号、タイトル、URL、base/head ref、stateを取得:
 
 ```bash
 gh pr view $PR --json number,title,url,baseRefName,headRefName,state
 ```
 
-PR番号が確定したら、`run_id` を後付けbindする（`OCW_RUN_ID` が環境にあれば。`bind-pr` は `--source` を受け付けないため、同じ情報を汎用の `event pr.bind` で発行し `--source` を明示する）:
+取得した `url` は `$URL` として以降で参照する。
+
+PR番号が確定したら、`run_id` を後付けbindする（`OCW_RUN_ID` が環境にある場合のみ。無ければ発行しない。`bind-pr` は `--source` を受け付けないため、同じ情報を汎用の `event pr.bind` で発行し `--source` を明示する）:
 
 ```bash
-command -v ocw-meter >/dev/null && ocw-meter event pr.bind --run-id "$OCW_RUN_ID" --pr-number "$PR" --pr-url "$URL" --source pr-review-loop --idempotency-key "bind:$OCW_RUN_ID:$PR" || true
+[ -n "${OCW_RUN_ID:-}" ] && command -v ocw-meter >/dev/null && ocw-meter event pr.bind --run-id "$OCW_RUN_ID" --pr-number "$PR" --pr-url "$URL" --source pr-review-loop --idempotency-key "bind:$OCW_RUN_ID:$PR" || true
 command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase pr_create --source pr-review-loop --round "$ROUND" || true
 ```
 
-2. 現在のHEAD SHAを取得。この値を `$HEAD_SHA` として、以降このサイクルでレビュー対象とするHEADの参照に使う:
+2. 現在のHEAD SHAを取得:
 
 ```bash
 git rev-parse HEAD
 ```
+
+この値は `$HEAD_SHA` として、以降このサイクルでレビュー対象とするHEADの参照に使う。
 
 3. 規約docを読む（`CONVENTION_DOCS` が設定されている場合のみ）:
 
@@ -479,12 +483,13 @@ command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase review_coll
 承認 → Phase 7（報告）。
 変更要求 → Phase 5（修正）。
 
-工程計測（この判定の直後、Phase 5/6/7のいずれに進む場合も1回だけ実行する。`--verdict` には確定した判定を
-`approved` / `changes_requested` / `ambiguous` のいずれかでリテラルに入れる。`$FINDINGS_COUNT` はPhase 3bで
-保持した未解決指摘の件数（承認なら0）、`$HEAD_SHA` はレビュー対象のHEAD）:
+工程計測（この判定の直後、Phase 5/6/7のいずれに進む場合も1回だけ実行する。`$VERDICT` には確定した判定を
+`approved` / `changes_requested` / `ambiguous` のいずれかでリテラルに入れる（他の `$XXX` 表記と同じ記法。
+`<...>` のような山括弧はbashの入力リダイレクト/パイプとして解釈されるため使わないこと）。`$FINDINGS_COUNT` は
+Phase 3bで保持した未解決指摘の件数（承認なら0）、`$HEAD_SHA` はレビュー対象のHEAD）:
 
 ```bash
-command -v ocw-meter >/dev/null && ocw-meter event review.round --round "$ROUND" --verdict <approved|changes_requested|ambiguous> --findings-count "$FINDINGS_COUNT" --reviewed-head-sha "$HEAD_SHA" --source pr-review-loop || true
+command -v ocw-meter >/dev/null && ocw-meter event review.round --round "$ROUND" --verdict "$VERDICT" --findings-count "$FINDINGS_COUNT" --reviewed-head-sha "$HEAD_SHA" --source pr-review-loop || true
 ```
 
 ## Phase 5: 修正
@@ -592,7 +597,9 @@ herdr pane run "$REVIEWER_PANE" "PR #$PR 再レビュー依頼。全指摘に対
 command -v ocw-meter >/dev/null && ocw-meter event phase.end --phase rereview_request --source pr-review-loop --round "$ROUND" || true
 ```
 
-6. レビュワーの作業開始を待ち、Phase 3に戻る。次のサイクルに入るため、`$ROUND` が指すサイクル数を1つ進める（次にPhase 1.5以降で `--round` を発行するときは、この進めた後の値をリテラルに使う）。
+6. レビュワーの作業開始を待ち、Phase 3に戻る。
+
+次のサイクルに入るため、`$ROUND` が指すサイクル数を1つ進める（次にPhase 1.5以降で `--round` を発行するときは、この進めた後の値をリテラルに使う）。
 
 ### アンチパターン: 冗長な再レビュープロンプト
 


### PR DESCRIPTION
## Summary
- `bin/ocw`: worktree作成のたびに `run_id` を採番し、標準出力に `run:` 行として出力。`run_id` は linked worktree の `.git/worktrees/<slug>/ocw-run-id`（`.git`はlinked worktreeでは*ファイル*なので、実際のgit管理下ディレクトリである `git rev-parse --absolute-git-dir` の指す場所に保存。worktree削除時に自動で掃除される）に保存し、`run.start` / `run.end` を `ocw-meter`（孫1で実装済み）へfail-openで記録する。Herdrモードでは `herdr workspace create --env` / `herdr pane split --env` で `OCW_ROLE` / `OCW_RUN_ID` を各ペイン(commander/implementer/reviewer)へ渡す。run_id永続化自体（`rev-parse`/書き込み。リダイレクト順序もfail-openに正しく効くよう修正済み）もfail-open。`ocw rm -f` は `run.end` の `outcome` を `failure` として記録する。
- `claude/skills/pr-review-loop/SKILL.md`: 各Phase境界に `command -v ocw-meter >/dev/null && ocw-meter event ... --source pr-review-loop ... || true` の独立イベント記録を追加。**レビュー規約テキスト（譲れないレビュー基準8項目・Phase4判定基準・安全制約・停止条件）は1文字も変更していない**（下記で証明）。`$ROUND`/`$HEAD_SHA`/`$FINDINGS_COUNT`/`$URL`/`$VERDICT` はBashツール呼び出しをまたいで保持されないシェル変数ではなく、エージェントが追跡する値をリテラルに埋め込む記法である旨をPhase 1冒頭に明記。`review.round` はPhase 4末尾の1箇所に集約し、`approved`/`changes_requested`/`ambiguous` の3値を発行できる（`--verdict "$VERDICT"` と、他の`$XXX`表記と同じクォート済みリテラル記法に統一。山括弧 `<...>` はbashの入力リダイレクト/パイプと解釈されるため使わない）。`pr.bind` は `--source` を受け付けないため `event pr.bind` に置換し、`OCW_RUN_ID` が空なら発行しないガードを維持。
- `bin/README.md` / `claude/README.md`: 計測の使い方、非Herdrモードでの制約、`run.end` が記録されないrunが存在しうる点を追記。
- `bin/tests/test_ocw.py`（新設）: run_id発行/永続化、run.start/end記録、T18（meter不在）・T19（書込失敗・stdout非回帰込み）・run_id永続化のfail-open（rev-parse失敗・書き込み失敗の両経路）・`ocw rm -f`のoutcome・既存エラーパスの非回帰をカバー。
- `bin/tests/test_ocw_meter.py`: 孫1が置いたスコープ境界ガード（`NoAccidentalCouplingTests`。「ocwがocw-meterを参照していないことを確認するテスト」）を削除。本PRはまさにそのカップリングを意図的に行うため。

## レビュー履歴
- ラウンド1（HEAD `01760dd`）: 変更要求・9件 → 全対応（HEAD `b7f247b`, `a73abf8`）
- ラウンド2（HEAD `a73abf8`）: 変更要求・4件（`--verdict`のbash構文崩壊、規約diffゼロ証明の実態不一致、`2>/dev/null`の順序、`pr.bind`ガード消失）→ 全対応（HEAD `2953356`）

## 自己レビュー
- 正当性: 計画書 `docs/planning/DOC-003_ai-llm-cost-observability_計画.md` の「孫2用プロンプト」の4項目（ocw埋め込み・pr-review-loop埋め込み・スキル冒頭注記・ドキュメント）を全て実装済み。ラウンド1・ラウンド2の全13指摘も対応済み。
- エッジケース: meter不在(T18)・書込失敗(T19)・run_id永続化自体の失敗（rev-parse失敗・書き込み失敗の両方）・空引数・重複ブランチ・未マージブランチ削除・force削除を確認。
- テスト: `python3 -m unittest discover -s bin/tests -v` → **70 tests, 0 failures**。`bin/tests/lint.sh` → OK。
- 無関係変更: なし（許可された変更対象ファイルのみ）。
- 後方互換性: `ocw-meter` が存在しない/書き込み失敗時でも `ocw` の出力（stdout）・終了コードは従来と同一であることをbaseline比較でテスト保証（`run:` 行の追加を除く）。stderrについても、`bin/ocw` 自身の書き込み失敗によるbashエラー漏れは修正済み（リダイレクト順序）。`ocw-meter` 自身の「失敗を隠さない」設計上の警告は乗りうる旨をREADMEに明記。
- 保守性: linked worktreeでの `.git` がファイルである点、`$ROUND`等がリテラル埋め込み記法である点など、非自明な理由はコメント/注記で明記。
- スタイル: `bash -n` / `py_compile` 通過済み。

## 規約テキスト無変更の証明
```
$ git diff origin/ai/llm-cost-observability -- claude/skills/pr-review-loop/SKILL.md | grep -cE '^-[^-]|^-$'
0
```
（現HEAD `2953356` で再実測。ラウンド2レビューで、ラウンド1修正時に既存3行を書き換えてしまっていた指摘を受け、既存行を完全復元し注記を別行の純追加に直したことで0に復元。）削除行はdiffヘッダの1行のみで、既存本文の削除・変更は0件（追加のみ）。「譲れないレビュー基準」8項目・Phase 4 判定基準・安全制約・停止条件のいずれも文字レベルで無変更。

## `ocw` の既存挙動の非回帰比較手順
1. `ocw-meter` をPATHから外した状態で `ocw <name>` / `ocw -H <name>` / `ocw rm <name>` / `ocw rm -f <name>` / `ocw ls` / 引数なし / 存在しない名前でのrm を実行し、標準出力・標準エラー・終了コードを記録する（`run:` 行の追加を除き変更が無いこと）。
2. `bin/tests/test_ocw.py` の `MeterAbsentRegressionTests` / `ExistingBehaviorRegressionTests` が上記を自動化している。`python3 -m unittest bin.tests.test_ocw -v` で再現可能。

## Herdr環境変数の受け渡し（手動検証）
`herdr pane split` / `herdr workspace create` の `--env KEY=VALUE` を使い、実際に稼働中のHerdrサーバーで一時workspaceを作成し `herdr pane run ... "echo $FOO"` で値がペインのシェルまで到達することを確認済み（自動テストはHerdrサーバー起動・実ペイン生成を伴うためユニットテストの対象外とし、PR説明にて代替）。

## 実PR1本での検証（本PR自身のレビューサイクルで実施）
ラウンド1・ラウンド2レビューで実際に発生した値を使い、修正後のイベント呼び出し列を `ocw-meter` へ実際に通して確認した:

```
phase.start/end (pr_create, self_review, review_request, review_wait, review_collect)
  → 全て source=pr-review-loop, round=1 で記録
pr.bind → OCW_RUN_ID未設定時は0件、設定時のみ run_id/pr_number 付きで記録（ガード動作確認）
review.round --verdict "$VERDICT" → source=pr-review-loop, round=1,
  verdict=changes_requested, findings_count=9/4（ラウンド1/2の実件数）,
  reviewed_head_sha=<各ラウンドの実HEAD）で欠損なく記録
```

修正前の `--verdict <...>` 構文でカレントディレクトリにゴミファイルが作られること・修正後は作られないことも実機で確認済み。

## Test plan
- [x] `python3 -m unittest discover -s bin/tests -v` (70 tests, 0 failures)
- [x] `bin/tests/lint.sh` (OK)
- [x] 手動: 一時gitリポジトリで `ocw <name>` → `ocw rm <name>` を実行し、`run:` 行・`ocw-run-id` ファイル・`ocw-meter` の `run.start`/`run.end` イベントを確認
- [x] 手動: Herdr実サーバーで `--env` によるペインへの環境変数到達を確認
- [x] 実PR1本（本PR）で `pr-review-loop` の工程イベント呼び出しを実際に `ocw-meter` へ通し、`source`/`round`/`findings_count`/`reviewed_head_sha` が期待どおり記録されることを確認（上記セクション参照）
- [x] `ocw` の既存挙動の非回帰比較手順を明記（上記セクション参照）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
