### PR TITLE
feat: ocw-meter ingest / report --reconcile — DeepSeek transcript取り込みと費用推定 (孫3)

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -149,24 +149,52 @@ ocw-meter event <event_type> [--key value ...]
 # PRの後付けbind（run_id → PR番号）
 ocw-meter bind-pr --run <run_id> --pr <n> [--url <url>]
 
+# ~/.claude/projects/*/*.jsonl を走査し usage.message イベントを生成（冪等・増分）
+ocw-meter ingest [--since <rfc3339-ts>]
+
 # 保存済みイベントのschema検証。壊れた行はquarantineへ隔離
 ocw-meter validate [--file <path>]
 
-# イベント件数・completeness・coverageの要約（骨格。費用集計は後続フェーズ）
+# イベント件数・completeness・coverage・推定費用の要約
 ocw-meter report [--pr <n>] [--json]
+
+# model別トークン集計・推定費用・provider管理画面との突合（coverage比率）
+ocw-meter report --reconcile [--month <YYYY-MM>] [--provider-total <model>=<tokens> ...] [--json]
 ```
 
 | サブコマンド | 失敗時の挙動 |
 |---|---|
 | `event` / `bind-pr` | **常に exit 0**。stderrに1行warnのみ。本番フローを止めない |
-| `validate` / `report` | 失敗したら非ゼロで落ちる（壊れたデータを黙って集計しない） |
+| `validate` / `report` / `ingest` | 失敗したら非ゼロで落ちる（壊れたデータを黙って集計しない） |
+
+**`ingest` の要点（`docs/planning/DOC-003_..._計画.md` 孫3プロンプト / ADR-001 §8 準拠）:**
+
+- **`message.id` で重複排除する。** 1レスポンスがcontent blockごとに複数行へ分割追記されるため
+  （実測: assistant行の59.4%がmessage.id重複、ADR-001 §2.2）、素朴に合計すると2倍以上の過大計上になる。
+  同一message.idの行が複数あれば**ドキュメント順で最後の行**（usage/stop_reasonが最も完全）を採用する
+- **冪等**。`state/ingest-cursor.json` に transcriptファイルごとの (inode, size, mtime, offset) を保持し、
+  差分だけ読む。カーソルは書き込み成功後にのみ保存されるため、途中で中断しても再実行で結果が変わらない。
+  inode変化・サイズ縮小（ローテート/切り詰め）を検出したら該当ファイルを頭から読み直す
+  （重複は message.id キーで自然に吸収される）
+- **`message.content` には一切触れない。** 抽出するのは `id`/`model`/`usage`/`stop_reason`/`timestamp`/
+  `sessionId`/`gitBranch`/`cwd`/`isSidechain`/`effort` のみ
+- 費用推定は `bin/prices/*.json` から。**Anthropicモデル（`claude-*`）は定額契約のため
+  `cost_estimate_usd: null` / `cost_basis: "subscription"`**（API単価には換算しない）。
+  価格表に無いモデルは `cost_estimate_usd: null` / `completeness: "unknown"`
+- role/PR/run_idの帰属は Herdr (`herdr pane list`) とこのmeter自身のローカルイベント
+  （`run.start`/`run.end`/`pr.bind`）・transcriptの `pr-link` 行から解決する。どれも失敗したら
+  `role: "unknown"` / `pr_number: null` / `run_id: null`。**推測で埋めない**
+- 過去に書き込んだイベントの `cost_estimate_usd` は、価格表を追加・更新しても**再計算されない**
 
 **保存先と環境変数:**
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `OCW_METER_HOME` | `~/.local/state/ocw-meter` | 保存先ルート。**git worktree内を指すと拒否される**（誤commit防止）。`event`/`bind-pr`は書き込みをスキップして exit 0（設定ミスが誰にも気づかれないままにならないよう、既定の保存先へ `meter.error` を1件/日で記録し、fallbackした旨をstderrに警告する）、`validate`/`report`は非ゼロで停止する |
+| `OCW_METER_HOME` | `~/.local/state/ocw-meter` | 保存先ルート。**git worktree内を指すと拒否される**（誤commit防止）。`event`/`bind-pr`は書き込みをスキップして exit 0（設定ミスが誰にも気づかれないままにならないよう、既定の保存先へ `meter.error` を1件/日で記録し、fallbackした旨をstderrに警告する）、`validate`/`report`/`ingest`は非ゼロで停止する |
 | `OCW_METER_RAW` | `0` | 予約済み（将来フェーズのopt-in raw保存用）。現時点のサブコマンドでは未使用 |
+| `OCW_METER_CLAUDE_PROJECTS_DIR` | `~/.claude/projects` | `ingest` がtranscriptを探すディレクトリ |
+| `OCW_METER_PRICE_DIR` | `<このファイルのあるディレクトリ>/prices` | `ingest` が価格表(`*.json`)を探すディレクトリ |
+| `OCW_METER_INGEST_USE_GH` | `0` | `1` にすると、PR番号未解決時に `gh pr list --head <branch>` へフォールバックする（既定オフ = ネットワークを一切叩かない） |
 
 保存レイアウト: `events/YYYY-MM-DD.jsonl`（基本はappend-only, mode 600。**例外**: 同一`idempotency_key`を再送すると
 後勝ち(last-write-wins)でその日のファイル内の該当行をmkstemp+os.replaceで原子的に置き換える）/
@@ -181,13 +209,22 @@ GitHub token形式（`ghp_...` 等 / `github_pat_...`）に一致する値、キ
 `api_key` / `token` / `secret` / `password` / `authorization` に一致するものは保存前に `[REDACTED]` へ置換される。
 この置換は保存物だけでなく、meterが出す例外・警告メッセージにも適用される。
 
-**このフェーズでの既知の限界**:
-- `ingest`（DeepSeek transcript取り込み）と `snapshot-quota`（Claude利用枠取得）はまだ実装されていない。
-  `report` の費用・coverage列はプレースホルダで、実データは後続フェーズで入る
+**既知の限界（カバレッジは「全部取れている」ものではない — 計画書5.10 / ADR-001 §2.2 実測）**:
+- **`deepseek-v4-flash` はtranscriptに一切記録されない（実測カバー率 0%）。** タイトル生成・要約等の
+  背景ユーティリティ呼び出しやサブエージェント（`CLAUDE_CODE_SUBAGENT_MODEL=deepseek-v4-flash`）分は
+  `~/.claude/projects/*.jsonl` に現れないため、`ingest` では原理的に取得できない
+- **`deepseek-v4-pro` のtranscriptカバー率は実測で約89%。** 残り約11%は他マシン・別期間・
+  streaming中断/retryで課金されたが記録されない分などが要因（正確な内訳は provider管理画面との
+  突合が必要 — `ocw-meter report --reconcile --provider-total <model>=<tokens>` を使うこと）
+- `snapshot-quota`（Claude利用枠取得）はまだ実装されていない（孫4スコープ）
+- PR紐付け（`pr-link`）は`ingest`実行時点で読めた範囲の情報に基づく。transcriptへの`pr-link`追記が
+  後から起きても、既に書き込み済みの`usage.message`イベントは遡って更新されない
+  （`cost_estimate_usd`と同じ「過去は再計算しない」方針）
 - `event`/`bind-pr` は1呼び出しごとに git メタ情報の解決（subprocess呼び出し数回）と
   月次seen-keysファイルの全読み込みを行う（実測 約75ms/回）。`ocw`/`pr-review-loop` の工程境界イベント
-  （1runあたり数十件）には十分だが、**大量イベントをループでこのCLI経由で書き込む用途（将来のbulk ingest等）には
-  向かない**。そのような用途は同一プロセス内でgitメタとseen-key集合を1度だけ解決するバッチ経路を別途持つこと
+  （1runあたり数十件）には十分だが、**大量イベントをループでこのCLI経由で書き込む用途には向かない**。
+  `ingest` はこの制約を踏まえ、Herdr/run/pr情報を1回だけ解決し、seen-key集合と書き込みロックを
+  バッチ全体で保持する専用パス（`bulk_write_events`）を持つ
 
 ## 4. Customization
 

--- a/bin/README.md
+++ b/bin/README.md
@@ -181,10 +181,20 @@ ocw-meter report --reconcile [--month <YYYY-MM>] [--provider-total <model>=<toke
 - 費用推定は `bin/prices/*.json` から。**Anthropicモデル（`claude-*`）は定額契約のため
   `cost_estimate_usd: null` / `cost_basis: "subscription"`**（API単価には換算しない）。
   価格表に無いモデルは `cost_estimate_usd: null` / `completeness: "unknown"`
-- role/PR/run_idの帰属は Herdr (`herdr pane list`) とこのmeter自身のローカルイベント
-  （`run.start`/`run.end`/`pr.bind`）・transcriptの `pr-link` 行から解決する。どれも失敗したら
+- role の帰属は Herdr (`herdr pane list`) から解決する。`run_id` はメッセージ自身の `cwd`（=
+  worktree）にある `<git-dir>/ocw-run-id` を直接読んで解決する（`bin/ocw` が `git worktree add` 直後に
+  書き込み、`ocw rm` が読み戻すのと同じファイル・同じ仕組み）。PR番号は ①その`run_id`に対する
+  `pr.bind`（`state/session-pr-links.json` とは別に、このmeter自身のイベントストアから解決）
+  ②`state/session-pr-links.json` に永続化されたtranscriptの `pr-link` 行（増分実行をまたいでも保持される）
+  ③`gh pr list --head` フォールバック、の順。どれも失敗したら
   `role: "unknown"` / `pr_number: null` / `run_id: null`。**推測で埋めない**
-- 過去に書き込んだイベントの `cost_estimate_usd` は、価格表を追加・更新しても**再計算されない**
+- `--since <ts>` を渡した実行は**増分カーソルを進めない**（読み取り専用）。`--since` でスキップした
+  期間を後から `--since` 無しで実行すれば取り込まれる — カーソルが先に進んで永久に欠落することはない
+- メッセージの費用は**そのメッセージ自身のtimestampの日付**に対応する価格表で計算する（`ingest`を
+  実行した日ではない）。過去に書き込んだイベントの `cost_estimate_usd` は、価格表を追加・更新しても
+  **再計算されない**
+- `report --reconcile` の月境界は**UTC固定**。DeepSeek管理画面（北京時間 UTC+8想定）等、provider側の
+  集計タイムゾーンと異なる場合、月初・月末で最大±8時間分のずれが突合結果に生じうる（計画書17章 R8）
 
 **保存先と環境変数:**
 
@@ -199,7 +209,13 @@ ocw-meter report --reconcile [--month <YYYY-MM>] [--provider-total <model>=<toke
 保存レイアウト: `events/YYYY-MM-DD.jsonl`（基本はappend-only, mode 600。**例外**: 同一`idempotency_key`を再送すると
 後勝ち(last-write-wins)でその日のファイル内の該当行をmkstemp+os.replaceで原子的に置き換える）/
 `state/seen-keys/YYYY-MM.txt`（`idempotency_key`による重複排除）/
-`quarantine/YYYY-MM-DD.jsonl`（schema不正・破損行の隔離先）/ `state/meter-errors.jsonl`（`meter.error`自己診断専用。
+`quarantine/YYYY-MM-DD.jsonl`（`validate`が隔離した破損イベントの隔離先）/
+`quarantine/ingest-transcript.jsonl`（`ingest`が隔離した破損transcript元行の隔離先。前者とは別カウントで
+`report`に出る。生コンテンツは保存しない）/
+`state/ingest-cursor.json`（`ingest`の増分読み取りカーソル）/
+`state/session-pr-links.json`（`ingest`がtranscriptの`pr-link`行から学習したsession→PRの対応。
+増分実行をまたいで保持される）/
+`state/meter-errors.jsonl`（`meter.error`自己診断専用。
 `events/`とは別ファイルにすることで、後勝ちdedupによるイベントファイル書き換えと競合せずlock無しで追記できる）。
 ディレクトリは mode 700。`ocw-meter report` はこのファイルの件数も表示する。
 

--- a/bin/ocw-meter
+++ b/bin/ocw-meter
@@ -57,6 +57,14 @@ subcommands:
     fail-open like event/bind-pr — a silently-broken ingest would make
     every downstream cost number meaningless).
 
+    --since is a READ-ONLY filter: a run using it does NOT advance the
+    persisted cursor, so nothing filtered out this way is ever lost —
+    a later run without --since re-reads and captures it. Cost is
+    priced by each message's OWN timestamp, not the date `ingest`
+    happens to run on. run_id is resolved by reading
+    <worktree's git-dir>/ocw-run-id directly (the same file bin/ocw
+    itself writes/reads), not by matching stored run.start events.
+
   validate
     Re-reads stored events. Quarantines (removes) lines that are
     corrupt — malformed JSON or a broken core envelope. Lines with a
@@ -449,8 +457,8 @@ def git_head_sha():
     return _git(["rev-parse", "HEAD"])
 
 
-def git_repo_slug():
-    url = _git(["remote", "get-url", "origin"])
+def git_repo_slug(cwd=None):
+    url = _git(["remote", "get-url", "origin"], cwd=cwd)
     if not url:
         return None
     m = re.search(r"[:/]([^/:]+)/([^/]+?)(?:\.git)?$", url)
@@ -1231,15 +1239,40 @@ def iter_stored_events(paths):
             yield obj, raw_line, ("; ".join(errors) if errors else None)
 
 
+INGEST_QUARANTINE_FILENAME = "ingest-transcript.jsonl"
+
+
 def count_quarantine_lines(paths):
+    """Counts quarantined EVENTS this meter itself wrote (`validate`'s
+    quarantine — corrupt/malformed `usage.message` etc. lines). PR #27
+    review round 1 finding 10: this used to glob every *.jsonl under
+    quarantine/, which also swept up ingest's own
+    `ingest-transcript.jsonl` (malformed SOURCE transcript lines) into
+    the same number — two categorically different things (our own
+    output being corrupt vs. someone else's input being corrupt) that
+    `report`'s single "quarantined: N lines" reads as one. See
+    `count_ingest_transcript_quarantine_lines` for the other half."""
     total = 0
     for target in sorted(paths.quarantine_dir.glob("*.jsonl")):
+        if target.name == INGEST_QUARANTINE_FILENAME:
+            continue
         try:
             with open(target, encoding="utf-8") as fh:
                 total += sum(1 for line in fh if line.strip())
         except OSError:
             continue
     return total
+
+
+def count_ingest_transcript_quarantine_lines(paths):
+    target = paths.quarantine_dir / INGEST_QUARANTINE_FILENAME
+    if not target.exists():
+        return 0
+    try:
+        with open(target, encoding="utf-8") as fh:
+            return sum(1 for line in fh if line.strip())
+    except OSError:
+        return 0
 
 
 def count_meter_errors(paths):
@@ -1305,6 +1338,22 @@ def _report_reconcile(paths, month, provider_totals, as_json):
             "cost_basis": sorted(bucket["cost_basis_seen"]) or None,
         }
 
+    # PR #27 review round 1 finding 5: a model with a --provider-total
+    # but ZERO transcript messages (the exact "0% covered" case plan
+    # §5.10 / ADR-001 §2.2 documents for deepseek-v4-flash) was silently
+    # absent from the whole report instead of showing as its own
+    # coverage_ratio: 0.0 row — the one case this --reconcile flag most
+    # needs to surface was the one case it couldn't.
+    for model, provider_total in provider_totals.items():
+        if model not in models_out:
+            models_out[model] = {
+                "messages": 0, "input_tokens": 0, "cache_read_input_tokens": 0,
+                "cache_creation_input_tokens": 0, "output_tokens": 0,
+                "transcript_total_tokens": 0, "provider_total_tokens": provider_total,
+                "coverage_ratio": 0.0 if provider_total else None,
+                "cost_estimate_usd": None, "cost_basis": None,
+            }
+
     summary = {
         "month": month,
         "cost_basis": "estimated — not an invoice",
@@ -1312,7 +1361,10 @@ def _report_reconcile(paths, month, provider_totals, as_json):
             "deepseek-v4-flash はtranscriptに一切記録されない（実測カバー率0%、計画書5.10）。"
             "deepseek-v4-pro のtranscriptカバー率は実測で約89%（ADR-001 §2.2）。"
             "coverage_ratio は --provider-total を渡したmodelにのみ算出される。claude-* は "
-            "定額契約のため cost_estimate_usd は常にnull（cost_basis: subscription）"
+            "定額契約のため cost_estimate_usd は常にnull（cost_basis: subscription）。"
+            "月の区切りはUTC固定。provider管理画面の集計タイムゾーン（例: DeepSeek管理画面は"
+            "北京時間 UTC+8）と異なる場合、月初・月末で最大±8時間分のずれが突合結果に生じうる"
+            "（計画書17章 R8）"
         ),
         "models": models_out,
     }
@@ -1399,6 +1451,17 @@ def cmd_report(args):
     if reconcile:
         if month is None:
             month = datetime.now(timezone.utc).strftime("%Y-%m")
+        elif not re.match(r"^\d{4}-\d{2}$", month):
+            # PR #27 review round 1 finding 6a: `_report_reconcile` used
+            # to filter with `ts.startswith(month)`, so a malformed value
+            # like "2026" silently aggregated the WHOLE year under a
+            # report that displays it as if it were one month, and
+            # "07-2026" silently matched zero events. `report` is the
+            # fail-loud half of this CLI (plan §10.1) — a garbage filter
+            # producing a garbage-but-plausible-looking number is exactly
+            # the failure mode that policy exists to prevent.
+            print(f"error: --month must be YYYY-MM, got: {month!r}", file=sys.stderr)
+            return 1
         return _report_reconcile(paths, month, provider_totals, as_json)
 
     valid_events, malformed = [], 0
@@ -1432,6 +1495,7 @@ def cmd_report(args):
 
     total = len(filtered)
     quarantined = count_quarantine_lines(paths)
+    transcript_quarantined = count_ingest_transcript_quarantine_lines(paths)
     meter_errors = count_meter_errors(paths)
 
     usage_events = [e for e in filtered if e.get("event_type") == "usage.message"]
@@ -1468,6 +1532,7 @@ def cmd_report(args):
         "completeness": completeness_counts,
         "malformed_unvalidated_lines": malformed,
         "quarantined_lines": quarantined,
+        "transcript_lines_quarantined": transcript_quarantined,
         "meter_error_diagnostics": meter_errors,
         "coverage": coverage,
         "price_table": price_table_summary,
@@ -1494,7 +1559,8 @@ def cmd_report(args):
             f"partial {pct(completeness_counts['partial']):.1f}% / "
             f"unknown {pct(completeness_counts['unknown']):.1f}%"
         )
-        print(f"quarantined:   {quarantined} lines")
+        print(f"quarantined:   {quarantined} lines (events this meter wrote)")
+        print(f"transcript lines quarantined (ingest source data): {transcript_quarantined} lines")
         print(f"meter.error diagnostics (state/meter-errors.jsonl): {meter_errors} lines")
         print(f"malformed (not yet quarantined; run 'ocw-meter validate'): {malformed} lines")
         print(f"coverage:      {summary['coverage']}")
@@ -1661,6 +1727,43 @@ def save_ingest_cursor(paths, cursor):
         raise
 
 
+def load_session_pr_links(paths):
+    """PR #27 review round 1 finding 2: `pr_link_map` was previously
+    built fresh from only THIS run's newly-read transcript lines, so a
+    session's `pr-link` line — read once, on whichever ingest run
+    happens to see it first — was forgotten on every subsequent
+    incremental run (the cursor has already moved past it), silently
+    dropping PR attribution for that session's later messages forever.
+    Persisting session_id -> pr_info here, alongside the cursor, fixes
+    that: once seen, a session's PR binding is never lost. Not gated by
+    --since like the cursor is (see save_ingest_cursor's caller) — a
+    pr-link discovery isn't the kind of "did we lose data" hazard the
+    --since/cursor interaction is; recording it is always safe."""
+    path = paths.state_dir / "session-pr-links.json"
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def save_session_pr_links(paths, mapping):
+    path = paths.state_dir / "session-pr-links.json"
+    ensure_dir(paths.state_dir, 0o700)
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=str(paths.state_dir), prefix=".tmp-", suffix=".json")
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
+            json.dump(mapping, fh, ensure_ascii=False, sort_keys=True)
+        os.chmod(tmp_path, 0o600)
+        os.replace(tmp_path, path)
+    except Exception:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_path)
+        raise
+
+
 def read_new_lines(file_path, prev_entry):
     """Incrementally reads the bytes appended to `file_path` since
     `prev_entry` (plan §1: "(ファイルパス, inode, size, mtime, offset)
@@ -1709,7 +1812,7 @@ def quarantine_ingest_line(paths, source_file, reason, byte_length):
     requires that `message.content` never appears in anything this tool
     persists — so only a byte length and reason are kept, not the line
     itself."""
-    qpath = paths.quarantine_dir / "ingest-transcript.jsonl"
+    qpath = paths.quarantine_dir / INGEST_QUARANTINE_FILENAME
     ensure_dir(qpath.parent, 0o700)
     record_ = {
         "quarantined_at": iso_utc(datetime.now(timezone.utc)),
@@ -1843,15 +1946,13 @@ def resolve_herdr_role_map():
 
 # ── run_id / PR attribution from this meter's own local event store ────
 
-def load_local_run_and_pr_index(paths):
-    """Single pass over every stored event, building the two lookup
-    tables `ingest` needs for plan §7.4's attribution priority:
-    run.start/run.end pairs keyed by run_id (for run_id resolution by
-    worktree + time range) and pr.bind entries keyed by run_id (for PR
-    attribution once a run_id is known). Tolerates malformed lines by
+def load_local_pr_binds(paths):
+    """Single pass over every stored event, building the pr.bind lookup
+    table `ingest` needs for plan §7.4's attribution priority (PR
+    resolution once a run_id is known). Tolerates malformed lines by
     skipping them — this is advisory context-building, not `validate`,
     so a corrupt line here just means less context, not an error."""
-    starts, ends, binds = {}, {}, {}
+    binds = {}
     for target in sorted(paths.events_dir.glob("*.jsonl")):
         try:
             text = target.read_text(encoding="utf-8", errors="replace")
@@ -1864,41 +1965,68 @@ def load_local_run_and_pr_index(paths):
                 obj = json.loads(line)
             except json.JSONDecodeError:
                 continue
-            event_type = obj.get("event_type")
-            run_id = obj.get("run_id")
-            if not run_id:
+            if obj.get("event_type") != "pr.bind":
                 continue
-            if event_type == "run.start":
-                worktree = obj.get("worktree")
-                ts = parse_ts(obj.get("ts"))
-                if worktree and ts is not None:
-                    starts[run_id] = (worktree, ts)
-            elif event_type == "run.end":
-                ts = parse_ts(obj.get("ts"))
-                if ts is not None:
-                    ends[run_id] = ts
-            elif event_type == "pr.bind":
-                pr_number = obj.get("pr_number")
-                if isinstance(pr_number, int):
-                    binds[run_id] = {"pr_number": pr_number, "pr_url": obj.get("pr_url")}
-    runs = [
-        {"run_id": run_id, "worktree": worktree, "start_ts": start_ts, "end_ts": ends.get(run_id)}
-        for run_id, (worktree, start_ts) in starts.items()
-    ]
-    return runs, binds
+            run_id = obj.get("run_id")
+            pr_number = obj.get("pr_number")
+            if run_id and isinstance(pr_number, int):
+                binds[run_id] = {"pr_number": pr_number, "pr_url": obj.get("pr_url")}
+    return binds
 
 
-def resolve_run_id(runs, worktree, at_ts):
-    if worktree is None or at_ts is None:
+def resolve_run_id_via_ocw_run_id_file(cwd, cache):
+    """Resolves run_id by reading `<worktree's git-dir>/ocw-run-id`
+    directly from the transcript message's OWN `cwd` — mirroring
+    exactly what `bin/ocw` itself does: it writes the run_id there right
+    after `git worktree add` (`worktree_git_dir="$(git -C "$worktree_dir"
+    rev-parse --absolute-git-dir)"`, then `printf ... >"${worktree_git_dir}/
+    ocw-run-id"`) and reads it back the same way in `ocw rm`.
+
+    PR #27 review round 1 finding 3: matching against locally stored
+    `run.start` events by (worktree, time range) does NOT work, because
+    `bin/ocw` never passes `--worktree` to `ocw-meter event run.start` —
+    it defaults to `git_worktree_root()` at the point `ocw` itself was
+    invoked, i.e. the ORIGIN worktree, not the newly created one that
+    transcript messages' `cwd` actually points at. That mismatch caused
+    both false negatives (real work always resolving to null) and false
+    positives (misattributing implementer/reviewer messages to whatever
+    run happened to be starting in the origin worktree at that moment).
+    Reading the git-dir file is authoritative for the EXACT worktree a
+    message came from and requires no cross-referencing at all.
+
+    Returns None once the worktree has been removed (git prunes its
+    metadata dir, including this file, on `ocw rm`/`git worktree
+    remove`) — that is correct, not a bug (plan §7.4: 不明なら null。
+    推測しない), not every historical message can still be traced back."""
+    if cwd is None:
         return None
-    candidates = [
-        r for r in runs
-        if r["worktree"] == worktree and r["start_ts"] <= at_ts and (r["end_ts"] is None or at_ts <= r["end_ts"])
-    ]
-    if not candidates:
+    if cwd in cache:
+        return cache[cwd]
+    run_id = None
+    git_dir = _git(["rev-parse", "--absolute-git-dir"], cwd=cwd)
+    if git_dir:
+        try:
+            run_id = (pathlib.Path(git_dir) / "ocw-run-id").read_text(encoding="utf-8").strip() or None
+        except OSError:
+            run_id = None
+    cache[cwd] = run_id
+    return run_id
+
+
+def repo_slug_for_cwd(cwd, cache):
+    """`repo` (plan §8.1: `owner/name`) resolved from the transcript
+    message's own `cwd`, cached per distinct cwd for the whole `ingest`
+    run — PR #27 review round 1 finding 9: this field was hardcoded to
+    null, making per-repository cost breakdowns impossible even though
+    `ocw`/`claude-ds` are routinely used across multiple repos on one
+    machine. `cwd` is already in the plan §1 field whitelist (it's read
+    for `worktree` too), so resolving `repo` from it costs one `git`
+    call per distinct worktree directory, not per message."""
+    if cwd is None:
         return None
-    candidates.sort(key=lambda r: r["start_ts"], reverse=True)
-    return candidates[0]["run_id"]
+    if cwd not in cache:
+        cache[cwd] = git_repo_slug(cwd=cwd)
+    return cache[cwd]
 
 
 def gh_pr_for_branch(branch):
@@ -1934,7 +2062,7 @@ def gh_pr_for_branch(branch):
 
 # ── assembling usage.message events ─────────────────────────────────────
 
-def build_usage_event(candidate, price_tables, at_date_str, role_map, runs, binds, pr_link_map, gh_cache):
+def build_usage_event(candidate, price_tables, today_str, role_map, binds, pr_link_map, gh_cache, run_id_cache, repo_cache):
     usage = candidate["usage"] or {}
     input_tokens = usage.get("input_tokens")
     cache_read = usage.get("cache_read_input_tokens")
@@ -1943,7 +2071,16 @@ def build_usage_event(candidate, price_tables, at_date_str, role_map, runs, bind
 
     model = normalize_model_name(candidate["model"])
     provider = infer_provider(model)
-    price_table = select_price_table(price_tables, at_date_str)
+    ts_dt = parse_ts(candidate["timestamp"])
+    # PR #27 review round 1 finding 4 (plan §17 R5): the price table must
+    # be chosen by the MESSAGE's own date, not the date `ingest` happens
+    # to run on — otherwise a price table added later (e.g. once peak/
+    # off-peak pricing starts) gets applied retroactively to messages
+    # that predate its effective_date the very first time they're ever
+    # ingested (this is NOT the "recalculate stored events" case plan
+    # §5.5 forbids; it's picking the WRONG table on first write).
+    price_date_str = ts_dt.strftime("%Y-%m-%d") if ts_dt is not None else today_str
+    price_table = select_price_table(price_tables, price_date_str)
     cost_estimate, price_version, price_effective, cost_basis = compute_cost(
         model,
         {
@@ -1959,8 +2096,7 @@ def build_usage_event(candidate, price_tables, at_date_str, role_map, runs, bind
     role_info = role_map.get(session_id) if session_id else None
 
     worktree = candidate["cwd"]
-    ts_dt = parse_ts(candidate["timestamp"])
-    run_id = resolve_run_id(runs, worktree, ts_dt)
+    run_id = resolve_run_id_via_ocw_run_id_file(worktree, run_id_cache)
 
     pr_info = binds.get(run_id) if run_id else None
     if pr_info is None:
@@ -1999,7 +2135,7 @@ def build_usage_event(candidate, price_tables, at_date_str, role_map, runs, bind
         "parser_version": INGEST_PARSER_VERSION,
         "completeness": completeness,
         "run_id": run_id,
-        "repo": None,
+        "repo": repo_slug_for_cwd(worktree, repo_cache),
         "worktree": worktree,
         "branch": candidate["git_branch"],
         "head_sha": None,
@@ -2065,6 +2201,7 @@ def bulk_write_events(paths, events):
                     seen = {line.rstrip("\n") for line in fh if line.strip()}
 
             existing_lines = []
+            trailing_newline = True
             if events_file.exists():
                 text = events_file.read_text(encoding="utf-8")
                 if text:
@@ -2108,7 +2245,32 @@ def bulk_write_events(paths, events):
                     file_changed = True
 
             if file_changed:
-                content = "\n".join(existing_lines) + ("\n" if existing_lines else "")
+                # PR #27 review round 1 finding 7: this used to append a
+                # trailing "\n" unconditionally, which silently "healed"
+                # a crash-truncated final line (round-3 review on
+                # `_replace_line_by_idempotency_key` explicitly commits
+                # to NOT doing that — `validate_file`'s only signal for
+                # "process crashed mid-write" (T05) is a missing trailing
+                # newline on the file's last line).
+                #
+                # A pure replacement touches no new content, so it must
+                # preserve the file's original terminal state exactly,
+                # same as `_replace_line_by_idempotency_key`. Appending
+                # brand-new lines is different: if the old tail was
+                # untermined, gluing new JSON directly onto it byte-for-
+                # byte (no separator) would corrupt BOTH the old garbage
+                # AND the new, otherwise-valid event — so a terminator is
+                # unavoidably inserted there. That means the "possible
+                # crash" classification for the OLD line is lost the
+                # moment anything is appended after it (it's no longer
+                # the file's last line) — an inherent tradeoff, not
+                # silent: recorded as a meter.error diagnostic below.
+                appended_new_lines = bool(new_seen_keys)
+                if appended_new_lines and not trailing_newline:
+                    with contextlib.suppress(Exception):
+                        emit_meter_error(str(paths.root), "ingest_appended_after_truncated_day_file", None)
+                newline_at_end = True if appended_new_lines else trailing_newline
+                content = "\n".join(existing_lines) + ("\n" if (existing_lines and newline_at_end) else "")
                 ensure_dir(paths.events_dir, 0o700)
                 tmp_fd, tmp_path = tempfile.mkstemp(dir=str(paths.events_dir), prefix=".tmp-", suffix=".jsonl")
                 try:
@@ -2166,7 +2328,10 @@ def cmd_ingest(args):
     new_cursor_files = dict(cursor_files)
 
     candidates = {}
-    pr_link_map = {}
+    # Starts from what earlier runs have already discovered (see
+    # load_session_pr_links) instead of empty — PR #27 review round 1
+    # finding 2.
+    pr_link_map = load_session_pr_links(paths)
     quarantined_count = 0
     files_scanned = 0
     files_with_new_data = 0
@@ -2227,25 +2392,40 @@ def cmd_ingest(args):
         }
 
     role_map = resolve_herdr_role_map()
-    runs, binds = load_local_run_and_pr_index(paths)
+    binds = load_local_pr_binds(paths)
     price_tables = load_price_tables(price_table_dir())
     today_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-    gh_cache = {}
+    gh_cache, run_id_cache, repo_cache = {}, {}, {}
 
     events = [
-        build_usage_event(candidate, price_tables, today_str, role_map, runs, binds, pr_link_map, gh_cache)
+        build_usage_event(candidate, price_tables, today_str, role_map, binds, pr_link_map, gh_cache, run_id_cache, repo_cache)
         for candidate in candidates.values()
     ]
 
     write_counts = bulk_write_events(paths, events) if events else {"written": 0, "replaced": 0}
 
-    # Cursor is only persisted AFTER the write succeeds: if this process
-    # is interrupted between reading and writing, the next run re-reads
-    # the same bytes from the same starting offset. That's safe (not
-    # wasted) because message.id-keyed writes are idempotent either way
-    # — this is what makes `ingest` produce identical results no matter
-    # how many times, or where, it is interrupted and re-run.
-    save_ingest_cursor(paths, {"files": new_cursor_files})
+    # pr-link discoveries are always persisted (see load_session_pr_links)
+    # — unlike the cursor below, this is never gated on --since, since
+    # forgetting a discovered PR binding is never desirable.
+    save_session_pr_links(paths, pr_link_map)
+
+    # Cursor is persisted AFTER the write succeeds: if this process is
+    # interrupted between reading and writing, the next run re-reads the
+    # same bytes from the same starting offset. That's safe (not wasted)
+    # because message.id-keyed writes are idempotent either way — this
+    # is what makes `ingest` produce identical results no matter how
+    # many times, or where, it is interrupted and re-run.
+    #
+    # EXCEPT when --since was used: PR #27 review round 1 finding 1 — a
+    # naive advance here would permanently mark the filtered-out (older
+    # than --since) bytes as "already read", so a LATER unrestricted
+    # `ingest` run would never see them again (the offset already moved
+    # past them). Treating a --since run as read-only with respect to
+    # the persisted cursor means it never loses data: the next run
+    # (restricted or not) simply re-reads the same unconsumed range from
+    # wherever the last UNRESTRICTED run left off.
+    if since_dt is None:
+        save_ingest_cursor(paths, {"files": new_cursor_files})
 
     print(f"transcript files scanned:            {files_scanned}")
     print(f"transcript files with new data:      {files_with_new_data}")
@@ -2253,6 +2433,8 @@ def cmd_ingest(args):
     print(f"usage.message written (new):         {write_counts['written']}")
     print(f"usage.message replaced (re-run/dup):  {write_counts['replaced']}")
     print(f"transcript lines quarantined:         {quarantined_count}")
+    if since_dt is not None:
+        print("note: --since was set; the incremental cursor was NOT advanced (read-only for this run)")
     return 0
 
 

--- a/bin/ocw-meter
+++ b/bin/ocw-meter
@@ -19,8 +19,10 @@ usage() {
 usage:
   ocw-meter event <event_type> [--key value ...]
   ocw-meter bind-pr --run <run_id> --pr <n> [--url <url>]
+  ocw-meter ingest [--since <rfc3339-ts>]
   ocw-meter validate [--file <path>]
   ocw-meter report [--pr <n>] [--json]
+  ocw-meter report --reconcile [--month <YYYY-MM>] [--provider-total <model>=<tokens> ...] [--json]
   ocw-meter help
 
 subcommands:
@@ -35,6 +37,26 @@ subcommands:
   bind-pr
     Convenience wrapper around `event pr.bind`. Always exits 0.
 
+  ingest
+    Scans ~/.claude/projects/*/*.jsonl (override with
+    OCW_METER_CLAUDE_PROJECTS_DIR) for `type: "assistant"` lines and
+    writes one `usage.message` event per distinct `message.id`
+    (dedup — a single response is re-appended per content block, so
+    the same message.id can appear many times; the LAST occurrence
+    wins). Incremental and idempotent: a per-file
+    (inode, size, mtime, offset) cursor is kept in
+    state/ingest-cursor.json, so re-running produces identical
+    results, and a rotated/truncated file is re-read from the start
+    (duplicates are absorbed by the message.id dedup key either way).
+    Cost is estimated from bin/prices/*.json (never for `claude-*`,
+    which is `cost_basis: "subscription"` — a flat-rate plan has no
+    meaningful per-message price). Only ever reads
+    id/model/usage/stop_reason/timestamp/sessionId/gitBranch/cwd/
+    isSidechain/effort — `message.content` is never touched. Exits
+    non-zero on unexpected failure (like validate/report, not
+    fail-open like event/bind-pr — a silently-broken ingest would make
+    every downstream cost number meaningless).
+
   validate
     Re-reads stored events. Quarantines (removes) lines that are
     corrupt — malformed JSON or a broken core envelope. Lines with a
@@ -44,9 +66,19 @@ subcommands:
     non-zero on unexpected failure.
 
   report
-    Prints an event-count / completeness / coverage summary. Skeleton
-    only in this phase — cost figures arrive with the DeepSeek ingest
-    and Claude quota phases. Exits non-zero on unexpected failure.
+    Prints an event-count / completeness / coverage summary, including
+    total estimated cost and which price_table_version(s)/cost_basis
+    were applied once usage.message events exist.
+
+  report --reconcile
+    Prints model別 transcript token totals (miss/hit/creation/output)
+    and estimated cost for one month (default: current month, UTC).
+    Pass `--provider-total <model>=<tokens>` (repeatable) with a value
+    read off the provider's own billing dashboard to get a coverage
+    ratio. Always prints `cost_basis: estimated — not an invoice` and a
+    `known_gaps` line (plan §5.10: deepseek-v4-flash is 0% covered,
+    deepseek-v4-pro is ~89% covered) — this output is never meant to
+    read as "the complete picture".
 
 environment:
   OCW_METER_HOME
@@ -55,17 +87,39 @@ environment:
     event/bind-pr print a stderr warning and skip the write (never
     silent), and also record a meter.error diagnostic under the
     *default* storage root's state/meter-errors.jsonl, since the
-    configured one is exactly the path being refused. validate/report
-    error out instead.
+    configured one is exactly the path being refused. validate/report/
+    ingest error out instead.
 
   OCW_METER_RAW
     default: 0
     Reserved for a later phase (opt-in raw snapshot storage). Unused
     by this subcommand set.
 
+  OCW_METER_CLAUDE_PROJECTS_DIR
+    default: $HOME/.claude/projects
+    Where `ingest` looks for `<slug>/<session-id>.jsonl` transcripts.
+
+  OCW_METER_PRICE_DIR
+    default: <this script's directory>/prices
+    Where `ingest` looks for price_table_version-tagged pricing JSON
+    files (bin/prices/*.json). The one with the latest effective_date
+    <= today is applied to new events; past events keep whatever
+    version they were written with and are never recalculated.
+
+  OCW_METER_INGEST_USE_GH
+    default: 0
+    Set to 1 to allow `ingest` to shell out to `gh pr list --head
+    <branch>` as a last-resort PR-number fallback (plan §7.4 item 3).
+    Off by default so `ingest` never touches the network unless asked.
+
 notes:
-  - `ingest` and `snapshot-quota` are not implemented in this phase.
-  - Nothing here talks to the network or reads prompt/response content.
+  - `snapshot-quota` is not implemented in this phase.
+  - `ingest` reads Herdr's `pane list`/`workspace list` (if the `herdr`
+    command exists and its server is reachable) to resolve role/
+    workspace_id/pane_id, and this meter's own locally stored events to
+    resolve run_id/pr_number — neither is the network, and both are
+    best-effort: any failure just leaves the field "unknown"/null
+    rather than raising.
   - Callers should guard every invocation with:
       command -v ocw-meter >/dev/null && ocw-meter event ... || true
     ocw-meter being entirely absent from PATH is a supported, normal
@@ -88,6 +142,10 @@ if [ -z "${OCW_METER_HOME:-}" ] && [ -n "${HOME:-}" ]; then
 fi
 export OCW_METER_HOME="${OCW_METER_HOME:-}"
 export OCW_METER_RAW="${OCW_METER_RAW:-0}"
+# Lets `ingest` find bin/prices/*.json relative to this file regardless
+# of the caller's cwd, without hardcoding a path (OCW_METER_PRICE_DIR
+# still overrides this for tests/customization).
+export OCW_METER_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 cmd="${1:-}"
 if [ -z "$cmd" ]; then
@@ -101,7 +159,7 @@ case "$cmd" in
     usage
     exit 0
     ;;
-  event | bind-pr | validate | report)
+  event | bind-pr | validate | report | ingest)
     ;;
   *)
     usage >&2
@@ -134,30 +192,32 @@ if ! command -v python3 >/dev/null 2>&1; then
 fi
 
 python3 - "$cmd" "$@" <<'PY'
-# PERFORMANCE NOTE for whoever builds the DeepSeek transcript `ingest`
-# subcommand (a later phase): this CLI resolves git metadata (repo slug,
-# worktree root, branch, HEAD SHA, plus the worktree-safety check itself
-# — 5 `git` subprocess calls per `event` invocation) and reloads
-# the *entire* monthly seen-keys file on every single invocation. Measured
-# at ~75ms/event in this repo. That is fine for the phase-boundary event
-# volumes `ocw` / `pr-review-loop` produce (tens of events per run), but a
-# real transcript has tens of thousands of messages (ADR-001 §2.2 measured
-# 39,888 distinct `message.id`s in one month) — looping this CLI once per
-# message would take on the order of an hour and re-read an
-# ever-growing seen-keys file on every iteration (effectively O(n^2)).
-# `ingest` must NOT shell out to `ocw-meter event` per message; it needs
-# its own bulk-write path that resolves git metadata once and keeps the
-# seen-key set (and the storage lock) for the whole batch.
+# PERFORMANCE NOTE (why `ingest`, below, has its own write path instead
+# of calling `record`/`write_event` once per message): this CLI resolves
+# git metadata (repo slug, worktree root, branch, HEAD SHA, plus the
+# worktree-safety check itself — 5 `git` subprocess calls per `event`
+# invocation) and reloads the *entire* monthly seen-keys file on every
+# single `event` invocation. Measured at ~75ms/event in this repo. That
+# is fine for the phase-boundary event volumes `ocw` / `pr-review-loop`
+# produce (tens of events per run), but a real transcript has tens of
+# thousands of messages (ADR-001 §2.2 measured 39,888 distinct
+# `message.id`s in one month) — looping this CLI once per message would
+# take on the order of an hour and re-read an ever-growing seen-keys
+# file on every iteration (effectively O(n^2)). `ingest` does NOT shell
+# out to `ocw-meter event` per message; see `bulk_write_events` below,
+# which resolves Herdr/run/pr context once and keeps the seen-key set
+# (and the storage lock) for the whole batch.
 #
-# On top of that: a duplicate idempotency_key now triggers last-write-
-# wins (round-2), which rewrites the *entire* day's events file via
+# On top of that: a duplicate idempotency_key triggers last-write-wins
+# (round-2), which rewrites the *entire* day's events file via
 # `_replace_line_by_idempotency_key`. ADR-001 §2.2 measured 59.4% of
 # real assistant lines as message.id duplicates — meaning a naive
 # per-message ingest loop would trigger this full-file rewrite for the
 # majority of its calls, each one O(file size). This is the single
 # biggest reason `ingest` needs its own batch path: resolve all
-# duplicates for one message.id in memory before doing a single write,
-# rather than writing-then-rewriting through this CLI's primitives.
+# duplicates for one message.id in memory before doing a single write
+# per calendar-day file, rather than writing-then-rewriting through this
+# CLI's per-event primitives.
 import contextlib
 import errno
 import fcntl
@@ -166,6 +226,7 @@ import math
 import os
 import pathlib
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -174,6 +235,10 @@ import uuid
 from datetime import datetime, timezone
 
 SCHEMA_VERSION = 1
+# Bumped whenever `ingest`'s transcript-line -> usage.message extraction
+# logic changes shape (plan §8.1 `parser_version`). Stored events keep
+# whatever version produced them; never rewritten retroactively.
+INGEST_PARSER_VERSION = 1
 
 ENVELOPE_FIELDS = (
     "schema_version", "event_id", "idempotency_key", "event_type", "ts",
@@ -1187,9 +1252,104 @@ def count_meter_errors(paths):
         return 0
 
 
+def _report_reconcile(paths, month, provider_totals, as_json):
+    """`ocw-meter report --reconcile` (孫3 §3): model別のtranscript由来
+    トークン合計・推定費用を出し、`--provider-total model=tokens` で
+    人間が渡した管理画面値との coverage 比率を計算する。plan §5.10 /
+    ADR-001 §2.2 の既知ギャップを毎回 `known_gaps` として併記する
+    （「全部取れている」と読める出力を出さない）。"""
+    totals_by_model = {}
+    for obj, _raw, error in iter_stored_events(paths):
+        if error or obj.get("event_type") != "usage.message":
+            continue
+        ts = obj.get("ts")
+        if not isinstance(ts, str) or not ts.startswith(month):
+            continue
+        model = obj.get("model") or "(unknown)"
+        bucket = totals_by_model.setdefault(model, {
+            "messages": 0, "input_tokens": 0, "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 0, "output_tokens": 0,
+            "cost_estimate_usd": 0.0, "has_cost": False, "cost_basis_seen": set(),
+        })
+        bucket["messages"] += 1
+        for field in ("input_tokens", "cache_read_input_tokens", "cache_creation_input_tokens", "output_tokens"):
+            value = obj.get(field)
+            if isinstance(value, (int, float)):
+                bucket[field] += value
+        cost = obj.get("cost_estimate_usd")
+        if isinstance(cost, (int, float)):
+            bucket["cost_estimate_usd"] += cost
+            bucket["has_cost"] = True
+        basis = obj.get("cost_basis")
+        if basis:
+            bucket["cost_basis_seen"].add(basis)
+
+    models_out = {}
+    for model, bucket in totals_by_model.items():
+        transcript_total_tokens = (
+            bucket["input_tokens"] + bucket["cache_read_input_tokens"]
+            + bucket["cache_creation_input_tokens"] + bucket["output_tokens"]
+        )
+        provider_total = provider_totals.get(model)
+        coverage_ratio = (transcript_total_tokens / provider_total) if provider_total else None
+        models_out[model] = {
+            "messages": bucket["messages"],
+            "input_tokens": bucket["input_tokens"],
+            "cache_read_input_tokens": bucket["cache_read_input_tokens"],
+            "cache_creation_input_tokens": bucket["cache_creation_input_tokens"],
+            "output_tokens": bucket["output_tokens"],
+            "transcript_total_tokens": transcript_total_tokens,
+            "provider_total_tokens": provider_total,
+            "coverage_ratio": coverage_ratio,
+            "cost_estimate_usd": bucket["cost_estimate_usd"] if bucket["has_cost"] else None,
+            "cost_basis": sorted(bucket["cost_basis_seen"]) or None,
+        }
+
+    summary = {
+        "month": month,
+        "cost_basis": "estimated — not an invoice",
+        "known_gaps": (
+            "deepseek-v4-flash はtranscriptに一切記録されない（実測カバー率0%、計画書5.10）。"
+            "deepseek-v4-pro のtranscriptカバー率は実測で約89%（ADR-001 §2.2）。"
+            "coverage_ratio は --provider-total を渡したmodelにのみ算出される。claude-* は "
+            "定額契約のため cost_estimate_usd は常にnull（cost_basis: subscription）"
+        ),
+        "models": models_out,
+    }
+
+    if as_json:
+        print(json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True))
+        return 0
+
+    print(f"month:         {summary['month']}")
+    print(f"cost_basis:    {summary['cost_basis']}")
+    if not models_out:
+        print("models:        (no usage.message events for this month — run 'ocw-meter ingest' first)")
+    for model, m in sorted(models_out.items()):
+        print(f"  {model}:")
+        print(f"    messages:             {m['messages']}")
+        print(f"    input_tokens (miss):  {m['input_tokens']}")
+        print(f"    cache_read (hit):     {m['cache_read_input_tokens']}")
+        print(f"    cache_creation:       {m['cache_creation_input_tokens']}")
+        print(f"    output_tokens:        {m['output_tokens']}")
+        cost_str = f"${m['cost_estimate_usd']:.2f}" if m["cost_estimate_usd"] is not None else "null"
+        print(f"    cost_estimate_usd:    {cost_str}")
+        if m["provider_total_tokens"] is not None:
+            print(f"    provider_total:       {m['provider_total_tokens']}")
+            print(f"    coverage:             {m['coverage_ratio'] * 100:.1f}%")
+        else:
+            print("    provider_total:       (not supplied — pass --provider-total <model>=<tokens>)")
+            print("    coverage:             unknown")
+    print(f"known_gaps:    {summary['known_gaps']}")
+    return 0
+
+
 def cmd_report(args):
     filter_pr = None
     as_json = False
+    reconcile = False
+    month = None
+    provider_totals = {}
     i = 0
     while i < len(args):
         token = args[i]
@@ -1202,6 +1362,30 @@ def cmd_report(args):
         elif token == "--json":
             as_json = True
             i += 1
+        elif token == "--reconcile":
+            reconcile = True
+            i += 1
+        elif token == "--month":
+            if i + 1 >= len(args):
+                print("error: --month requires a value (YYYY-MM)", file=sys.stderr)
+                return 1
+            month = args[i + 1]
+            i += 2
+        elif token == "--provider-total":
+            if i + 1 >= len(args):
+                print("error: --provider-total requires a value (<model>=<tokens>)", file=sys.stderr)
+                return 1
+            raw = args[i + 1]
+            model_name, sep, tokens_str = raw.partition("=")
+            if not sep:
+                print(f"error: --provider-total must be <model>=<tokens>, got: {raw!r}", file=sys.stderr)
+                return 1
+            try:
+                provider_totals[model_name] = int(tokens_str)
+            except ValueError:
+                print(f"error: --provider-total tokens must be an integer, got: {raw!r}", file=sys.stderr)
+                return 1
+            i += 2
         else:
             print(f"error: unknown report flag: {token}", file=sys.stderr)
             return 1
@@ -1211,6 +1395,11 @@ def cmd_report(args):
         print(f"error: OCW_METER_HOME ({root}) resolves inside a Git worktree; refusing to operate", file=sys.stderr)
         return 1
     paths = ensure_storage(root)
+
+    if reconcile:
+        if month is None:
+            month = datetime.now(timezone.utc).strftime("%Y-%m")
+        return _report_reconcile(paths, month, provider_totals, as_json)
 
     valid_events, malformed = [], 0
     for obj, _raw, error in iter_stored_events(paths):
@@ -1245,6 +1434,32 @@ def cmd_report(args):
     quarantined = count_quarantine_lines(paths)
     meter_errors = count_meter_errors(paths)
 
+    usage_events = [e for e in filtered if e.get("event_type") == "usage.message"]
+    if usage_events:
+        cost_sum, has_cost = 0.0, False
+        price_versions, cost_bases = set(), set()
+        for e in usage_events:
+            cost = e.get("cost_estimate_usd")
+            if isinstance(cost, (int, float)):
+                cost_sum += cost
+                has_cost = True
+            if e.get("price_table_version"):
+                price_versions.add(e["price_table_version"])
+            if e.get("cost_basis"):
+                cost_bases.add(e["cost_basis"])
+        coverage = (
+            f"{len(usage_events)} usage.message event(s); run "
+            "'ocw-meter report --reconcile' for model別 coverage against provider totals"
+        )
+        price_table_summary = ", ".join(sorted(price_versions)) if price_versions else "(none applied)"
+        cost_basis_summary = ", ".join(sorted(cost_bases)) if cost_bases else "(none)"
+        cost_estimate_summary = f"${cost_sum:.2f} (estimated — not an invoice)" if has_cost else "null"
+    else:
+        coverage = "no usage.message events yet — run 'ocw-meter ingest'"
+        price_table_summary = "not applicable (no cost data ingested yet)"
+        cost_basis_summary = "not applicable (no cost data ingested yet)"
+        cost_estimate_summary = "null"
+
     summary = {
         "storage_root": str(paths.root),
         "filter_pr": filter_pr,
@@ -1254,9 +1469,10 @@ def cmd_report(args):
         "malformed_unvalidated_lines": malformed,
         "quarantined_lines": quarantined,
         "meter_error_diagnostics": meter_errors,
-        "coverage": "not available yet (usage.message events are produced by a later ingest phase)",
-        "price_table": "not applicable (no cost data ingested yet)",
-        "cost_basis": "not applicable (no cost data ingested yet)",
+        "coverage": coverage,
+        "price_table": price_table_summary,
+        "cost_basis": cost_basis_summary,
+        "cost_estimate_usd": cost_estimate_summary,
     }
 
     if as_json:
@@ -1284,7 +1500,759 @@ def cmd_report(args):
         print(f"coverage:      {summary['coverage']}")
         print(f"price_table:   {summary['price_table']}")
         print(f"cost_basis:    {summary['cost_basis']}")
+        print(f"cost_estimate: {summary['cost_estimate_usd']}")
 
+    return 0
+
+
+# ── ingest: DeepSeek/Claude transcript -> usage.message (孫3) ──────────
+#
+# `ingest` is deliberately NOT built on top of `record`/`write_event`
+# (see the PERFORMANCE NOTE at the top of this file): it resolves git-
+# equivalent context (Herdr role map, local run/pr index, price tables)
+# ONCE per invocation, then writes every usage.message event for the
+# whole batch through `bulk_write_events`, which does at most one
+# read+rewrite per calendar-day events file instead of one per
+# duplicate message.id (ADR-001 §2.2 measured 59.4% of real assistant
+# lines as message.id duplicates).
+
+def claude_projects_dir():
+    env = os.environ.get("OCW_METER_CLAUDE_PROJECTS_DIR")
+    if env:
+        return pathlib.Path(env)
+    home = os.environ.get("HOME")
+    return pathlib.Path(home) / ".claude" / "projects" if home else None
+
+
+def price_table_dir():
+    env = os.environ.get("OCW_METER_PRICE_DIR")
+    if env:
+        return pathlib.Path(env)
+    script_dir = os.environ.get("OCW_METER_SCRIPT_DIR")
+    return pathlib.Path(script_dir) / "prices" if script_dir else None
+
+
+def normalize_model_name(model):
+    """`deepseek-v4-pro[1m]` -> `deepseek-v4-pro` (plan §8.4). Transcripts
+    already store the name without the context-window suffix as of the
+    plan's own probes, but this strips it defensively in case that ever
+    changes upstream."""
+    if not isinstance(model, str) or not model:
+        return model
+    return re.sub(r"\[[^\]]*\]$", "", model)
+
+
+def infer_provider(model):
+    if not isinstance(model, str) or not model:
+        return None
+    if model.startswith("claude-"):
+        return "anthropic"
+    if model.startswith("deepseek-"):
+        return "deepseek"
+    return "unknown"
+
+
+# ── price tables ────────────────────────────────────────────────────
+
+def load_price_tables(price_dir):
+    """Loads every *.json under price_dir, sorted by effective_date
+    ascending. A malformed individual price file is skipped, not fatal
+    (plan §5.5: versioned data files, not code — a bad one shouldn't
+    take down `ingest`)."""
+    tables = []
+    if price_dir is None or not price_dir.is_dir():
+        return tables
+    for path in sorted(price_dir.glob("*.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        if not all(k in data for k in ("price_table_version", "effective_date", "models")):
+            continue
+        tables.append(data)
+    tables.sort(key=lambda t: t.get("effective_date") or "")
+    return tables
+
+
+def select_price_table(tables, at_date_str):
+    """Picks the table with the latest effective_date <= at_date_str
+    (plan §5.5). Falls back to the earliest available table if every
+    table's effective_date is in the future relative to at_date_str —
+    a conservative choice, never a crash, and this situation shouldn't
+    arise in practice since price files are only added once effective."""
+    applicable = [t for t in tables if (t.get("effective_date") or "") <= at_date_str]
+    if applicable:
+        return applicable[-1]
+    return tables[0] if tables else None
+
+
+def compute_cost(model, usage_fields, price_table):
+    """plan §8.4 cost formula, with the 孫3-prompt override that
+    Anthropic (`claude-*`) usage is never converted from a subscription
+    into a per-token estimate (cost_basis: "subscription",
+    cost_estimate_usd: null — a flat-rate plan has no meaningful
+    per-message price). Returns (cost_estimate_usd, price_table_version,
+    price_effective_date, cost_basis). Never raises."""
+    provider = infer_provider(model)
+    if provider == "anthropic":
+        return None, None, None, "subscription"
+
+    if price_table is None:
+        return None, None, None, "estimated"
+
+    prices = price_table.get("models", {}).get(model)
+    if not isinstance(prices, dict):
+        # Includes deepseek-v4-flash (plan §5.10: 0% transcript coverage,
+        # so this branch is mostly theoretical today) and any future/
+        # unrecognized model name — never guess a price.
+        return None, price_table.get("price_table_version"), price_table.get("effective_date"), "estimated"
+
+    values = (
+        usage_fields.get("cache_read_input_tokens"),
+        usage_fields.get("input_tokens"),
+        usage_fields.get("cache_creation_input_tokens"),
+        usage_fields.get("output_tokens"),
+    )
+    if any(not isinstance(v, (int, float)) for v in values):
+        return None, price_table.get("price_table_version"), price_table.get("effective_date"), "estimated"
+
+    cache_read, input_tokens, cache_creation, output_tokens = values
+    try:
+        cost = (
+            cache_read * prices["cache_hit_in"]
+            + (input_tokens + cache_creation) * prices["cache_miss_in"]
+            + output_tokens * prices["out"]
+        ) / 1_000_000
+    except (KeyError, TypeError):
+        return None, price_table.get("price_table_version"), price_table.get("effective_date"), "estimated"
+
+    return cost, price_table.get("price_table_version"), price_table.get("effective_date"), "estimated"
+
+
+# ── ingest cursor (incremental, idempotent transcript reading) ────────
+
+def load_ingest_cursor(paths):
+    path = paths.state_dir / "ingest-cursor.json"
+    if not path.exists():
+        return {"files": {}}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {"files": {}}
+    if not isinstance(data, dict) or not isinstance(data.get("files"), dict):
+        return {"files": {}}
+    return data
+
+
+def save_ingest_cursor(paths, cursor):
+    path = paths.state_dir / "ingest-cursor.json"
+    ensure_dir(paths.state_dir, 0o700)
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=str(paths.state_dir), prefix=".tmp-", suffix=".json")
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
+            json.dump(cursor, fh, ensure_ascii=False, sort_keys=True)
+        os.chmod(tmp_path, 0o600)
+        os.replace(tmp_path, path)
+    except Exception:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_path)
+        raise
+
+
+def read_new_lines(file_path, prev_entry):
+    """Incrementally reads the bytes appended to `file_path` since
+    `prev_entry` (plan §1: "(ファイルパス, inode, size, mtime, offset)
+    を保存し増分読み取り"). Re-reads from byte 0 when the inode changed
+    or the file shrank (rotation/truncation) — duplicates this produces
+    are absorbed downstream by message.id dedup, per plan §1.
+
+    Only bytes up to the last b"\\n" are returned as complete lines; any
+    trailing partial line (no newline yet — the writer may still be
+    mid-write) is left unconsumed so the offset does NOT advance past
+    it, and it gets picked up whole on a later run. Returns None if the
+    file vanished between glob and stat (best-effort, not fatal)."""
+    try:
+        st = os.stat(file_path)
+    except OSError:
+        return None
+    stat_info = {"inode": st.st_ino, "size": st.st_size, "mtime": st.st_mtime}
+
+    if prev_entry is None:
+        start_offset = 0
+    elif prev_entry.get("inode") != stat_info["inode"] or st.st_size < prev_entry.get("size", 0):
+        start_offset = 0
+    else:
+        start_offset = min(prev_entry.get("offset", 0), st.st_size)
+
+    try:
+        with open(file_path, "rb") as fh:
+            fh.seek(start_offset)
+            chunk = fh.read()
+    except OSError:
+        return None
+
+    last_nl = chunk.rfind(b"\n")
+    complete = chunk[: last_nl + 1] if last_nl != -1 else b""
+    new_offset = start_offset + len(complete)
+    lines = [line for line in complete.split(b"\n") if line.strip()]
+    return {"lines": lines, "new_offset": new_offset, "stat": stat_info}
+
+
+def quarantine_ingest_line(paths, source_file, reason, byte_length):
+    """Quarantines a broken/unparsable SOURCE transcript line. Unlike
+    `validate`'s quarantine (which stores our own already-content-free
+    events verbatim), this deliberately never stores the raw bytes: a
+    line that failed to parse as JSON might contain a garbled fragment
+    of prompt/response content from a partial write, and plan §1
+    requires that `message.content` never appears in anything this tool
+    persists — so only a byte length and reason are kept, not the line
+    itself."""
+    qpath = paths.quarantine_dir / "ingest-transcript.jsonl"
+    ensure_dir(qpath.parent, 0o700)
+    record_ = {
+        "quarantined_at": iso_utc(datetime.now(timezone.utc)),
+        "source_file": str(source_file),
+        "reason": reason,
+        "line_byte_length": byte_length,
+    }
+    with open(qpath, "a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record_, ensure_ascii=False) + "\n")
+    with contextlib.suppress(OSError):
+        os.chmod(qpath, 0o600)
+
+
+# ── transcript line extraction ─────────────────────────────────────────
+
+def extract_assistant_candidate(obj):
+    """Pulls out ONLY the fields plan §1 whitelists from a `type:
+    "assistant"` transcript line: id/model/usage/stop_reason (under
+    `message`) plus timestamp/sessionId/gitBranch/cwd/isSidechain/effort
+    at the top level. `message.content` is never read here or anywhere
+    else in `ingest`. Returns None if there's no `message.id` — without
+    one there is no idempotency key, and plan §5.3 requires message.id-
+    based dedup above everything else, so an id-less assistant line
+    cannot be safely recorded at all (it goes to quarantine instead)."""
+    if not isinstance(obj, dict) or obj.get("type") != "assistant":
+        return None
+    message = obj.get("message")
+    if not isinstance(message, dict):
+        return None
+    message_id = message.get("id")
+    if not message_id:
+        return None
+    usage = message.get("usage") if isinstance(message.get("usage"), dict) else {}
+    return {
+        "message_id": message_id,
+        "model": message.get("model"),
+        "usage": usage,
+        "stop_reason": message.get("stop_reason"),
+        "timestamp": obj.get("timestamp"),
+        "session_id": obj.get("sessionId"),
+        "git_branch": obj.get("gitBranch"),
+        "cwd": obj.get("cwd"),
+        "is_sidechain": obj.get("isSidechain"),
+        "effort": obj.get("effort"),
+    }
+
+
+def extract_pr_link(obj):
+    if not isinstance(obj, dict) or obj.get("type") != "pr-link":
+        return None
+    session_id = obj.get("sessionId")
+    pr_number = obj.get("prNumber")
+    if not session_id or not isinstance(pr_number, int):
+        return None
+    return session_id, {"pr_number": pr_number, "pr_url": obj.get("prUrl")}
+
+
+# ── role attribution via Herdr (plan §7.4 item 2 / §5.7) ───────────────
+
+def _herdr(args, timeout=5):
+    try:
+        result = subprocess.run(["herdr", *args], capture_output=True, text=True, timeout=timeout)
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def _collect_dicts_with_key(value, key_name, out):
+    if isinstance(value, dict):
+        if key_name in value:
+            out.append(value)
+        for child in value.values():
+            _collect_dicts_with_key(child, key_name, out)
+    elif isinstance(value, list):
+        for item in value:
+            _collect_dicts_with_key(item, key_name, out)
+
+
+def resolve_herdr_role_map():
+    """Best-effort session_id -> {role, workspace_id, pane_id} map.
+    Returns {} (never raises) if Herdr isn't installed, its server isn't
+    running, or any call/parse fails — role stays "unknown" downstream
+    rather than being guessed (plan §7.4: "不明なら role: unknown。捏造
+    しない"). `herdr pane list`'s exact JSON nesting isn't guaranteed by
+    this codebase's own contract with it (see `bin/ocw`'s
+    `json_workspace_ids`/`json_has_pane_cwd`, which use the same
+    recurse-and-collect approach for the same reason), so this walks the
+    structure looking for dicts carrying the keys it needs instead of
+    assuming a fixed shape."""
+    role_map = {}
+    if shutil.which("herdr") is None:
+        return role_map
+    if _herdr(["status", "server"]) is None:
+        return role_map
+
+    workspace_out = _herdr(["workspace", "list"])
+    if workspace_out is None:
+        return role_map
+    try:
+        workspace_data = json.loads(workspace_out)
+    except json.JSONDecodeError:
+        return role_map
+    workspace_dicts = []
+    _collect_dicts_with_key(workspace_data, "workspace_id", workspace_dicts)
+    workspace_ids = sorted({d.get("workspace_id") for d in workspace_dicts if d.get("workspace_id")})
+
+    for workspace_id in workspace_ids:
+        pane_out = _herdr(["pane", "list", "--workspace", str(workspace_id)])
+        if pane_out is None:
+            continue
+        try:
+            pane_data = json.loads(pane_out)
+        except json.JSONDecodeError:
+            continue
+        pane_dicts = []
+        _collect_dicts_with_key(pane_data, "agent_session", pane_dicts)
+        for pane in pane_dicts:
+            session = pane.get("agent_session")
+            session_id = session.get("value") if isinstance(session, dict) else None
+            label = pane.get("label")
+            if session_id and label:
+                role_map[session_id] = {
+                    "role": label,
+                    "workspace_id": pane.get("workspace_id") or workspace_id,
+                    "pane_id": pane.get("pane_id"),
+                }
+    return role_map
+
+
+# ── run_id / PR attribution from this meter's own local event store ────
+
+def load_local_run_and_pr_index(paths):
+    """Single pass over every stored event, building the two lookup
+    tables `ingest` needs for plan §7.4's attribution priority:
+    run.start/run.end pairs keyed by run_id (for run_id resolution by
+    worktree + time range) and pr.bind entries keyed by run_id (for PR
+    attribution once a run_id is known). Tolerates malformed lines by
+    skipping them — this is advisory context-building, not `validate`,
+    so a corrupt line here just means less context, not an error."""
+    starts, ends, binds = {}, {}, {}
+    for target in sorted(paths.events_dir.glob("*.jsonl")):
+        try:
+            text = target.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for line in text.split("\n"):
+            if not line.strip():
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            event_type = obj.get("event_type")
+            run_id = obj.get("run_id")
+            if not run_id:
+                continue
+            if event_type == "run.start":
+                worktree = obj.get("worktree")
+                ts = parse_ts(obj.get("ts"))
+                if worktree and ts is not None:
+                    starts[run_id] = (worktree, ts)
+            elif event_type == "run.end":
+                ts = parse_ts(obj.get("ts"))
+                if ts is not None:
+                    ends[run_id] = ts
+            elif event_type == "pr.bind":
+                pr_number = obj.get("pr_number")
+                if isinstance(pr_number, int):
+                    binds[run_id] = {"pr_number": pr_number, "pr_url": obj.get("pr_url")}
+    runs = [
+        {"run_id": run_id, "worktree": worktree, "start_ts": start_ts, "end_ts": ends.get(run_id)}
+        for run_id, (worktree, start_ts) in starts.items()
+    ]
+    return runs, binds
+
+
+def resolve_run_id(runs, worktree, at_ts):
+    if worktree is None or at_ts is None:
+        return None
+    candidates = [
+        r for r in runs
+        if r["worktree"] == worktree and r["start_ts"] <= at_ts and (r["end_ts"] is None or at_ts <= r["end_ts"])
+    ]
+    if not candidates:
+        return None
+    candidates.sort(key=lambda r: r["start_ts"], reverse=True)
+    return candidates[0]["run_id"]
+
+
+def gh_pr_for_branch(branch):
+    """Fallback PR resolution (plan §7.4 item 3: gitBranch -> `gh pr
+    list --head`). Off by default and never invoked by tests (T:
+    "外部APIを叩かないこと") — opt in with OCW_METER_INGEST_USE_GH=1.
+    Failure of any kind (no `gh`, not authenticated, no PR found,
+    network error) is silent and just leaves pr_number null; `ingest`
+    must keep working with zero network access available."""
+    if os.environ.get("OCW_METER_INGEST_USE_GH", "0") not in ("1", "true", "yes"):
+        return None
+    if not branch or shutil.which("gh") is None:
+        return None
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "list", "--head", branch, "--json", "number,url", "--limit", "1"],
+            capture_output=True, text=True, timeout=10,
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    if isinstance(data, list) and data:
+        number = data[0].get("number")
+        if isinstance(number, int):
+            return {"pr_number": number, "pr_url": data[0].get("url")}
+    return None
+
+
+# ── assembling usage.message events ─────────────────────────────────────
+
+def build_usage_event(candidate, price_tables, at_date_str, role_map, runs, binds, pr_link_map, gh_cache):
+    usage = candidate["usage"] or {}
+    input_tokens = usage.get("input_tokens")
+    cache_read = usage.get("cache_read_input_tokens")
+    cache_creation = usage.get("cache_creation_input_tokens")
+    output_tokens = usage.get("output_tokens")
+
+    model = normalize_model_name(candidate["model"])
+    provider = infer_provider(model)
+    price_table = select_price_table(price_tables, at_date_str)
+    cost_estimate, price_version, price_effective, cost_basis = compute_cost(
+        model,
+        {
+            "input_tokens": input_tokens,
+            "cache_read_input_tokens": cache_read,
+            "cache_creation_input_tokens": cache_creation,
+            "output_tokens": output_tokens,
+        },
+        price_table,
+    )
+
+    session_id = candidate["session_id"]
+    role_info = role_map.get(session_id) if session_id else None
+
+    worktree = candidate["cwd"]
+    ts_dt = parse_ts(candidate["timestamp"])
+    run_id = resolve_run_id(runs, worktree, ts_dt)
+
+    pr_info = binds.get(run_id) if run_id else None
+    if pr_info is None:
+        pr_info = pr_link_map.get(session_id) if session_id else None
+    if pr_info is None:
+        branch = candidate["git_branch"]
+        if branch not in gh_cache:
+            gh_cache[branch] = gh_pr_for_branch(branch)
+        pr_info = gh_cache[branch]
+
+    numeric_present = all(isinstance(v, (int, float)) for v in (input_tokens, cache_read, cache_creation, output_tokens))
+    if not usage:
+        completeness = "unknown"
+    elif numeric_present:
+        completeness = "complete"
+    else:
+        completeness = "partial"
+    # 孫3プロンプト §2: "価格表に無いモデルは cost_estimate_usd: null /
+    # completeness: unknown" — a model this meter can't price (missing
+    # price file entry, e.g. deepseek-v4-flash today per plan §5.10) is
+    # its own kind of incompleteness, distinct from missing usage
+    # fields. Deliberately does NOT apply to cost_basis == "subscription"
+    # (Anthropic models): there cost_estimate_usd is null ON PURPOSE,
+    # not because pricing is unknown.
+    if cost_basis == "estimated" and cost_estimate is None and completeness == "complete":
+        completeness = "unknown"
+
+    event = {
+        "schema_version": SCHEMA_VERSION,
+        "event_id": str(uuid.uuid4()),
+        "idempotency_key": f"msg:{candidate['message_id']}",
+        "event_type": "usage.message",
+        "ts": candidate["timestamp"] or iso_utc(datetime.now(timezone.utc)),
+        "ts_local_offset": local_offset_str(),
+        "source": "transcript",
+        "parser_version": INGEST_PARSER_VERSION,
+        "completeness": completeness,
+        "run_id": run_id,
+        "repo": None,
+        "worktree": worktree,
+        "branch": candidate["git_branch"],
+        "head_sha": None,
+        "workspace_id": (role_info or {}).get("workspace_id"),
+        "pane_id": (role_info or {}).get("pane_id"),
+        "role": (role_info or {}).get("role") or "unknown",
+        "session_id": session_id,
+        "provider": provider,
+        "model": model,
+        "phase": None,
+        "round": None,
+        "pr_number": (pr_info or {}).get("pr_number"),
+        "pr_url": (pr_info or {}).get("pr_url"),
+        "message_id": candidate["message_id"],
+        "input_tokens": input_tokens if isinstance(input_tokens, (int, float)) else None,
+        "cache_read_input_tokens": cache_read if isinstance(cache_read, (int, float)) else None,
+        "cache_creation_input_tokens": cache_creation if isinstance(cache_creation, (int, float)) else None,
+        "output_tokens": output_tokens if isinstance(output_tokens, (int, float)) else None,
+        "reasoning_tokens": None,  # U5 / P2 未確定（孫0 P2待ち）— 推測しない
+        "is_sidechain": candidate["is_sidechain"] if isinstance(candidate["is_sidechain"], bool) else None,
+        "effort": candidate["effort"],
+        "stop_reason": candidate["stop_reason"],
+        "cost_estimate_usd": cost_estimate,
+        "price_table_version": price_version,
+        "price_effective_date": price_effective,
+        "cost_basis": cost_basis,
+        "currency": "USD" if cost_basis != "subscription" else None,
+    }
+    for key in list(event.keys()):
+        event[key] = redact_value(key, event[key])
+    return event
+
+
+# ── bulk write path (see PERFORMANCE NOTE at top of file) ──────────────
+
+def bulk_write_events(paths, events):
+    """Writes many usage.message events efficiently: at most one read +
+    atomic rewrite per calendar-day events file for this whole batch,
+    instead of routing each event through `write_event` (which would
+    trigger `_replace_line_by_idempotency_key`'s full-file rewrite once
+    per duplicate — ADR-001 §2.2 measured 59.4% of real assistant lines
+    as duplicates). Holds the storage lock for the whole batch, matching
+    plan §10.3's concurrent-writer requirement. Returns {"written": n,
+    "replaced": n}."""
+    by_day = {}
+    for event in events:
+        dt = parse_ts(event["ts"]) or datetime.now(timezone.utc)
+        by_day.setdefault(dt.strftime("%Y-%m-%d"), []).append(event)
+
+    counts = {"written": 0, "replaced": 0}
+    with acquire_lock(paths.lock_file, timeout=30.0) as acquired:
+        if not acquired:
+            raise MeterTimeout("could not acquire storage lock within 30s")
+
+        for day, day_events in by_day.items():
+            events_file = paths.events_dir / f"{day}.jsonl"
+            month = day[:7]
+            seen_file = paths.seen_keys_dir / f"{month}.txt"
+
+            seen = set()
+            if seen_file.exists():
+                with open(seen_file, "r", encoding="utf-8") as fh:
+                    seen = {line.rstrip("\n") for line in fh if line.strip()}
+
+            existing_lines = []
+            if events_file.exists():
+                text = events_file.read_text(encoding="utf-8")
+                if text:
+                    trailing_newline = text.endswith("\n")
+                    existing_lines = text.split("\n")
+                    if trailing_newline:
+                        existing_lines = existing_lines[:-1]
+
+            existing_by_key = {}
+            for idx, line in enumerate(existing_lines):
+                if not line.strip():
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                key = obj.get("idempotency_key")
+                if key:
+                    existing_by_key[key] = idx
+
+            new_seen_keys = []
+            file_changed = False
+            for event in day_events:
+                key = event["idempotency_key"]
+                new_line = json.dumps(event, ensure_ascii=False, sort_keys=True, allow_nan=False)
+                if key in existing_by_key:
+                    existing_lines[existing_by_key[key]] = new_line
+                    counts["replaced"] += 1
+                    file_changed = True
+                elif key in seen:
+                    # Stored under this key in a DIFFERENT day's file —
+                    # mirrors write_event's own "duplicate" fallback
+                    # (see its docstring) rather than assuming this
+                    # cannot happen for a ts-derived day bucket.
+                    counts["replaced"] += 1
+                else:
+                    existing_lines.append(new_line)
+                    new_seen_keys.append(key)
+                    seen.add(key)
+                    counts["written"] += 1
+                    file_changed = True
+
+            if file_changed:
+                content = "\n".join(existing_lines) + ("\n" if existing_lines else "")
+                ensure_dir(paths.events_dir, 0o700)
+                tmp_fd, tmp_path = tempfile.mkstemp(dir=str(paths.events_dir), prefix=".tmp-", suffix=".jsonl")
+                try:
+                    with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
+                        fh.write(content)
+                    os.chmod(tmp_path, 0o600)
+                    os.replace(tmp_path, events_file)
+                except Exception:
+                    with contextlib.suppress(OSError):
+                        os.unlink(tmp_path)
+                    raise
+
+            if new_seen_keys:
+                ensure_dir(paths.seen_keys_dir, 0o700)
+                with open(seen_file, "a", encoding="utf-8") as fh:
+                    for key in new_seen_keys:
+                        fh.write(key + "\n")
+                with contextlib.suppress(OSError):
+                    os.chmod(seen_file, 0o600)
+
+    return counts
+
+
+# ── subcommand: ingest ──────────────────────────────────────────────────
+
+def cmd_ingest(args):
+    parsed = parse_flags(args, {"--since": "since"}) if args else {}
+    since_str = parsed.get("since")
+    since_dt = None
+    if since_str:
+        since_dt = parse_ts(since_str)
+        if since_dt is None:
+            print(f"error: --since is not a valid RFC3339 timestamp: {since_str!r}", file=sys.stderr)
+            return 1
+
+    root = storage_root()
+    if in_git_worktree(root):
+        print(f"error: OCW_METER_HOME ({root}) resolves inside a Git worktree; refusing to operate", file=sys.stderr)
+        return 1
+    paths = ensure_storage(root)
+
+    projects_dir = claude_projects_dir()
+    if projects_dir is None:
+        print(
+            "error: could not determine the Claude projects directory "
+            "(HOME is not set; set OCW_METER_CLAUDE_PROJECTS_DIR explicitly)",
+            file=sys.stderr,
+        )
+        return 1
+
+    transcript_files = sorted(projects_dir.glob("*/*.jsonl")) if projects_dir.is_dir() else []
+
+    cursor = load_ingest_cursor(paths)
+    cursor_files = cursor["files"]
+    new_cursor_files = dict(cursor_files)
+
+    candidates = {}
+    pr_link_map = {}
+    quarantined_count = 0
+    files_scanned = 0
+    files_with_new_data = 0
+
+    for file_path in transcript_files:
+        files_scanned += 1
+        key = str(file_path)
+        result = read_new_lines(file_path, cursor_files.get(key))
+        if result is None:
+            continue
+        if result["lines"]:
+            files_with_new_data += 1
+
+        for raw_line in result["lines"]:
+            try:
+                text_line = raw_line.decode("utf-8")
+            except UnicodeDecodeError:
+                quarantine_ingest_line(paths, file_path, "invalid UTF-8 encoding", len(raw_line))
+                quarantined_count += 1
+                continue
+            try:
+                obj = json.loads(text_line)
+            except json.JSONDecodeError:
+                quarantine_ingest_line(paths, file_path, "malformed JSON", len(raw_line))
+                quarantined_count += 1
+                continue
+            if not isinstance(obj, dict):
+                continue
+
+            obj_type = obj.get("type")
+            if obj_type == "assistant":
+                candidate = extract_assistant_candidate(obj)
+                if candidate is None:
+                    quarantine_ingest_line(paths, file_path, "assistant line missing message.id", len(raw_line))
+                    quarantined_count += 1
+                    continue
+                if since_dt is not None:
+                    line_ts = parse_ts(candidate["timestamp"])
+                    if line_ts is not None and line_ts < since_dt:
+                        continue
+                # Last occurrence in document order wins (plan §5.3: a
+                # response is re-appended per content block, and the
+                # LAST line for a given message.id carries the complete
+                # usage/stop_reason — see
+                # tests/fixtures/transcript_duplicate_message_id.jsonl).
+                candidates[candidate["message_id"]] = candidate
+            elif obj_type == "pr-link":
+                extracted = extract_pr_link(obj)
+                if extracted is not None:
+                    session_id, pr_info = extracted
+                    pr_link_map[session_id] = pr_info
+
+        new_cursor_files[key] = {
+            "inode": result["stat"]["inode"],
+            "size": result["stat"]["size"],
+            "mtime": result["stat"]["mtime"],
+            "offset": result["new_offset"],
+        }
+
+    role_map = resolve_herdr_role_map()
+    runs, binds = load_local_run_and_pr_index(paths)
+    price_tables = load_price_tables(price_table_dir())
+    today_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    gh_cache = {}
+
+    events = [
+        build_usage_event(candidate, price_tables, today_str, role_map, runs, binds, pr_link_map, gh_cache)
+        for candidate in candidates.values()
+    ]
+
+    write_counts = bulk_write_events(paths, events) if events else {"written": 0, "replaced": 0}
+
+    # Cursor is only persisted AFTER the write succeeds: if this process
+    # is interrupted between reading and writing, the next run re-reads
+    # the same bytes from the same starting offset. That's safe (not
+    # wasted) because message.id-keyed writes are idempotent either way
+    # — this is what makes `ingest` produce identical results no matter
+    # how many times, or where, it is interrupted and re-run.
+    save_ingest_cursor(paths, {"files": new_cursor_files})
+
+    print(f"transcript files scanned:            {files_scanned}")
+    print(f"transcript files with new data:      {files_with_new_data}")
+    print(f"distinct message.id in this run:     {len(candidates)}")
+    print(f"usage.message written (new):         {write_counts['written']}")
+    print(f"usage.message replaced (re-run/dup):  {write_counts['replaced']}")
+    print(f"transcript lines quarantined:         {quarantined_count}")
     return 0
 
 
