### PR TITLE
docs: ルート AGENTS.md / CLAUDE.md を新設

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,85 @@
+# AGENTS.md
+
+## 概要
+
+クロスプラットフォーム（macOS / Linux / WSL2）対応の dotfiles。mise でランタイムを固定し、
+各ツールディレクトリ（`zsh/` `nvim/` `tmux/` `bin/` `claude/`）の `deploy.sh` が
+ユーザーの `$HOME` に symlink を張ることで設定を配布する。
+
+## 最重要ルール
+
+- **人間の明示的指示がない限り、`git merge` / `git pull` / `git reset --hard` /
+  `git push --force` / `gh pr merge` を実行しない。例外はない。**
+  すべての不可逆操作の前にこのルールを照合すること。
+- **deploy スクリプト（`deploy-all.sh` / `uninstall.sh` / `*/deploy.sh`）を実オペレーションで
+  実行しない。** symlink 先はユーザーの実 `$HOME` であり、`~/.zshrc` `~/.tmux.conf`
+  `~/.claude/settings.json` `~/bin/*` を実際に置き換える。動作確認は `--dry-run`、または
+  `HOME` を一時ディレクトリに差し替えたサンドボックスで行うこと。
+- 指示された範囲外の機能を先回りして実装しない。
+- **linter の抑制ディレクティブ（`# shellcheck disable=...` 等）や linter 設定の除外・閾値緩和を、
+  AI の判断で追加しない。** 違反が設計上不合理だと判断した場合は、抑制せず違反内容・対象ファイル・
+  判断理由を人間に報告する。
+
+## ディレクトリ構成
+
+| ディレクトリ | 役割 |
+|---|---|
+| `zsh/` | Zsh 設定（Antidote でプラグイン管理） |
+| `nvim/` | NeoVim 設定（lazy.nvim でプラグイン管理） |
+| `tmux/` | tmux 設定 |
+| `bin/` | スタンドアロンの CLI ツール（`ocw`, `claude-ds`） |
+| `claude/` | Claude Code 向け配布物（設定・スキル） |
+| `shared/` | 全 deploy スクリプトが共有するヘルパー（`helpers.sh`） |
+| `docs/` | このリポジトリ自体の設計文書・計画書 |
+
+各ツールディレクトリは「設定ファイル本体 + `deploy.sh` + `README.md`」という共通構造を持つ。
+
+## 3つの領域（混同しないこと）
+
+| 対象 | 正体 | 誰が読むか |
+|---|---|---|
+| `claude/CLAUDE.md`, `claude/settings.json`, `claude/skills/` | **配布される成果物。** `claude/deploy.sh` がユーザーの `~/.claude/` へ symlink する | このリポジトリを使う人間のマシンの Claude Code |
+| ルート `AGENTS.md` / `CLAUDE.md`（このファイル） | **このリポジトリを開発するためのルール** | このリポジトリで作業する AI |
+| `.claude/settings.json` | リポジトリで作業する AI 向けの permissions を置く場所 | このリポジトリで作業する Claude Code |
+
+`claude/CLAUDE.md`（配布物。個人の口調設定などが入っている）は編集対象が別物であることに注意する。
+
+## デプロイの仕組み
+
+- `deploy-all.sh` が `shared/helpers.sh` を source し、`AVAILABLE_TOOLS` を解決した上で
+  各 `<tool>/deploy.sh` を呼び出す。
+- オプション: `--dry-run` / `--force` / `--only <tools>` / `--backup` / `--no-backup`。
+- symlink は `shared/helpers.sh` の `symlink_backup` 経由で張る。既存ファイルは `.backup` に
+  退避される。`symlink_restore` が uninstall 側の対応関数。
+- `claude/settings.json` だけは symlink ではなく、ベース設定と `settings.machine.json`
+  （マシン固有・非追跡）をマージした**実ファイル**として生成される。マシンごとの上書き設定を
+  git 管理下に置かずに反映するため。
+
+## クロスプラットフォーム制約
+
+- `shared/helpers.sh` は POSIX sh。bashism を書かない。
+- `deploy-all.sh` `uninstall.sh` `*/deploy.sh` も `#!/bin/sh`。
+- `bin/ocw` `bin/claude-ds` は bash（`#!/usr/bin/env bash`）。
+- プラットフォーム分岐は `is_macos` / `is_linux` / `is_wsl` / `get_brew_prefix` を使い、
+  直接 `uname` を叩かない。
+- macOS の BSD 版コマンドと GNU 版の差異（`sed -i`、`date`、`readlink -f` など）に注意する。
+
+## コミット前の必須ステップ
+
+現時点では以下でよい:
+
+- 変更したシェルスクリプトが `sh -n` / `bash -n` で構文エラーにならないこと
+- `--dry-run` で意図した動作になることを確認すること
+
+※ 孫4 で pre-commit が導入された時点でこの節は実際のコマンドに更新される。
+
+## PR 作成時の注意
+
+PR を作る前に `docs/design/` の「プルリクエストの作法」を読むこと
+（孫2 で作成される予定の文書。作成前はこの節の原則に従う）。
+
+## 実装時の注意
+
+- 新しいツールディレクトリを足すときは `shared/helpers.sh` の `AVAILABLE_TOOLS` にも追加する。
+- README は「ルート `README.md`（全体）」と「各ツールの `README.md`（詳細）」の二層構造。
+  片方だけ更新しない。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,11 @@
   すべての不可逆操作の前にこのルールを照合すること。
 - **deploy スクリプト（`deploy-all.sh` / `uninstall.sh` / `*/deploy.sh`）を実オペレーションで
   実行しない。** symlink 先はユーザーの実 `$HOME` であり、`~/.zshrc` `~/.tmux.conf`