@@ -1313,9 +2281,13 @@ def main():
                 emit_meter_error(storage_root(), f"cmd_{cmd.replace('-', '_')}_unexpected_exception", exc)
             return 0
 
-    if cmd in ("validate", "report"):
+    if cmd in ("validate", "report", "ingest"):
         try:
-            return cmd_validate(rest) if cmd == "validate" else cmd_report(rest)
+            if cmd == "validate":
+                return cmd_validate(rest)
+            if cmd == "report":
+                return cmd_report(rest)
+            return cmd_ingest(rest)
         except Exception as exc:
             print(f"error: ocw-meter {cmd} failed: {redact_text(f'{type(exc).__name__}: {exc}')}", file=sys.stderr)
             return 1

--- a/bin/ocw-meter
+++ b/bin/ocw-meter
@@ -389,12 +389,26 @@ def iso_utc(dt):
 
 
 def parse_ts(value):
+    """Always returns a timezone-AWARE datetime (or None). `ts` is
+    normally always `Z`-suffixed (`iso_utc` never produces anything
+    else), but `event`'s `--ts` override lets a caller store an
+    offset-less value (plan §8.1 lists `ts` as a plain overridable
+    envelope field, and nothing in `hard_line_errors` rejects an
+    offset-less-but-otherwise-valid ISO 8601 string). PR #27 review
+    round 3 finding "新規1": comparing such a naive datetime against an
+    aware one (as `ingest`'s run_id staleness check — round 2 finding
+    "新規1" — does) raises TypeError and takes down the whole `ingest`
+    run with no recovery path (`validate` doesn't reject offset-less
+    `ts` either). A naive value is treated as UTC, matching every other
+    `ts` in this schema and `month_of`'s existing (and, before this fix,
+    silently wrong for naive input) `.astimezone(timezone.utc)` call."""
     if not isinstance(value, str) or not value:
         return None
     try:
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError:
         return None
+    return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
 
 
 def local_offset_str():
@@ -2500,9 +2514,21 @@ def cmd_ingest(args):
     print(f"distinct message.id in this run:     {len(candidates)}")
     print(f"usage.message written (new):         {write_counts['written']}")
     print(f"usage.message replaced (re-run/dup):  {write_counts['replaced']}")
-    print(f"transcript lines quarantined:         {quarantined_count}")
+    if since_dt is None:
+        print(f"transcript lines quarantined:         {quarantined_count}")
+    else:
+        # PR #27 review round 3 finding "新規2": under --since,
+        # quarantine writes are skipped (round 2 finding "新規2"), so
+        # printing this under the same "quarantined:" label as a normal
+        # run — even with the cursor note appended separately — read as
+        # "this many were recorded" when zero were. Label matches what
+        # actually happened: detected while reading, nothing persisted.
+        print(f"transcript lines with parse errors (detected, NOT persisted — see note below): {quarantined_count}")
     if since_dt is not None:
-        print("note: --since was set; the incremental cursor was NOT advanced (read-only for this run)")
+        print(
+            "note: --since was set; this run is read-only — the incremental cursor was NOT "
+            "advanced and no quarantine records were written (see round 2 finding \"新規2\")"
+        )
     return 0
 
 

--- a/bin/ocw-meter
+++ b/bin/ocw-meter
@@ -1451,7 +1451,7 @@ def cmd_report(args):
     if reconcile:
         if month is None:
             month = datetime.now(timezone.utc).strftime("%Y-%m")