-  `~/.claude/settings.json` `~/bin/*` を実際に置き換える。動作確認は `--dry-run`、または
-  `HOME` を一時ディレクトリに差し替えたサンドボックスで行うこと。
+  `~/.claude/settings.json` `~/bin/*` を実際に置き換える。動作確認は `deploy-all.sh --dry-run`、
+  または `HOME` を一時ディレクトリに差し替えたサンドボックスで行うこと。
+  **個別の `<tool>/deploy.sh` は `--dry-run` 引数を解釈しない**（環境変数 `DRY_RUN=1` のみ見る）。
+  `sh zsh/deploy.sh --dry-run` のように直接引数を渡しても無視され実際に書き換えが起きるため、
+  個別スクリプトを dry-run するときは `DRY_RUN=1 sh zsh/deploy.sh` のように環境変数で渡すこと。
 - 指示された範囲外の機能を先回りして実装しない。
 - **linter の抑制ディレクティブ（`# shellcheck disable=...` 等）や linter 設定の除外・閾値緩和を、
   AI の判断で追加しない。** 違反が設計上不合理だと判断した場合は、抑制せず違反内容・対象ファイル・
@@ -38,19 +41,24 @@
 
 | 対象 | 正体 | 誰が読むか |
 |---|---|---|
-| `claude/CLAUDE.md`, `claude/settings.json`, `claude/skills/` | **配布される成果物。** `claude/deploy.sh` がユーザーの `~/.claude/` へ symlink する | このリポジトリを使う人間のマシンの Claude Code |
+| `claude/CLAUDE.md`, `claude/settings.json`, `claude/skills/` | **配布される成果物。** `claude/deploy.sh` がユーザーの `~/.claude/` 配下へ配置する（`CLAUDE.md` と `skills/` は symlink、`settings.json` は生成。詳細は「デプロイの仕組み」参照） | このリポジトリを使う人間のマシンの Claude Code |
 | ルート `AGENTS.md` / `CLAUDE.md`（このファイル） | **このリポジトリを開発するためのルール** | このリポジトリで作業する AI |
 | `.claude/settings.json` | リポジトリで作業する AI 向けの permissions を置く場所 | このリポジトリで作業する Claude Code |
 