-        elif not re.match(r"^\d{4}-\d{2}$", month):
+        elif not re.match(r"^\d{4}-(0[1-9]|1[0-2])$", month):
             # PR #27 review round 1 finding 6a: `_report_reconcile` used
             # to filter with `ts.startswith(month)`, so a malformed value
             # like "2026" silently aggregated the WHOLE year under a
@@ -1460,7 +1460,13 @@ def cmd_report(args):
             # fail-loud half of this CLI (plan §10.1) — a garbage filter
             # producing a garbage-but-plausible-looking number is exactly
             # the failure mode that policy exists to prevent.
-            print(f"error: --month must be YYYY-MM, got: {month!r}", file=sys.stderr)
+            #
+            # Round 2 finding "持ち越し6a": the first fix only checked
+            # digit-count shape (`\d{4}-\d{2}`), so "2026-13"/"2026-00"
+            # still passed through and silently matched zero events —
+            # the exact same failure mode, just moved to the month
+            # digits. The month component is now restricted to 01-12.
+            print(f"error: --month must be YYYY-MM with a valid month (01-12), got: {month!r}", file=sys.stderr)
             return 1
         return _report_reconcile(paths, month, provider_totals, as_json)
 
@@ -1746,7 +1752,21 @@ def load_session_pr_links(paths):
         data = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return {}
-    return data if isinstance(data, dict) else {}
+    if not isinstance(data, dict):
+        return {}
+    # PR #27 review round 2 finding "新規3": `load_ingest_cursor` treats
+    # a malformed file/entry as "start fresh", never raising — this
+    # state file (written only by this meter itself, but still worth
+    # being defensive about, e.g. a future format change leaving old
+    # entries around) previously validated only the top-level container,
+    # so a single malformed VALUE crashed `ingest` entirely with an
+    # unhelpful AttributeError deep inside `build_usage_event`. Drop
+    # individual bad entries instead of failing the whole run over them.
+    return {
+        session_id: value
+        for session_id, value in data.items()
+        if isinstance(value, dict) and isinstance(value.get("pr_number"), int)
+    }
 
 
 def save_session_pr_links(paths, mapping):
@@ -1824,6 +1844,22 @@ def quarantine_ingest_line(paths, source_file, reason, byte_length):
         fh.write(json.dumps(record_, ensure_ascii=False) + "\n")
     with contextlib.suppress(OSError):
         os.chmod(qpath, 0o600)
+
+
+def quarantine_this_run(paths, since_dt, source_file, reason, byte_length):
+    """Wraps `quarantine_ingest_line` with the same --since read-only
+    rule the cursor follows (PR #27 review round 2 finding "新規2"): a
+    --since run re-reads the same unconsumed byte range every time
+    (since it never advances the persisted cursor — round 1 finding 1),
+    so unconditionally quarantining would append a duplicate record for
+    the SAME broken line on every single --since invocation, silently
+    inflating `report`'s transcript-quarantine count in proportion to
+    how many times --since happened to be run rather than how much
+    source data is actually broken. `quarantined_count` (this run's
+    stdout summary) still reflects what was found, just not persisted
+    twice — the eventual --since-less run permanently records it once."""
+    if since_dt is None:
+        quarantine_ingest_line(paths, source_file, reason, byte_length)
 
 
 # ── transcript line extraction ─────────────────────────────────────────
@@ -1946,13 +1982,15 @@ def resolve_herdr_role_map():
 
 # ── run_id / PR attribution from this meter's own local event store ────
 
-def load_local_pr_binds(paths):
-    """Single pass over every stored event, building the pr.bind lookup
-    table `ingest` needs for plan §7.4's attribution priority (PR
-    resolution once a run_id is known). Tolerates malformed lines by
-    skipping them — this is advisory context-building, not `validate`,
-    so a corrupt line here just means less context, not an error."""
-    binds = {}
+def load_local_pr_binds_and_run_starts(paths):
+    """Single pass over every stored event, building two lookup tables
+    `ingest` needs: the pr.bind table (plan §7.4 PR resolution once a
+    run_id is known) and run_id -> run.start ts (PR #27 review round 2
+    finding "新規1", see resolve_run_id_via_ocw_run_id_file's caller).
+    Tolerates malformed lines by skipping them — this is advisory
+    context-building, not `validate`, so a corrupt line here just means
+    less context, not an error."""
+    binds, run_starts = {}, {}
     for target in sorted(paths.events_dir.glob("*.jsonl")):
         try:
             text = target.read_text(encoding="utf-8", errors="replace")
@@ -1965,13 +2003,17 @@ def load_local_pr_binds(paths):
                 obj = json.loads(line)
             except json.JSONDecodeError:
                 continue
-            if obj.get("event_type") != "pr.bind":
-                continue
+            event_type = obj.get("event_type")
             run_id = obj.get("run_id")
-            pr_number = obj.get("pr_number")
-            if run_id and isinstance(pr_number, int):
-                binds[run_id] = {"pr_number": pr_number, "pr_url": obj.get("pr_url")}
-    return binds
+            if event_type == "pr.bind" and run_id:
+                pr_number = obj.get("pr_number")
+                if isinstance(pr_number, int):
+                    binds[run_id] = {"pr_number": pr_number, "pr_url": obj.get("pr_url")}
+            elif event_type == "run.start" and run_id:
+                ts = parse_ts(obj.get("ts"))
+                if ts is not None:
+                    run_starts[run_id] = ts
+    return binds, run_starts
 
 
 def resolve_run_id_via_ocw_run_id_file(cwd, cache):
@@ -1992,12 +2034,24 @@ def resolve_run_id_via_ocw_run_id_file(cwd, cache):
     positives (misattributing implementer/reviewer messages to whatever
     run happened to be starting in the origin worktree at that moment).
     Reading the git-dir file is authoritative for the EXACT worktree a
-    message came from and requires no cross-referencing at all.
+    message came from.
 
     Returns None once the worktree has been removed (git prunes its
     metadata dir, including this file, on `ocw rm`/`git worktree
     remove`) — that is correct, not a bug (plan §7.4: 不明なら null。
-    推測しない), not every historical message can still be traced back."""
+    推測しない), not every historical message can still be traced back.
+
+    PR #27 review round 2 finding "新規1": this file answers "which
+    run_id does THIS PATH currently belong to", not "which run_id was
+    active when this specific message was generated". `ocw rm <name>`
+    followed by `ocw new <name>` reuses the same worktree path for a
+    brand new run, so a message generated under the OLD incarnation
+    (never ingested before that happened) would otherwise get
+    silently re-attributed to the NEW run_id. The caller
+    (`build_usage_event`) cross-checks the returned run_id's own
+    `run.start` timestamp against the message's timestamp and discards
+    the match (falls back to null) if the message predates that
+    run.start — see `run_starts` there."""
     if cwd is None:
         return None
     if cwd in cache:
@@ -2062,7 +2116,7 @@ def gh_pr_for_branch(branch):
 
 # ── assembling usage.message events ─────────────────────────────────────
 
-def build_usage_event(candidate, price_tables, today_str, role_map, binds, pr_link_map, gh_cache, run_id_cache, repo_cache):
+def build_usage_event(candidate, price_tables, today_str, role_map, binds, run_starts, pr_link_map, gh_cache, run_id_cache, repo_cache):
     usage = candidate["usage"] or {}
     input_tokens = usage.get("input_tokens")
     cache_read = usage.get("cache_read_input_tokens")
@@ -2097,6 +2151,20 @@ def build_usage_event(candidate, price_tables, today_str, role_map, binds, pr_li
 
     worktree = candidate["cwd"]
     run_id = resolve_run_id_via_ocw_run_id_file(worktree, run_id_cache)
+    # PR #27 review round 2 finding "新規1": the ocw-run-id file answers
+    # "which run_id does THIS PATH belong to NOW", not "...when this
+    # message was generated". `ocw rm <name>` + `ocw new <name>` reuses
+    # the worktree path for a brand new run — a message from the OLD
+    # incarnation would otherwise silently re-attribute to the new
+    # run_id. If we know that run_id's own run.start ts and the message
+    # predates it, the match is from a stale path reuse: discard it
+    # (null, not guessed). Unknown run.start ts (e.g. from before this
+    # meter started recording, or a different machine) gives the match
+    # the benefit of the doubt rather than nulling everything out.
+    if run_id is not None and ts_dt is not None:
+        run_start_ts = run_starts.get(run_id)
+        if run_start_ts is not None and ts_dt < run_start_ts:
+            run_id = None
 
     pr_info = binds.get(run_id) if run_id else None
     if pr_info is None:
@@ -2349,13 +2417,13 @@ def cmd_ingest(args):
             try:
                 text_line = raw_line.decode("utf-8")
             except UnicodeDecodeError:
-                quarantine_ingest_line(paths, file_path, "invalid UTF-8 encoding", len(raw_line))
+                quarantine_this_run(paths, since_dt, file_path, "invalid UTF-8 encoding", len(raw_line))
                 quarantined_count += 1
                 continue
             try:
                 obj = json.loads(text_line)
             except json.JSONDecodeError:
-                quarantine_ingest_line(paths, file_path, "malformed JSON", len(raw_line))
+                quarantine_this_run(paths, since_dt, file_path, "malformed JSON", len(raw_line))
                 quarantined_count += 1
                 continue
             if not isinstance(obj, dict):
@@ -2365,7 +2433,7 @@ def cmd_ingest(args):
             if obj_type == "assistant":
                 candidate = extract_assistant_candidate(obj)
                 if candidate is None:
-                    quarantine_ingest_line(paths, file_path, "assistant line missing message.id", len(raw_line))
+                    quarantine_this_run(paths, since_dt, file_path, "assistant line missing message.id", len(raw_line))
                     quarantined_count += 1
                     continue
                 if since_dt is not None:
@@ -2392,13 +2460,13 @@ def cmd_ingest(args):
         }
 
     role_map = resolve_herdr_role_map()
-    binds = load_local_pr_binds(paths)
+    binds, run_starts = load_local_pr_binds_and_run_starts(paths)
     price_tables = load_price_tables(price_table_dir())
     today_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     gh_cache, run_id_cache, repo_cache = {}, {}, {}
 
     events = [
-        build_usage_event(candidate, price_tables, today_str, role_map, binds, pr_link_map, gh_cache, run_id_cache, repo_cache)
+        build_usage_event(candidate, price_tables, today_str, role_map, binds, run_starts, pr_link_map, gh_cache, run_id_cache, repo_cache)
         for candidate in candidates.values()
     ]
 

--- a/bin/ocw-meter
+++ b/bin/ocw-meter
@@ -2525,9 +2525,13 @@ def cmd_ingest(args):
         # actually happened: detected while reading, nothing persisted.
         print(f"transcript lines with parse errors (detected, NOT persisted — see note below): {quarantined_count}")
     if since_dt is not None:
+        # PR #27 review round 4 finding "新規1": this string is printed
+        # to the user's terminal — it must read on its own, not
+        # reference an internal PR review round number nobody running
+        # `ingest` has any context for.
         print(
             "note: --since was set; this run is read-only — the incremental cursor was NOT "
-            "advanced and no quarantine records were written (see round 2 finding \"新規2\")"
+            "advanced and no quarantine records were written"
         )
     return 0
 

--- a/bin/prices/deepseek-2026-08-01.json
+++ b/bin/prices/deepseek-2026-08-01.json
@@ -1,0 +1,13 @@
+{
+  "price_table_version": "deepseek-2026-08-01",
+  "effective_date": "2026-08-01",
+  "source": "https://api-docs.deepseek.com/quick_start/pricing",
+  "fetched_at": "2026-08-01",
+  "currency": "USD",
+  "unit": "per_1m_tokens",
+  "models": {
+    "deepseek-v4-pro":   { "cache_hit_in": 0.003625, "cache_miss_in": 0.435, "out": 0.87 },
+    "deepseek-v4-flash": { "cache_hit_in": 0.0028,   "cache_miss_in": 0.14,  "out": 0.28 }
+  },
+  "notes": "peak/off-peak 2x pricing announced (Beijing 09:00-12:00, 14:00-18:00) — effective date TBD as of fetched_at"
+}

--- a/bin/tests/test_ocw_meter.py
+++ b/bin/tests/test_ocw_meter.py
@@ -9,22 +9,31 @@ touches real state or the repo itself.
 No network access. No secrets. See docs/planning/DOC-003_..._計画.md §13
 for the numbered test-case list (T01, T02, ...) this file implements.
 
-Coverage of §13.2 in THIS phase (孫1 scope only):
+Coverage of §13.2 across 孫1 + 孫3 (this file):
 
-  implemented: T01 T02 T03 T04 T05 T06 T07
+  implemented: T01 T02 T03 T04 T05 T06 T07 T08
                T11 (forward-compat half: unknown fields survive)
+               T12 T13 T14 T16
                T17 T18 (regression guard) T19 T20 T21 T22
   deferred, not implementable until a later phase exists to test:
-    T08 - Herdr pane_id/session_id continuity is `ingest`'s role
-          resolution logic (plan §7.4 item 2); nothing to exercise
-          until `ingest` exists (孫3).
     T09 - 5h window reset/staleness is quota.sample-specific (孫4).
-    T10 - the rate_limits/usage-absence half is quota/usage-specific
-          (孫3/孫4); the generic "missing required field ->
-          quarantined" half is covered by EventSchemaValidationTests.
+    T10 - the rate_limits half is quota-specific (孫4); the
+          usage-absence half IS covered here
+          (IngestTests.test_ingest_missing_usage_field_is_completeness_unknown)
+          and the generic "missing required field -> quarantined" half
+          is covered by EventSchemaValidationTests.
     T11 - the "known key disappears" half is statusLine-parser-
           specific (孫4).