-`claude/CLAUDE.md`（配布物。個人の口調設定などが入っている）は編集対象が別物であることに注意する。
+**`claude/CLAUDE.md`（配布物。個人の口調設定などが入っている。ルート `CLAUDE.md` とは別物）は、
+指示が無い限り編集しない。**
 
 ## デプロイの仕組み
 
 - `deploy-all.sh` が `shared/helpers.sh` を source し、`AVAILABLE_TOOLS` を解決した上で
   各 `<tool>/deploy.sh` を呼び出す。
 - オプション: `--dry-run` / `--force` / `--only <tools>` / `--backup` / `--no-backup`。
-- symlink は `shared/helpers.sh` の `symlink_backup` 経由で張る。既存ファイルは `.backup` に
-  退避される。`symlink_restore` が uninstall 側の対応関数。
+- symlink は `shared/helpers.sh` の `symlink_backup` 経由で張る。既存ファイルは `.backup`
+  （既に存在する場合はタイムスタンプ+PID 付きの別名）に退避される。`symlink_restore` が
+  uninstall 側の対応関数。ただし退避の前提は次の2点で崩れる:
+  - `--no-backup`（`BACKUP=0`）指定時は退避されず `rm -f` される
+  - `claude/skills/` は `symlink_backup` を通らない。`claude/deploy.sh` がスキルごとに
+    個別に symlink を張り、退避先も `~/.claude/skills-backup/<名前>.<日時>.<PID>` になる
 - `claude/settings.json` だけは symlink ではなく、ベース設定と `settings.machine.json`
   （マシン固有・非追跡）をマージした**実ファイル**として生成される。マシンごとの上書き設定を
   git 管理下に置かずに反映するため。
@@ -69,17 +77,24 @@
 現時点では以下でよい:
 
 - 変更したシェルスクリプトが `sh -n` / `bash -n` で構文エラーにならないこと
-- `--dry-run` で意図した動作になることを確認すること
+- `deploy-all.sh --dry-run`（個別スクリプトは `DRY_RUN=1 sh <tool>/deploy.sh`）で
+  意図した動作になることを確認すること
 
 ※ 孫4 で pre-commit が導入された時点でこの節は実際のコマンドに更新される。
 
 ## PR 作成時の注意
 
-PR を作る前に `docs/design/` の「プルリクエストの作法」を読むこと
-（孫2 で作成される予定の文書。作成前はこの節の原則に従う）。
+PR を作る前に `docs/design/` の「プルリクエストの作法」を読むこと（孫2 で作成される予定の文書）。
+その文書が無い間は、最低限以下に従う:
+
+- 説明文は「背景・目的・実装内容・レビューで見てほしいところ・テスト結果・今後の予定」の構成で書く
+- ですます調・平易な言葉で書き、セッション内の固有名詞や個人的な文脈を入れない
 
 ## 実装時の注意
 
-- 新しいツールディレクトリを足すときは `shared/helpers.sh` の `AVAILABLE_TOOLS` にも追加する。
+- 新しいツールディレクトリを足すときは `shared/helpers.sh` の `AVAILABLE_TOOLS` に加えて、
+  `uninstall.sh` の `KNOWN_LINKS_<tool>`（生成ファイルがあれば `KNOWN_GENERATED_<tool>` も）にも
+  追加する。これを忘れると `uninstall.sh` は該当ツールを静かにスキップし、張った symlink が
+  ユーザーの `$HOME` に残り続ける。
 - README は「ルート `README.md`（全体）」と「各ツールの `README.md`（詳細）」の二層構造。
   片方だけ更新しない。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Options can be combined:
 
 ```
 ~/.dotfiles/
+├── AGENTS.md                  # Rules for AI agents developing this repo
+├── CLAUDE.md                  # `@AGENTS.md` (Claude Code entry point)
 ├── deploy-all.sh              # Unified deployment orchestrator
 ├── uninstall.sh               # Clean removal of known symlinks, restores backups where available
 ├── Brewfile                   # macOS Homebrew packages (zsh, tmux, git, curl)

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Options can be combined:
 ```
 ~/.dotfiles/
 ├── AGENTS.md                  # Rules for AI agents developing this repo