-    T16 - price-table versioning: no pricing exists yet (孫3).
+    T15 - API error -> block.*/error_category is pr-review-loop
+          instrumentation (孫2's scope, already covered there), not
+          something `ingest` (a read-only transcript scanner) produces.
+
+IngestTests below drives the real `ocw-meter ingest` subprocess against
+synthetic transcript fixtures under a tempdir (OCW_METER_CLAUDE_PROJECTS_DIR),
+not the developer's real ~/.claude/projects — nothing here reads real
+transcripts. See docs/planning/DOC-003_..._計画.md's 孫3プロンプト for the
+completion criteria this maps to (idempotency, message.id dedup,
+message.content non-exposure, cost formula, price-table versioning).
 """
 
 import concurrent.futures
@@ -89,6 +98,59 @@ def read_meter_errors(home):
     if not path.exists():
         return []
     return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+# ── ingest test helpers (孫3) ────────────────────────────────────────────
+
+REPO_PRICE_DIR = REPO_ROOT / "bin" / "prices"
+
+
+def assistant_line(session_id, message_id, *, model="deepseek-v4-pro", input_tokens=100,
+                    cache_read_input_tokens=200, cache_creation_input_tokens=0, output_tokens=50,
+                    stop_reason="end_turn", timestamp="2026-07-15T10:00:00.000Z",
+                    git_branch="ai/test", cwd="/fixture/worktree", is_sidechain=False, effort="high",
+                    usage=None):
+    if usage is None:
+        usage = {
+            "input_tokens": input_tokens,
+            "cache_read_input_tokens": cache_read_input_tokens,
+            "cache_creation_input_tokens": cache_creation_input_tokens,
+            "output_tokens": output_tokens,
+            "service_tier": "standard",
+        }
+    return {
+        "type": "assistant",
+        "timestamp": timestamp,
+        "sessionId": session_id,
+        "version": "2.1.220",
+        "gitBranch": git_branch,
+        "cwd": cwd,
+        "effort": effort,
+        "isSidechain": is_sidechain,
+        "message": {"id": message_id, "model": model, "stop_reason": stop_reason, "usage": usage},
+    }
+
+
+def write_transcript(projects_dir, slug, session_id, line_dicts):
+    session_dir = pathlib.Path(projects_dir) / slug
+    session_dir.mkdir(parents=True, exist_ok=True)
+    path = session_dir / f"{session_id}.jsonl"
+    path.write_text(
+        "".join(json.dumps(d, ensure_ascii=False) + "\n" for d in line_dicts),
+        encoding="utf-8",
+    )
+    return path
+
+
+def run_ingest(home, projects_dir, args=None, price_dir=None, extra_env=None, timeout=60):
+    env = {
+        "OCW_METER_CLAUDE_PROJECTS_DIR": str(projects_dir),
+        "OCW_METER_PRICE_DIR": str(price_dir if price_dir is not None else REPO_PRICE_DIR),
+        "OCW_METER_INGEST_USE_GH": "0",
+    }
+    if extra_env:
+        env.update(extra_env)
+    return run_meter(["ingest", *(args or [])], home, extra_env=env, timeout=timeout)
 
 
 class OcwMeterTestCase(unittest.TestCase):
@@ -954,6 +1016,367 @@ class TranscriptFixtureDedupTests(OcwMeterTestCase):
         events = read_events(self.home)
         self.assertEqual(len(events), 1)
         self.assertEqual(events[0]["note"], "second")
+
+
+class IngestTests(OcwMeterTestCase):
+    def setUp(self):
+        super().setUp()
+        self.projects_dir = pathlib.Path(self.tmpdir.name) / "claude-projects"
+        self.projects_dir.mkdir(parents=True, exist_ok=True)
+
+    def test_ingest_dedupes_content_block_split_lines_via_real_fixture(self):
+        # T04/T12, driven through the actual `ingest` scan path (not the
+        # `event` primitive directly, unlike TranscriptFixtureDedupTests
+        # above) — this is the fixture ADR-001 §2.2's 59.4%-duplicate
+        # measurement is based on, reused as-is per the 孫3 prompt's "実
+        # transcript由来の縮小fixture" test requirement.
+        fixture = REPO_ROOT / "bin" / "tests" / "fixtures" / "transcript_duplicate_message_id.jsonl"
+        session_dir = self.projects_dir / "fixture-project"
+        session_dir.mkdir(parents=True)
+        (session_dir / "00b2ac54-fixture.jsonl").write_text(fixture.read_text(encoding="utf-8"), encoding="utf-8")
+
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        events = [e for e in read_events(self.home) if e["event_type"] == "usage.message"]
+        self.assertEqual(len(events), 2)  # 4 raw assistant lines -> 2 distinct message_id
+        by_id = {e["message_id"]: e for e in events}
+        # The LAST occurrence of msg_fixture_dup_001 has output_tokens
+        # 329 and a real stop_reason (the fixture's first two rows have
+        # output_tokens 0/150 and stop_reason null — an in-progress
+        # stream). Keeping an earlier row would silently under-count.
+        self.assertEqual(by_id["msg_fixture_dup_001"]["output_tokens"], 329)
+        self.assertEqual(by_id["msg_fixture_dup_001"]["stop_reason"], "end_turn")
+        self.assertEqual(by_id["msg_fixture_dup_001"]["completeness"], "complete")
+        self.assertEqual(by_id["msg_fixture_dup_002"]["output_tokens"], 77)
+
+    def test_ingest_is_idempotent_across_repeated_runs(self):
+        write_transcript(self.projects_dir, "proj", "sess-idem", [
+            assistant_line("sess-idem", "m1"),
+            assistant_line("sess-idem", "m2", timestamp="2026-07-15T10:05:00.000Z"),
+        ])
+        r1 = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(r1.returncode, 0, r1.stderr)
+        self.assertIn("usage.message written (new):         2", r1.stdout)
+        first_events = read_events(self.home)
+
+        r2 = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(r2.returncode, 0, r2.stderr)
+        self.assertIn("usage.message written (new):         0", r2.stdout)
+        second_events = read_events(self.home)
+
+        key = lambda e: e["message_id"]
+        self.assertEqual(sorted(first_events, key=key), sorted(second_events, key=key))
+
+    def test_ingest_incremental_only_processes_newly_appended_lines(self):
+        path = write_transcript(self.projects_dir, "proj", "sess-inc", [assistant_line("sess-inc", "m1")])
+        r1 = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(r1.returncode, 0, r1.stderr)
+        self.assertEqual(len(read_events(self.home)), 1)
+
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(assistant_line("sess-inc", "m2", timestamp="2026-07-15T11:00:00.000Z"), ensure_ascii=False) + "\n")
+
+        r2 = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(r2.returncode, 0, r2.stderr)
+        self.assertIn("usage.message written (new):         1", r2.stdout)
+        events = read_events(self.home)
+        self.assertEqual({e["message_id"] for e in events}, {"m1", "m2"})
+
+    def test_ingest_rereads_from_scratch_on_file_rotation(self):
+        path = write_transcript(self.projects_dir, "proj", "sess-rot", [assistant_line("sess-rot", "m1")])
+        r1 = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(r1.returncode, 0, r1.stderr)
+        self.assertEqual(len(read_events(self.home)), 1)
+
+        # Simulate rotation: a brand-new file (new inode) replaces the
+        # old one at the same path, containing the same message plus a
+        # new one — this is what plan §1's "inode変化...を検出したら...
+        # 頭から読み直す" guards against. os.replace onto an existing
+        # path changes the inode even though the path string is the same.
+        tmp_path = path.with_suffix(".jsonl.new")
+        tmp_path.write_text(
+            "".join(
+                json.dumps(line, ensure_ascii=False) + "\n"
+                for line in [assistant_line("sess-rot", "m1"), assistant_line("sess-rot", "m2", timestamp="2026-07-15T12:00:00.000Z")]
+            ),
+            encoding="utf-8",
+        )
+        os.replace(tmp_path, path)
+
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        events = read_events(self.home)
+        # m1 is absorbed by message_id dedup even though its bytes were
+        # re-read from offset 0 — must not appear as a duplicate event.
+        self.assertEqual({e["message_id"] for e in events}, {"m1", "m2"})
+        self.assertEqual(len(events), 2)
+
+    def test_ingest_leaves_an_unterminated_final_line_for_the_next_run(self):
+        path = write_transcript(self.projects_dir, "proj", "sess-partial", [assistant_line("sess-partial", "m1")])
+        with open(path, "a", encoding="utf-8") as fh:
+            # No trailing newline: the writer may still be mid-write.
+            fh.write(json.dumps(assistant_line("sess-partial", "m2", timestamp="2026-07-15T13:00:00.000Z"), ensure_ascii=False))
+
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual({e["message_id"] for e in read_events(self.home)}, {"m1"})
+        self.assertEqual(read_quarantine(self.home), [])
+
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write("\n")
+        result2 = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result2.returncode, 0, result2.stderr)
+        self.assertEqual({e["message_id"] for e in read_events(self.home)}, {"m1", "m2"})
+
+    def test_ingest_quarantines_malformed_line_without_storing_its_bytes(self):
+        session_dir = self.projects_dir / "proj"
+        session_dir.mkdir(parents=True)
+        path = session_dir / "sess-bad.jsonl"
+        path.write_text(
+            json.dumps(assistant_line("sess-bad", "m1"), ensure_ascii=False) + "\n"
+            + '{"type":"assistant","message":{"id":"broken", THIS-IS-NOT-VALID-JSON\n',
+            encoding="utf-8",
+        )
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual({e["message_id"] for e in read_events(self.home)}, {"m1"})
+
+        quarantined = read_quarantine(self.home)
+        self.assertEqual(len(quarantined), 1)
+        self.assertEqual(quarantined[0]["reason"], "malformed JSON")
+        # No raw_line field at all — a broken line might contain a
+        # garbled fragment of prompt/response content from a partial
+        # write, so ingest's own quarantine (unlike validate's) never
+        # stores the source bytes (plan §1: message.content不可触).
+        self.assertNotIn("raw_line", quarantined[0])
+        self.assertNotIn("THIS-IS-NOT-VALID-JSON", json.dumps(quarantined[0]))
+
+    def test_ingest_never_persists_message_content_anywhere(self):
+        line = assistant_line("sess-content", "m1")
+        line["message"]["content"] = [{"type": "text", "text": "THIS-IS-SECRET-PROMPT-CONTENT"}]
+        write_transcript(self.projects_dir, "proj", "sess-content", [line])
+
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        for path in pathlib.Path(self.home).rglob("*"):
+            if path.is_file():
+                self.assertNotIn("THIS-IS-SECRET-PROMPT-CONTENT", path.read_text(encoding="utf-8", errors="replace"))
+
+    def test_ingest_missing_usage_field_is_completeness_unknown(self):
+        # T13 (transcript-observable half of "stream interrupted"): a
+        # `usage`-less assistant line is treated the same way as data
+        # this meter genuinely cannot see — null fields, not a guess.
+        line = assistant_line("sess-nousage", "m1")
+        del line["message"]["usage"]
+        write_transcript(self.projects_dir, "proj", "sess-nousage", [line])
+
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = read_events(self.home)[0]
+        self.assertEqual(event["completeness"], "unknown")
+        self.assertIsNone(event["input_tokens"])
+        self.assertIsNone(event["output_tokens"])
+        self.assertIsNone(event["cost_estimate_usd"])
+
+    def test_ingest_distinct_message_ids_both_kept_not_merged(self):
+        # T14 (retry): a retry gets a NEW message.id from the provider —
+        # it is a second, separately-billable event, not merged into the
+        # first (only a REPEATED message.id gets deduped).
+        write_transcript(self.projects_dir, "proj", "sess-retry", [
+            assistant_line("sess-retry", "m1", output_tokens=10),
+            assistant_line("sess-retry", "m2", output_tokens=20, timestamp="2026-07-15T14:00:00.000Z"),
+        ])
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(len(read_events(self.home)), 2)
+
+    def test_ingest_anthropic_model_is_subscription_not_estimated(self):
+        write_transcript(self.projects_dir, "proj", "sess-anthropic", [
+            assistant_line("sess-anthropic", "m1", model="claude-opus-5"),
+        ])
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = read_events(self.home)[0]
+        self.assertEqual(event["provider"], "anthropic")
+        self.assertEqual(event["cost_basis"], "subscription")
+        self.assertIsNone(event["cost_estimate_usd"])
+        self.assertEqual(event["completeness"], "complete")
+
+    def test_ingest_deepseek_cost_matches_plan_formula(self):
+        # Uses the real bin/prices/deepseek-2026-08-01.json and the exact
+        # July totals from plan §1 / ADR-001 §2.2 — this is the $46.78
+        # figure the 孫3 prompt's completion criteria checks against.
+        write_transcript(self.projects_dir, "proj", "sess-cost", [
+            assistant_line(
+                "sess-cost", "m1", model="deepseek-v4-pro",
+                input_tokens=38336862, cache_read_input_tokens=5428087040,
+                cache_creation_input_tokens=0, output_tokens=11983028,
+            ),
+        ])
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = read_events(self.home)[0]
+        self.assertEqual(event["cost_basis"], "estimated")
+        self.assertAlmostEqual(event["cost_estimate_usd"], 46.7785848500, places=4)
+        self.assertEqual(event["price_table_version"], "deepseek-2026-08-01")
+        self.assertEqual(event["price_effective_date"], "2026-08-01")
+
+    def test_ingest_unpriced_model_is_completeness_unknown(self):
+        # A DeepSeek-shaped model name absent from bin/prices/*.json
+        # (both real price entries, deepseek-v4-pro/-flash, are present
+        # in the repo's committed price table — this exercises the
+        # "genuinely unpriced" branch with a name that will never match).
+        write_transcript(self.projects_dir, "proj", "sess-unpriced", [
+            assistant_line("sess-unpriced", "m1", model="deepseek-v4-nonexistent"),
+        ])
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = read_events(self.home)[0]
+        self.assertIsNone(event["cost_estimate_usd"])
+        self.assertEqual(event["cost_basis"], "estimated")
+        self.assertEqual(event["completeness"], "unknown")
+
+    def test_ingest_new_price_table_does_not_touch_already_ingested_events(self):
+        # T16: adding a newer price_table_version must not retroactively
+        # change cost_estimate_usd on events already written.
+        price_dir = pathlib.Path(self.tmpdir.name) / "prices-v1"
+        price_dir.mkdir()
+        (price_dir / "deepseek-2026-08-01.json").write_text(json.dumps({
+            "price_table_version": "deepseek-2026-08-01", "effective_date": "2026-08-01",
+            "models": {"deepseek-v4-pro": {"cache_hit_in": 0.003625, "cache_miss_in": 0.435, "out": 0.87}},
+        }), encoding="utf-8")
+        write_transcript(self.projects_dir, "proj", "sess-pricever", [
+            assistant_line("sess-pricever", "m1", model="deepseek-v4-pro",
+                            input_tokens=1000, cache_read_input_tokens=2000, output_tokens=300),
+        ])
+        r1 = run_ingest(self.home, self.projects_dir, price_dir=price_dir)
+        self.assertEqual(r1.returncode, 0, r1.stderr)
+        before = read_events(self.home)[0]
+
+        # A new, deliberately much more expensive price table shows up.
+        (price_dir / "deepseek-2099-01-01.json").write_text(json.dumps({
+            "price_table_version": "deepseek-2099-01-01", "effective_date": "2099-01-01",
+            "models": {"deepseek-v4-pro": {"cache_hit_in": 99, "cache_miss_in": 99, "out": 99}},
+        }), encoding="utf-8")
+
+        result = run_ingest(self.home, self.projects_dir, price_dir=price_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("usage.message written (new):         0", result.stdout)
+        self.assertIn("usage.message replaced (re-run/dup):  0", result.stdout)
+        after = read_events(self.home)[0]
+
+        self.assertEqual(before["cost_estimate_usd"], after["cost_estimate_usd"])
+        self.assertEqual(before["price_table_version"], after["price_table_version"])
+
+    def test_ingest_role_resolved_via_herdr_pane_list(self):
+        # T08: role/pane/workspace attribution via a mocked Herdr CLI —
+        # not implementable before `ingest` existed (孫1's docstring
+        # deferred it here explicitly).
+        session_id = "sess-herdr"
+        write_transcript(self.projects_dir, "proj", session_id, [assistant_line(session_id, "m1")])
+
+        pane_json = json.dumps({"panes": [{
+            "pane_id": "w1:p2", "label": "implementer", "workspace_id": "w1",
+            "agent_session": {"agent": "claude", "kind": "id", "value": session_id},
+            "cwd": "/whatever",
+        }]})
+        fake_bin = pathlib.Path(self.tmpdir.name) / "fake-bin"
+        fake_bin.mkdir()
+        herdr_script = fake_bin / "herdr"
+        herdr_script.write_text(
+            "#!/usr/bin/env bash\n"
+            'if [ "$1" = "status" ] && [ "$2" = "server" ]; then exit 0; fi\n'
+            'if [ "$1" = "workspace" ] && [ "$2" = "list" ]; then echo \'{"workspaces":[{"workspace_id":"w1"}]}\'; exit 0; fi\n'
+            f"if [ \"$1\" = \"pane\" ] && [ \"$2\" = \"list\" ]; then echo '{pane_json}'; exit 0; fi\n"
+            "exit 1\n",
+            encoding="utf-8",
+        )
+        herdr_script.chmod(0o755)
+
+        path_with_fake_herdr_first = f"{fake_bin}:{os.environ.get('PATH', '')}"
+        result = run_ingest(self.home, self.projects_dir, extra_env={"PATH": path_with_fake_herdr_first})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = read_events(self.home)[0]
+        self.assertEqual(event["role"], "implementer")
+        self.assertEqual(event["workspace_id"], "w1")
+        self.assertEqual(event["pane_id"], "w1:p2")
+
+    def test_ingest_role_stays_unknown_when_herdr_unavailable(self):
+        write_transcript(self.projects_dir, "proj", "sess-noherdr", [assistant_line("sess-noherdr", "m1")])
+        # A PATH with no `herdr` on it at all (and no dev-machine Herdr
+        # server to accidentally talk to) — role resolution must fail
+        # closed to "unknown", never guess (plan §7.4: 推測で埋めない).
+        result = run_ingest(self.home, self.projects_dir, extra_env={"PATH": "/usr/bin:/bin"})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = read_events(self.home)[0]
+        self.assertEqual(event["role"], "unknown")
+        self.assertIsNone(event["workspace_id"])
+        self.assertIsNone(event["pane_id"])
+
+    def test_ingest_pr_number_resolved_from_pr_link_transcript_line(self):
+        session_id = "sess-prlink"
+        write_transcript(self.projects_dir, "proj", session_id, [
+            assistant_line(session_id, "m1"),
+            {"type": "pr-link", "sessionId": session_id, "prNumber": 42,
+             "prUrl": "https://github.com/manemone/dotfiles/pull/42",
+             "prRepository": "manemone/dotfiles", "timestamp": "2026-07-15T10:01:00.000Z"},
+        ])
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = read_events(self.home)[0]
+        self.assertEqual(event["pr_number"], 42)
+        self.assertEqual(event["pr_url"], "https://github.com/manemone/dotfiles/pull/42")
+
+    def test_ingest_pr_number_null_when_unresolvable_and_gh_disabled(self):
+        write_transcript(self.projects_dir, "proj", "sess-nopr", [assistant_line("sess-nopr", "m1")])
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIsNone(read_events(self.home)[0]["pr_number"])
+
+    def test_ingest_no_external_network_calls_by_default(self):
+        # `gh` must never be invoked unless OCW_METER_INGEST_USE_GH=1 —
+        # a fake `gh` that would fail loudly if actually called proves
+        # ingest never shells out to it under default settings.
+        write_transcript(self.projects_dir, "proj", "sess-nogh", [assistant_line("sess-nogh", "m1")])
+        fake_bin = pathlib.Path(self.tmpdir.name) / "no-gh-bin"
+        fake_bin.mkdir()
+        poison_gh = fake_bin / "gh"
+        poison_gh.write_text("#!/usr/bin/env bash\necho 'gh should not have been called' >&2\nexit 7\n", encoding="utf-8")
+        poison_gh.chmod(0o755)
+        result = run_ingest(
+            self.home, self.projects_dir,
+            extra_env={"PATH": f"{fake_bin}:{os.environ.get('PATH', '')}", "OCW_METER_INGEST_USE_GH": "0"},
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("gh should not have been called", result.stderr)
+
+    def test_ingest_run_id_resolved_from_local_run_start_event(self):
+        worktree = "/fixture/worktree"
+        run_meter(
+            # run.start must predate the transcript message's timestamp
+            # (2026-07-15T10:30) for the time-range match in
+            # `resolve_run_id` to find it — a real `ocw` invocation
+            # always records run.start before any work happens.
+            ["event", "run.start", "--idempotency-key", "run1-start", "--run-id", "run1",
+             "--ts", "2026-07-15T09:00:00.000Z",
+             "--worktree", worktree, "--base-ref", "origin/main", "--command", "claude"],
+            self.home,
+        )
+        write_transcript(self.projects_dir, "proj", "sess-run", [
+            assistant_line("sess-run", "m1", cwd=worktree, timestamp="2026-07-15T10:30:00.000Z"),
+        ])
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        usage_event = next(e for e in read_events(self.home) if e["event_type"] == "usage.message")
+        self.assertEqual(usage_event["run_id"], "run1")
+
+    def test_ingest_refuses_to_operate_inside_a_git_worktree(self):
+        write_transcript(self.projects_dir, "proj", "sess-refuse", [assistant_line("sess-refuse", "m1")])
+        result = run_ingest(REPO_ROOT / "tmp-test-ocw-meter-ingest-worktree-guard", self.projects_dir)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse((REPO_ROOT / "tmp-test-ocw-meter-ingest-worktree-guard").exists())
 
 
 if __name__ == "__main__":

--- a/bin/tests/test_ocw_meter.py
+++ b/bin/tests/test_ocw_meter.py
@@ -1210,6 +1210,26 @@ class IngestTests(OcwMeterTestCase):
         self.assertEqual(result2.returncode, 0, result2.stderr)
         self.assertEqual(len(read_quarantine(self.home)), 1)  # still just once
 
+    def test_ingest_since_output_does_not_claim_quarantine_when_none_was_persisted(self):
+        # PR #27 review round 3 finding "新規2": under --since, nothing
+        # is actually written to quarantine/ingest-transcript.jsonl (see
+        # the test above), but the old output label
+        # "transcript lines quarantined: N" implied it had been. This
+        # tool's own design principle (plan §10.4: 部分的な記録を完全と
+        # 誤認しない) applies to its OWN stdout, not just stored data.
+        session_dir = self.projects_dir / "proj"
+        session_dir.mkdir(parents=True)
+        (session_dir / "sess-bad-since2.jsonl").write_text(
+            json.dumps(assistant_line("sess-bad-since2", "m1", timestamp="2026-07-15T10:00:00.000Z"), ensure_ascii=False) + "\n"
+            + "{broken json\n",
+            encoding="utf-8",
+        )
+        result = run_ingest(self.home, self.projects_dir, args=["--since", "2026-01-01T00:00:00Z"])
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("transcript lines quarantined:", result.stdout)
+        self.assertIn("NOT persisted", result.stdout)
+        self.assertEqual(len(read_quarantine(self.home)), 0)
+
     def test_ingest_tolerates_malformed_session_pr_links_state_file(self):
         # PR #27 review round 2 finding "新規3": a malformed entry in
         # state/session-pr-links.json (this meter's own state, but
@@ -1518,7 +1538,13 @@ class IngestTests(OcwMeterTestCase):
         ])
         result = run_ingest(self.home, self.projects_dir)
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(read_events(self.home)[0]["run_id"], "run-normal")
+        # The run.start event (ts 2026-07-01) sorts into an earlier
+        # day-file than the usage.message (2026-07-15), so index [0]
+        # would trivially be the run.start event itself (whose own
+        # run_id field is "run-normal" regardless of what the message
+        # resolved to) — select the usage.message explicitly.
+        usage_event = next(e for e in read_events(self.home) if e["event_type"] == "usage.message")
+        self.assertEqual(usage_event["run_id"], "run-normal")
 
     def test_ingest_pr_number_resolved_via_run_id_bind_using_ocw_run_id_file(self):
         # End-to-end: pr.bind's run_id must line up with what the fixed
@@ -1535,9 +1561,31 @@ class IngestTests(OcwMeterTestCase):
         ])
         result = run_ingest(self.home, self.projects_dir)
         self.assertEqual(result.returncode, 0, result.stderr)
-        event = read_events(self.home)[0]
+        event = next(e for e in read_events(self.home) if e["event_type"] == "usage.message")
         self.assertEqual(event["run_id"], "run-xyz789")
         self.assertEqual(event["pr_number"], 99)
+
+    def test_ingest_survives_a_run_start_with_an_offset_less_timestamp(self):
+        # PR #27 review round 3 finding "新規1": `event --ts` accepts an
+        # offset-less (naive) ISO 8601 value — `hard_line_errors` doesn't
+        # reject it, so it can genuinely end up stored. Round 2's run_id
+        # staleness cross-check ("新規1" there) then compared it against
+        # a timezone-AWARE message timestamp, raising TypeError and
+        # taking down `ingest` entirely, with no recovery path (this
+        # naive `ts` isn't rejected by `validate` either).
+        worktree_dir = make_ocw_style_worktree(self.tmpdir.name, run_id="run-naive-ts")
+        run_meter(
+            ["event", "run.start", "--idempotency-key", "naive-run-start", "--run-id", "run-naive-ts",
+             "--ts", "2026-07-01T00:00:00", "--base-ref", "origin/main", "--command", "claude"],
+            self.home,
+        )
+        write_transcript(self.projects_dir, "proj", "sess-naive-ts", [
+            assistant_line("sess-naive-ts", "m1", cwd=str(worktree_dir), timestamp="2026-07-15T00:00:00.000Z"),
+        ])
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = next(e for e in read_events(self.home) if e["event_type"] == "usage.message")
+        self.assertEqual(event["run_id"], "run-naive-ts")
 
     def test_ingest_repo_resolved_from_cwd_git_remote(self):
         # PR #27 review round 1 finding 9: `repo` was hardcoded null.

--- a/bin/tests/test_ocw_meter.py
+++ b/bin/tests/test_ocw_meter.py
@@ -142,6 +142,37 @@ def write_transcript(projects_dir, slug, session_id, line_dicts):
     return path
 
 
+def make_ocw_style_worktree(tmp_root, run_id):
+    """Creates a throwaway git repo + linked worktree and writes
+    `run_id` to `<worktree's git-dir>/ocw-run-id`, mirroring bin/ocw's
+    OWN persistence exactly (`git -C "$worktree_dir" rev-parse
+    --absolute-git-dir` then `printf '%s\\n' "$run_id" >"$git_dir/
+    ocw-run-id"` — see bin/ocw around the `generate_run_id` call site).
+    Returns the worktree's absolute path, for use as an assistant
+    line's `cwd`."""
+    counter = getattr(make_ocw_style_worktree, "_counter", 0) + 1
+    make_ocw_style_worktree._counter = counter
+    repo_dir = pathlib.Path(tmp_root) / f"ocw-repo-{counter}"
+    worktree_dir = pathlib.Path(tmp_root) / f"ocw-worktree-{counter}"
+    repo_dir.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo_dir)], check=True)
+    subprocess.run(["git", "-C", str(repo_dir), "config", "user.email", "test@example.com"], check=True)
+    subprocess.run(["git", "-C", str(repo_dir), "config", "user.name", "test"], check=True)
+    (repo_dir / "README.md").write_text("x", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo_dir), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(repo_dir), "commit", "-q", "-m", "init"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo_dir), "worktree", "add", "-q", "-b", f"feature-{counter}", str(worktree_dir)],
+        check=True,
+    )
+    git_dir = subprocess.run(
+        ["git", "-C", str(worktree_dir), "rev-parse", "--absolute-git-dir"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    (pathlib.Path(git_dir) / "ocw-run-id").write_text(run_id + "\n", encoding="utf-8")
+    return worktree_dir
+
+
 def run_ingest(home, projects_dir, args=None, price_dir=None, extra_env=None, timeout=60):
     env = {
         "OCW_METER_CLAUDE_PROJECTS_DIR": str(projects_dir),
@@ -1352,31 +1383,321 @@ class IngestTests(OcwMeterTestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertNotIn("gh should not have been called", result.stderr)
 
-    def test_ingest_run_id_resolved_from_local_run_start_event(self):
-        worktree = "/fixture/worktree"
-        run_meter(
-            # run.start must predate the transcript message's timestamp
-            # (2026-07-15T10:30) for the time-range match in
-            # `resolve_run_id` to find it — a real `ocw` invocation
-            # always records run.start before any work happens.
-            ["event", "run.start", "--idempotency-key", "run1-start", "--run-id", "run1",
-             "--ts", "2026-07-15T09:00:00.000Z",
-             "--worktree", worktree, "--base-ref", "origin/main", "--command", "claude"],
-            self.home,
-        )
+    def test_ingest_run_id_resolved_via_ocw_run_id_file(self):
+        # PR #27 review round 1 finding 3: matching a locally stored
+        # run.start event by (worktree, time range) does NOT work in
+        # real usage, because bin/ocw never passes --worktree to
+        # `ocw-meter event run.start` (it defaults to the ORIGIN
+        # worktree ocw was invoked FROM, not the newly created one the
+        # transcript's own `cwd` points at). The fix reads
+        # <worktree's git-dir>/ocw-run-id directly — exactly what
+        # bin/ocw itself writes right after `git worktree add` and reads
+        # back in `ocw rm`. This test reproduces that real mechanism
+        # with an actual git worktree instead of a fake --worktree value.
+        worktree_dir = make_ocw_style_worktree(self.tmpdir.name, run_id="run-abc123")
         write_transcript(self.projects_dir, "proj", "sess-run", [
-            assistant_line("sess-run", "m1", cwd=worktree, timestamp="2026-07-15T10:30:00.000Z"),
+            assistant_line("sess-run", "m1", cwd=str(worktree_dir)),
         ])
         result = run_ingest(self.home, self.projects_dir)
         self.assertEqual(result.returncode, 0, result.stderr)
         usage_event = next(e for e in read_events(self.home) if e["event_type"] == "usage.message")
-        self.assertEqual(usage_event["run_id"], "run1")
+        self.assertEqual(usage_event["run_id"], "run-abc123")
+
+    def test_ingest_run_id_is_null_when_ocw_run_id_file_absent(self):
+        # No ocw-run-id file was ever written for this cwd (e.g. a
+        # session outside any `ocw` worktree, or one whose worktree was
+        # since removed — git prunes the file along with its metadata
+        # dir). Must be null, not guessed.
+        write_transcript(self.projects_dir, "proj", "sess-norun", [
+            assistant_line("sess-norun", "m1", cwd="/nonexistent/not-a-worktree"),
+        ])
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIsNone(read_events(self.home)[0]["run_id"])
+
+    def test_ingest_pr_number_resolved_via_run_id_bind_using_ocw_run_id_file(self):
+        # End-to-end: pr.bind's run_id must line up with what the fixed
+        # run_id resolution (finding 3) actually produces, since PR
+        # attribution priority ① depends on it (plan §7.4).
+        worktree_dir = make_ocw_style_worktree(self.tmpdir.name, run_id="run-xyz789")
+        run_meter(
+            ["event", "pr.bind", "--idempotency-key", "bind1", "--run-id", "run-xyz789",
+             "--pr-number", "99", "--pr-url", "https://github.com/manemone/dotfiles/pull/99"],
+            self.home,
+        )
+        write_transcript(self.projects_dir, "proj", "sess-run-pr", [
+            assistant_line("sess-run-pr", "m1", cwd=str(worktree_dir)),
+        ])
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = read_events(self.home)[0]
+        self.assertEqual(event["run_id"], "run-xyz789")
+        self.assertEqual(event["pr_number"], 99)
+
+    def test_ingest_repo_resolved_from_cwd_git_remote(self):
+        # PR #27 review round 1 finding 9: `repo` was hardcoded null.
+        worktree_dir = pathlib.Path(self.tmpdir.name) / "repo-with-remote"
+        subprocess.run(["git", "init", "-q", str(worktree_dir)], check=True)
+        subprocess.run(
+            ["git", "-C", str(worktree_dir), "remote", "add", "origin", "https://github.com/manemone/dotfiles.git"],
+            check=True,
+        )
+        write_transcript(self.projects_dir, "proj", "sess-repo", [
+            assistant_line("sess-repo", "m1", cwd=str(worktree_dir)),
+        ])
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(read_events(self.home)[0]["repo"], "manemone/dotfiles")
 
     def test_ingest_refuses_to_operate_inside_a_git_worktree(self):
         write_transcript(self.projects_dir, "proj", "sess-refuse", [assistant_line("sess-refuse", "m1")])
         result = run_ingest(REPO_ROOT / "tmp-test-ocw-meter-ingest-worktree-guard", self.projects_dir)
         self.assertNotEqual(result.returncode, 0)
         self.assertFalse((REPO_ROOT / "tmp-test-ocw-meter-ingest-worktree-guard").exists())
+
+    def test_ingest_normalizes_context_window_suffix_in_model_name(self):
+        write_transcript(self.projects_dir, "proj", "sess-1m", [
+            assistant_line("sess-1m", "m1", model="deepseek-v4-pro[1m]",
+                            input_tokens=1000, cache_read_input_tokens=2000, output_tokens=300),
+        ])
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = read_events(self.home)[0]
+        self.assertEqual(event["model"], "deepseek-v4-pro")
+        # The [1m] suffix must not have blocked the price lookup either.
+        self.assertIsNotNone(event["cost_estimate_usd"])
+        self.assertEqual(event["price_table_version"], "deepseek-2026-08-01")
+
+    def test_ingest_picks_price_table_by_message_timestamp_not_run_date(self):
+        # PR #27 review round 1 finding 4 (plan §17 R5): a price table
+        # added AFTER a message's own date must not retroactively apply
+        # to that message the first time it's ingested.
+        price_dir = pathlib.Path(self.tmpdir.name) / "prices-dated"
+        price_dir.mkdir()
+        (price_dir / "deepseek-2026-07-01.json").write_text(json.dumps({
+            "price_table_version": "deepseek-2026-07-01", "effective_date": "2026-07-01",
+            "models": {"deepseek-v4-pro": {"cache_hit_in": 0.003625, "cache_miss_in": 0.435, "out": 0.87}},
+        }), encoding="utf-8")
+        (price_dir / "deepseek-2026-07-20.json").write_text(json.dumps({
+            "price_table_version": "deepseek-2026-07-20", "effective_date": "2026-07-20",
+            "models": {"deepseek-v4-pro": {"cache_hit_in": 999, "cache_miss_in": 999, "out": 999}},
+        }), encoding="utf-8")
+        write_transcript(self.projects_dir, "proj", "sess-dated", [
+            # Message is from BEFORE the 07-20 table's effective_date —
+            # the 07-01 table must be applied, not 07-20's.
+            assistant_line("sess-dated", "m1", timestamp="2026-07-15T10:00:00.000Z",
+                            input_tokens=1000, cache_read_input_tokens=2000, output_tokens=300),
+        ])
+        result = run_ingest(self.home, self.projects_dir, price_dir=price_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = read_events(self.home)[0]
+        self.assertEqual(event["price_table_version"], "deepseek-2026-07-01")
+        self.assertLess(event["cost_estimate_usd"], 1.0)  # sanity: not the 999/1M-priced table
+
+    def test_ingest_since_does_not_permanently_lose_older_messages(self):
+        # PR #27 review round 1 finding 1: a --since run must not
+        # advance the persisted cursor, or the filtered-out range
+        # becomes permanently unreachable even by a later run with no
+        # --since at all.
+        write_transcript(self.projects_dir, "proj", "sess-since", [
+            assistant_line("sess-since", "old", timestamp="2026-06-01T00:00:00.000Z"),
+            assistant_line("sess-since", "new", timestamp="2026-07-15T00:00:00.000Z"),
+        ])
+        r1 = run_ingest(self.home, self.projects_dir, args=["--since", "2026-07-01T00:00:00Z"])
+        self.assertEqual(r1.returncode, 0, r1.stderr)
+        self.assertEqual({e["message_id"] for e in read_events(self.home)}, {"new"})
+
+        r2 = run_ingest(self.home, self.projects_dir)  # no --since this time
+        self.assertEqual(r2.returncode, 0, r2.stderr)
+        self.assertEqual({e["message_id"] for e in read_events(self.home)}, {"old", "new"})
+
+    def test_ingest_pr_link_survives_across_incremental_runs(self):
+        # PR #27 review round 1 finding 2: a session's `pr-link` must
+        # still apply to messages ingested in a LATER run, even though
+        # the cursor has already moved past the pr-link line itself.
+        session_id = "sess-prlink-incremental"
+        path = write_transcript(self.projects_dir, "proj", session_id, [
+            assistant_line(session_id, "m1"),
+            {"type": "pr-link", "sessionId": session_id, "prNumber": 7,
+             "prUrl": "https://github.com/manemone/dotfiles/pull/7",
+             "prRepository": "manemone/dotfiles", "timestamp": "2026-07-15T10:01:00.000Z"},
+        ])
+        r1 = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(r1.returncode, 0, r1.stderr)
+
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(assistant_line(session_id, "m2", timestamp="2026-07-15T11:00:00.000Z"), ensure_ascii=False) + "\n")
+        r2 = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(r2.returncode, 0, r2.stderr)
+
+        m2_event = next(e for e in read_events(self.home) if e["message_id"] == "m2")
+        self.assertEqual(m2_event["pr_number"], 7)
+
+    def test_ingest_appending_after_truncated_day_file_preserves_new_data_and_records_diagnostic(self):
+        # PR #27 review round 1 finding 7. A pure REPLACE (no new keys)
+        # must preserve the file's original trailing-newline state
+        # exactly; this covers the harder case, appending brand new
+        # events after an already-truncated tail, which must not corrupt
+        # either the old or the new data and must leave a visible trace
+        # instead of silently "healing" the crash marker.
+        write_transcript(self.projects_dir, "proj", "sess-trunc", [
+            assistant_line("sess-trunc", "m1", timestamp="2026-07-15T10:00:00.000Z"),
+        ])
+        r1 = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(r1.returncode, 0, r1.stderr)
+        events_file = self.home / "events" / "2026-07-15.jsonl"
+        # Truncate the stored file mid-write, simulating a crash.
+        original = events_file.read_text(encoding="utf-8")
+        events_file.write_text(original.rstrip("\n")[:-5], encoding="utf-8")
+
+        write_transcript(self.projects_dir, "proj", "sess-trunc", [
+            assistant_line("sess-trunc", "m1", timestamp="2026-07-15T10:00:00.000Z"),
+            assistant_line("sess-trunc", "m2", timestamp="2026-07-15T12:00:00.000Z"),
+        ])
+        r2 = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(r2.returncode, 0, r2.stderr)
+
+        # The new event (m2) must be intact, valid JSON — not merged
+        # into the truncated garbage.
+        validate_result = run_meter(["validate"], self.home)
+        self.assertEqual(validate_result.returncode, 0)
+        m2_events = [e for e in read_events(self.home) if e.get("message_id") == "m2"]
+        self.assertEqual(len(m2_events), 1)
+
+        # The tradeoff (old truncated line can no longer be classified
+        # as "possible crash" once something follows it) is recorded,
+        # not silent.
+        meter_errors = read_meter_errors(self.home)
+        self.assertTrue(any(e.get("stage") == "ingest_appended_after_truncated_day_file" for e in meter_errors))
+
+    def test_ingest_pure_replace_preserves_original_trailing_newline_state(self):
+        # The other half of finding 7: re-ingesting the SAME message
+        # (no new keys, just a replace) on a day file that already lacks
+        # a trailing newline must not add one.
+        write_transcript(self.projects_dir, "proj", "sess-trunc2", [
+            assistant_line("sess-trunc2", "dup1", output_tokens=1, timestamp="2026-07-16T10:00:00.000Z"),
+        ])
+        r1 = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(r1.returncode, 0, r1.stderr)
+        events_file = self.home / "events" / "2026-07-16.jsonl"
+        self.assertTrue(events_file.read_text(encoding="utf-8").endswith("\n"))
+        # Strip the trailing newline to simulate an already-truncated
+        # file whose last (and only) line is otherwise valid JSON.
+        text = events_file.read_text(encoding="utf-8")
+        events_file.write_text(text.rstrip("\n"), encoding="utf-8")
+
+        # Force a re-ingest of the exact same message.id by resetting
+        # the transcript cursor's offset (simulating file rotation).
+        cursor_path = self.home / "state" / "ingest-cursor.json"
+        cursor = json.loads(cursor_path.read_text(encoding="utf-8"))
+        for entry in cursor["files"].values():
+            entry["offset"] = 0
+            entry["inode"] = -1  # force the rotation/reread path
+        cursor_path.write_text(json.dumps(cursor), encoding="utf-8")
+
+        r2 = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(r2.returncode, 0, r2.stderr)
+        self.assertFalse(events_file.read_text(encoding="utf-8").endswith("\n"))
+
+
+class ReportReconcileTests(OcwMeterTestCase):
+    def setUp(self):
+        super().setUp()
+        self.projects_dir = pathlib.Path(self.tmpdir.name) / "claude-projects"
+        self.projects_dir.mkdir(parents=True, exist_ok=True)
+
+    def _seed_deepseek_message(self, message_id="m1", timestamp="2026-07-15T10:00:00.000Z", **kwargs):
+        write_transcript(self.projects_dir, "proj", f"sess-{message_id}", [
+            assistant_line(f"sess-{message_id}", message_id, timestamp=timestamp, **kwargs),
+        ])
+        result = run_ingest(self.home, self.projects_dir)
+        assert result.returncode == 0, result.stderr
+
+    def test_reconcile_reports_tokens_cost_and_known_gaps(self):
+        self._seed_deepseek_message(input_tokens=1000, cache_read_input_tokens=2000,
+                                     cache_creation_input_tokens=0, output_tokens=300)
+        result = run_meter(["report", "--reconcile", "--month", "2026-07", "--json"], self.home,
+                            extra_env={"OCW_METER_CLAUDE_PROJECTS_DIR": str(self.projects_dir), "OCW_METER_INGEST_USE_GH": "0"})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        data = json.loads(result.stdout)
+        self.assertEqual(data["cost_basis"], "estimated — not an invoice")
+        self.assertIn("known_gaps", data)
+        self.assertIn("deepseek-v4-flash", data["known_gaps"])
+        model = data["models"]["deepseek-v4-pro"]
+        self.assertEqual(model["input_tokens"], 1000)
+        self.assertEqual(model["cache_read_input_tokens"], 2000)
+        self.assertEqual(model["output_tokens"], 300)
+        self.assertIsNotNone(model["cost_estimate_usd"])
+        self.assertIsNone(model["provider_total_tokens"])
+        self.assertIsNone(model["coverage_ratio"])
+
+    def test_reconcile_provider_total_computes_coverage_ratio(self):
+        self._seed_deepseek_message(input_tokens=1000, cache_read_input_tokens=9000, output_tokens=0)
+        result = run_meter(
+            ["report", "--reconcile", "--month", "2026-07", "--provider-total", "deepseek-v4-pro=20000", "--json"],
+            self.home,
+            extra_env={"OCW_METER_CLAUDE_PROJECTS_DIR": str(self.projects_dir), "OCW_METER_INGEST_USE_GH": "0"},
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        model = json.loads(result.stdout)["models"]["deepseek-v4-pro"]
+        self.assertEqual(model["provider_total_tokens"], 20000)
+        self.assertAlmostEqual(model["coverage_ratio"], 10000 / 20000)
+
+    def test_reconcile_provider_total_for_model_absent_from_transcript_still_shown(self):
+        # PR #27 review round 1 finding 5: this is the exact "0%
+        # coverage" case (plan §5.10 / ADR-001 §2.2, deepseek-v4-flash)
+        # the whole flag exists to surface — it must not be the one case
+        # that silently disappears from the report.
+        self._seed_deepseek_message()  # only deepseek-v4-pro exists in transcript
+        result = run_meter(
+            ["report", "--reconcile", "--month", "2026-07",
+             "--provider-total", "deepseek-v4-flash=107000000", "--json"],
+            self.home,
+            extra_env={"OCW_METER_CLAUDE_PROJECTS_DIR": str(self.projects_dir), "OCW_METER_INGEST_USE_GH": "0"},
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        models = json.loads(result.stdout)["models"]
+        self.assertIn("deepseek-v4-flash", models)
+        flash = models["deepseek-v4-flash"]
+        self.assertEqual(flash["messages"], 0)
+        self.assertEqual(flash["transcript_total_tokens"], 0)
+        self.assertEqual(flash["provider_total_tokens"], 107000000)
+        self.assertEqual(flash["coverage_ratio"], 0.0)
+        self.assertIsNone(flash["cost_estimate_usd"])
+
+    def test_reconcile_rejects_malformed_month(self):
+        # PR #27 review round 1 finding 6a: report is the fail-loud half
+        # of this CLI (plan §10.1) — a garbage --month must not silently
+        # aggregate a whole year or silently match nothing.
+        for bad_month in ("2026", "07-2026", "2026-13x", "not-a-month"):
+            result = run_meter(["report", "--reconcile", "--month", bad_month], self.home)
+            self.assertNotEqual(result.returncode, 0, f"--month {bad_month!r} should have been rejected")
+
+    def test_reconcile_known_gaps_mentions_utc_month_boundary_caveat(self):
+        # PR #27 review round 1 finding 6b (plan §17 R8): month
+        # boundaries are UTC-fixed; the report must say so rather than
+        # implying exact alignment with a provider's own (e.g. Beijing
+        # time) monthly billing boundary.
+        result = run_meter(["report", "--reconcile", "--month", "2026-07", "--json"], self.home)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("UTC", json.loads(result.stdout)["known_gaps"])
+
+    def test_report_quarantine_counts_are_separated_from_ingest_transcript_quarantine(self):
+        # PR #27 review round 1 finding 10.
+        session_dir = self.projects_dir / "proj"
+        session_dir.mkdir(parents=True)
+        (session_dir / "sess-bad.jsonl").write_text(
+            json.dumps(assistant_line("sess-bad", "m1"), ensure_ascii=False) + "\n"
+            + "{not valid json\n",
+            encoding="utf-8",
+        )
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        report = run_meter(["report", "--json"], self.home)
+        self.assertEqual(report.returncode, 0, report.stderr)
+        data = json.loads(report.stdout)
+        self.assertEqual(data["transcript_lines_quarantined"], 1)
+        self.assertEqual(data["quarantined_lines"], 0)
 
 
 if __name__ == "__main__":

--- a/bin/tests/test_ocw_meter.py
+++ b/bin/tests/test_ocw_meter.py
@@ -1183,6 +1183,47 @@ class IngestTests(OcwMeterTestCase):
         self.assertNotIn("raw_line", quarantined[0])
         self.assertNotIn("THIS-IS-NOT-VALID-JSON", json.dumps(quarantined[0]))
 
+    def test_ingest_since_does_not_duplicate_quarantine_records_on_repeat(self):
+        # PR #27 review round 2 finding "新規2": a --since run never
+        # advances the cursor (round 1 finding 1's fix), so it re-reads
+        # the same broken line on every invocation. Quarantining it
+        # every time would inflate `transcript lines quarantined` in
+        # proportion to how many times --since was run, not how much
+        # source data is actually broken.
+        session_dir = self.projects_dir / "proj"
+        session_dir.mkdir(parents=True)
+        (session_dir / "sess-bad-since.jsonl").write_text(
+            json.dumps(assistant_line("sess-bad-since", "m1", timestamp="2026-07-15T10:00:00.000Z"), ensure_ascii=False) + "\n"
+            + "{broken json\n",
+            encoding="utf-8",
+        )
+        for _ in range(3):
+            result = run_ingest(self.home, self.projects_dir, args=["--since", "2026-01-01T00:00:00Z"])
+            self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(len(read_quarantine(self.home)), 0)  # never persisted under --since
+
+        # A --since-less run finally persists it, exactly once.
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(len(read_quarantine(self.home)), 1)
+        result2 = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result2.returncode, 0, result2.stderr)
+        self.assertEqual(len(read_quarantine(self.home)), 1)  # still just once
+
+    def test_ingest_tolerates_malformed_session_pr_links_state_file(self):
+        # PR #27 review round 2 finding "新規3": a malformed entry in
+        # state/session-pr-links.json (this meter's own state, but
+        # future format changes could leave stale entries around) must
+        # not crash `ingest` with an AttributeError — same
+        # start-fresh-on-corruption policy as load_ingest_cursor.
+        write_transcript(self.projects_dir, "proj", "sess-badstate", [assistant_line("sess-badstate", "m1")])
+        run_ingest(self.home, self.projects_dir)  # creates state/ dir
+        state_path = self.home / "state" / "session-pr-links.json"
+        state_path.write_text(json.dumps({"some-session": "not-a-dict"}), encoding="utf-8")
+
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
     def test_ingest_never_persists_message_content_anywhere(self):
         line = assistant_line("sess-content", "m1")
         line["message"]["content"] = [{"type": "text", "text": "THIS-IS-SECRET-PROMPT-CONTENT"}]
@@ -1414,6 +1455,70 @@ class IngestTests(OcwMeterTestCase):
         result = run_ingest(self.home, self.projects_dir)
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIsNone(read_events(self.home)[0]["run_id"])
+
+    def test_ingest_run_id_not_misattributed_when_worktree_path_is_reused(self):
+        # PR #27 review round 2 finding "新規1": `ocw rm <name>` followed
+        # by `ocw new <name>` reuses the SAME worktree path for a brand
+        # new run. The ocw-run-id file only knows "which run_id does
+        # this PATH belong to now" — a message generated under the OLD
+        # incarnation (never ingested before the path got reused) must
+        # NOT be silently re-attributed to the NEW run_id.
+        worktree_dir = make_ocw_style_worktree(self.tmpdir.name, run_id="RUN-OLD-111")
+        run_meter(
+            ["event", "run.start", "--idempotency-key", "old-run-start", "--run-id", "RUN-OLD-111",
+             "--ts", "2026-07-01T00:00:00.000Z", "--base-ref", "origin/main", "--command", "claude"],
+            self.home,
+        )
+        # The message predates RUN-OLD-111's own run.start? No — it's
+        # AFTER RUN-OLD-111 started but the worktree path gets reused for
+        # a NEW run whose run.start is even later, and the message
+        # predates THAT new run.start — the same worktree path, but the
+        # message belongs to the old incarnation.
+        write_transcript(self.projects_dir, "proj", "sess-reuse", [
+            assistant_line("sess-reuse", "old-run-msg", cwd=str(worktree_dir), timestamp="2026-07-15T00:00:00.000Z"),
+        ])
+        # Simulate `ocw rm` + `ocw new` reusing the same path: overwrite
+        # ocw-run-id with a NEW run_id whose run.start is AFTER the
+        # message's own timestamp.
+        git_dir = subprocess.run(
+            ["git", "-C", str(worktree_dir), "rev-parse", "--absolute-git-dir"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        (pathlib.Path(git_dir) / "ocw-run-id").write_text("RUN-NEW-999\n", encoding="utf-8")
+        run_meter(
+            ["event", "run.start", "--idempotency-key", "new-run-start", "--run-id", "RUN-NEW-999",
+             "--ts", "2026-07-20T00:00:00.000Z", "--base-ref", "origin/main", "--command", "claude"],
+            self.home,
+        )
+
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        # Two run.start events (different days) plus the usage.message
+        # sort chronologically across day-files — pick the message
+        # explicitly rather than assuming index 0.
+        event = next(e for e in read_events(self.home) if e["event_type"] == "usage.message")
+        # Must NOT be attributed to RUN-NEW-999 (the message predates its
+        # run.start) — and RUN-OLD-111's own run.start ts isn't checked
+        # against here since the file no longer points at it at all, so
+        # the only safe answer is null.
+        self.assertIsNone(event["run_id"])
+
+    def test_ingest_run_id_accepted_when_message_is_after_its_run_start(self):
+        # The cross-check must not become overly strict: a message
+        # genuinely generated after its run_id's own run.start must
+        # still resolve normally (this is the common, correct case).
+        worktree_dir = make_ocw_style_worktree(self.tmpdir.name, run_id="run-normal")
+        run_meter(
+            ["event", "run.start", "--idempotency-key", "normal-run-start", "--run-id", "run-normal",
+             "--ts", "2026-07-01T00:00:00.000Z", "--base-ref", "origin/main", "--command", "claude"],
+            self.home,
+        )
+        write_transcript(self.projects_dir, "proj", "sess-normal", [
+            assistant_line("sess-normal", "m1", cwd=str(worktree_dir), timestamp="2026-07-15T00:00:00.000Z"),
+        ])
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(read_events(self.home)[0]["run_id"], "run-normal")
 
     def test_ingest_pr_number_resolved_via_run_id_bind_using_ocw_run_id_file(self):
         # End-to-end: pr.bind's run_id must line up with what the fixed
@@ -1666,12 +1771,20 @@ class ReportReconcileTests(OcwMeterTestCase):
         self.assertIsNone(flash["cost_estimate_usd"])
 
     def test_reconcile_rejects_malformed_month(self):
-        # PR #27 review round 1 finding 6a: report is the fail-loud half
-        # of this CLI (plan §10.1) — a garbage --month must not silently
-        # aggregate a whole year or silently match nothing.
-        for bad_month in ("2026", "07-2026", "2026-13x", "not-a-month"):
+        # PR #27 review round 1 finding 6a (round 2 "持ち越し6a" extended
+        # this to out-of-range month numbers, which the first fix's
+        # digit-count-only regex still let through as a silent 0-result
+        # match): report is the fail-loud half of this CLI (plan §10.1)
+        # — a garbage --month must not silently aggregate a whole year
+        # or silently match nothing.
+        for bad_month in ("2026", "07-2026", "2026-13x", "not-a-month", "2026-13", "2026-00"):
             result = run_meter(["report", "--reconcile", "--month", bad_month], self.home)
             self.assertNotEqual(result.returncode, 0, f"--month {bad_month!r} should have been rejected")
+
+    def test_reconcile_accepts_boundary_valid_months(self):
+        for good_month in ("2026-01", "2026-12"):
+            result = run_meter(["report", "--reconcile", "--month", good_month], self.home)
+            self.assertEqual(result.returncode, 0, f"--month {good_month!r} should have been accepted")
 
     def test_reconcile_known_gaps_mentions_utc_month_boundary_caveat(self):
         # PR #27 review round 1 finding 6b (plan §17 R8): month


### PR DESCRIPTION
## Summary

計画書 `docs/planning/DOC-003_ai-llm-cost-observability_計画.md` の孫3プロンプト（DeepSeek usage の transcript ingest と費用推定）を実装。

- `ocw-meter ingest [--since <ts>]`: `~/.claude/projects/*/*.jsonl` を走査し `usage.message` イベントを生成
  - **`message.id` で重複排除**（同一message.idの複数行はドキュメント順で最後の行=最も完全なusageを採用）
  - **冪等・増分**: `state/ingest-cursor.json` に (inode, size, mtime, offset) を保持。カーソルは書き込み成功後にのみ保存
  - inode変化・サイズ縮小（ローテート/切り詰め）を検出したら該当ファイルを頭から読み直す（重複はキーで吸収）
  - 最終行が不完全な場合は次回に持ち越し、完全だが壊れているJSON行はquarantine（**raw contentは保存しない**）
  - **`message.content` には一切触れない**。抽出は id/model/usage/stop_reason/timestamp/sessionId/gitBranch/cwd/isSidechain/effort のみ
  - role/PR/run_id は Herdr (`herdr pane list`) とこのmeter自身のローカルイベント（run.start/run.end/pr.bind）・transcriptの`pr-link`行から解決。どれも失敗したら`unknown`/`null`（推測しない）
  - 大量メッセージ向けの専用bulk write path（`bulk_write_events`）で、`ocw-meter event`をループで呼ぶことによるO(n²)を回避（ADR-001 §2.2実測: assistant行の59.4%がmessage.id重複）
- `bin/prices/deepseek-2026-08-01.json`: 計画書8.4準拠の価格表（version管理・過去イベントは再計算しない）
- `ocw-meter report --reconcile [--month] [--provider-total <model>=<tokens>]`: model別トークン集計・推定費用・provider管理画面とのcoverage突合。常に `cost_basis: estimated — not an invoice` と既知ギャップ（v4-flash 0%カバー、v4-pro 約89%カバー）を併記
- `bin/README.md`: 既知の限界（カバレッジギャップ）を明記、「全部取れている」と読める記述を排除

## 実データでの検算

実transcript全件（43k+ messages、348ファイル）に対して `ingest` を実行し確認:

- 2回実行しても結果が同一（冪等）
- `validate` で0件quarantine（schema整合）
- 2026-07月分 `report --reconcile`: `deepseek-v4-pro` miss 38,336,862 / hit 5,428,087,040 / out 11,983,028 / **cost $46.7786** — 計画書1章・ADR-001 §2.2 の実測値（$46.78）とほぼ完全一致
- 実行時間: 全43k件で約5秒

## Test plan

- [x] `bin/tests/lint.sh`（bash -n / py_compile / embedded heredoc）OK
- [x] `python3 -m unittest discover -s bin/tests` — 90 tests OK（既存70件 + IngestTests 20件を追加）
- [x] 計画書 T12〜T16 実装（T15はpr-review-loop=孫2スコープのため対象外を明記）
- [x] 実transcriptに対する冪等性・重複排除・カバレッジ数値の検算（上記）
- [x] `message.content` が保存物に一切現れないことをテストで保証
- [x] 外部API（`gh`）を既定で叩かないことをテストで保証（`OCW_METER_INGEST_USE_GH=0`既定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 自己レビュー
- 正当性: 計画書8.4/17章 R1,R2,R5,R8 と ADR-001 §8 孫3指示を確認し、message.id重複排除・冪等増分read・role/PR/run帰属・価格表version管理・cost_basis区別（Anthropic=subscription/DeepSeek=estimated）を全て実装。実transcript全件（43k+件）で計画書1章の実測値（$46.78、v4-pro miss/hit/out）とほぼ完全一致することを確認済み
- エッジケース: 空usage/欠損フィールド→completeness unknown、inode変化・サイズ縮小によるファイルローテート、末尾行未終端（書き込み中）、壊れたJSON行のquarantine（生コンテンツは保存しない）、価格表に無いモデル、Herdr未起動・herdrコマンド不在、gh未使用時のpr_number null、を個別テストでカバー
- テスト: 90 examples, 0 failures（既存70件全パス＋IngestTests 20件を追加）。lint（bash -n / py_compile / embedded heredoc）もOK
- 無関係変更: `git diff --stat` で bin/README.md, bin/ocw-meter, bin/prices/deepseek-2026-08-01.json（新規）, bin/tests/test_ocw_meter.py のみ。禁止ファイル（bin/claude-ds, bin/ocw, claude/skills/**, claude/settings.json）は無変更

## レビュワーに特に見てほしい点
- `bulk_write_events` の同日ファイル一括書き換えロジック（O(n²)回避のための独自書き込みパス）に既存の `write_event` と等価な後勝ちセマンティクスが保たれているか
- `role`/`pr_number`/`run_id` の解決優先順位が計画書7.4の記載順と一致しているか