-├── CLAUDE.md                  # `@AGENTS.md` (Claude Code entry point)
+├── CLAUDE.md                  # Entry point for Claude Code (imports AGENTS.md)
 ├── deploy-all.sh              # Unified deployment orchestrator
 ├── uninstall.sh               # Clean removal of known symlinks, restores backups where available
 ├── Brewfile                   # macOS Homebrew packages (zsh, tmux, git, curl)


### PR DESCRIPTION
## 背景

このリポジトリには AI エージェント向けの支援ファイルがほぼありませんでした。
同一マシンの lora-dataset-forge には十分に整備された AGENTS.md があるため、これを参考に
dotfiles にも同等の基盤を作る計画（傘ブランチ `ai/repo-baseline`）の孫1です。

## このプルリクエストの目的

ルート `AGENTS.md` と `CLAUDE.md` を新設し、このリポジトリで作業する AI 向けのルールブックを
整備します。以降の孫（docs 基盤、DOC-ID ツール、品質ゲート、AI 設定ファイル）は
この `AGENTS.md` の該当節を追記していく前提のため、土台となる位置づけです。

## 実装内容

- ルート `AGENTS.md`（新規）: 概要、最重要ルール、ディレクトリ構成、3つの領域の区別
  （配布物 `claude/` / 開発ルール本体 / このリポジトリ用 permissions）、デプロイの仕組み、
  クロスプラットフォーム制約、コミット前の必須ステップ、PR 作成時の注意、実装時の注意
- ルート `CLAUDE.md`（新規）: `@AGENTS.md` の1行のみ。ルール本体を CLAUDE.md 側に書かず、
  AI 不問設計を徹底しました
- ルート `README.md`（更新）: Directory Structure に `AGENTS.md` / `CLAUDE.md` を追加

参考実装として lora-dataset-forge の AGENTS.md を読みましたが、丸コピはせず、構造だけを借りて
中身は dotfiles（シェルスクリプト + symlink デプロイ + クロスプラットフォーム）用に書き下ろしています。

## レビューで見てほしいところ

- 「コミット前の必須ステップ」と「PR 作成時の注意」は、後続の孫（doc/pre-commit 整備）で
  内容が確定する前提の暫定的な記述にしています。書き方が適切か確認をお願いします
- 「3つの領域」の表の `.claude/settings.json` の説明は、孫5 でファイルが追加される前提のため
  「予定」という書き方を避け、「permissions を置く場所」とだけ書いています

## テスト結果

- `AGENTS.md` に LDF 固有の記述（raw/、canon、VLM、rubocop、bundle exec）が無いことを確認しました
- `CLAUDE.md` が1行のみであることを確認しました
- 記述したパス・関数名（`symlink_backup`、`symlink_restore`、`is_macos`、`is_linux`、`is_wsl`、
  `get_brew_prefix`、`AVAILABLE_TOOLS`、`resolve_tools`）が実在することを `grep` で確認しました
- `deploy-all.sh` / `uninstall.sh` / `shared/helpers.sh` の shebang（`#!/bin/sh`）と
  `bin/ocw` / `bin/claude-ds` の shebang（`#!/usr/bin/env bash`）を確認し、記述と一致しています
- `sh -n deploy-all.sh` / `sh -n uninstall.sh` / `sh -n shared/helpers.sh` が構文エラーなし

## 今後の予定

孫2（docs/ 基盤）が `docs/design/` の規約文書を作成し、この AGENTS.md の参照をリンクに張り替えます。
以降の孫が順次この AGENTS.md の該当節を更新していきます。