### PR TITLE
feat: リポジトリで作業するAI向けの設定を整備

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pre-commit run:*)",
+      "Bash(./tools/doc-id/doc-id check)",
+      "Bash(./tools/doc-id/doc-id verify)",
+      "Bash(ruby tools/doc-id/test/doc_id_test.rb)",
+      "Bash(./deploy-all.sh --dry-run:*)",
+      "Bash(shellcheck:*)",
+      "Bash(shfmt:*)",
+      "Bash(sh -n:*)",
+      "Bash(bash -n:*)",
+      "Bash(bin/tests/lint.sh)",
+      "Bash(python3 -m unittest discover -s bin/tests:*)"
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
     "allow": [
       "Bash(pre-commit run:*)",
@@ -6,6 +7,7 @@
       "Bash(./tools/doc-id/doc-id verify)",
       "Bash(ruby tools/doc-id/test/doc_id_test.rb)",
       "Bash(./deploy-all.sh --dry-run:*)",
+      "Bash(tests/deploy_smoke.sh)",
       "Bash(shellcheck:*)",
       "Bash(shfmt:*)",
       "Bash(sh -n:*)",

--- a/.gitignore
+++ b/.gitignore
@@ -25,11 +25,9 @@ __pycache__/
 *.pyc
 
 # AI tools
-# .claude/settings.json (repo-local AI permissions, see AGENTS.md "3つの領域")
-# is not yet tracked here — adding `!/.claude/settings.json` is pending work
-# tracked in docs/planning/DOC-2608020558_repo-baseline_計画.md's 孫6.
 /.claude/*
 !/.claude/pr-review.yml
+!/.claude/settings.json
 
 # Machine-specific Claude Code settings (not tracked — create from .example)
 claude/settings.machine.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,9 +54,16 @@
 **`claude/CLAUDE.md`（配布物。個人の口調設定などが入っている。ルート `CLAUDE.md` とは別物）は、
 指示が無い限り編集しない。**
 
-`.claude/settings.json` は現時点ではまだ `.gitignore` の `/.claude/*` により追跡対象外（新規作成は
-`docs/planning/DOC-2608020558_repo-baseline_計画.md` の孫6の担当）。孫6で `!/.claude/settings.json`
-を足すまでは、上表の説明はこのファイルが作られた後の設計を指す。
+## AI 支援ツールの設定
+
+ルールの本体は常に `AGENTS.md`（このファイル）に書く。各 AI 製品向けの設定ファイルは、
+ルールを書き写さず `AGENTS.md` を指すことに徹する。新しい AI 製品を使い始めるときも同様に、
+その製品の設定ファイルから `AGENTS.md` を参照する形にする。
+
+| AI 製品 | 設定ファイル | 中身 |
+|---|---|---|
+| Claude Code | `CLAUDE.md` | `@AGENTS.md` の1行のみ |
+| opencode | `opencode.json` | `instructions` に `AGENTS.md` と `docs/design/` 配下の規約文書パスを列挙 |
 
 ## デプロイの仕組み
 

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ for details. `bin/` changes should additionally be verified with
 ├── CLAUDE.md                  # Entry point for Claude Code (imports AGENTS.md)
 ├── opencode.json              # Entry point for opencode (points to AGENTS.md + docs/design/)
 ├── .claude/
-│   └── settings.json          # Permissions for AI agents working in this repo (distinct from
-│                               # claude/, the deployed artifact below)
+│   ├── pr-review.yml          # PR review workflow config (lint_cmd / test_cmd)
+│   └── settings.json          # Permissions for AI agents in this repo (not the deployed claude/)
 ├── deploy-all.sh              # Unified deployment orchestrator
 ├── uninstall.sh               # Clean removal of known symlinks, restores backups where available
 ├── Brewfile                   # macOS Homebrew packages (zsh, tmux, git, curl)

--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ for details. `bin/` changes should additionally be verified with
 ~/.dotfiles/
 ├── AGENTS.md                  # Rules for AI agents developing this repo
 ├── CLAUDE.md                  # Entry point for Claude Code (imports AGENTS.md)
+├── opencode.json              # Entry point for opencode (points to AGENTS.md + docs/design/)
+├── .claude/
+│   └── settings.json          # Permissions for AI agents working in this repo (distinct from
+│                               # claude/, the deployed artifact below)
 ├── deploy-all.sh              # Unified deployment orchestrator
 ├── uninstall.sh               # Clean removal of known symlinks, restores backups where available
 ├── Brewfile                   # macOS Homebrew packages (zsh, tmux, git, curl)

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": [
+    "AGENTS.md",
+    "docs/design/DOC-2608020715_プルリクエストの作法.md",
+    "docs/design/DOC-2608020715-a_シェルスクリプトコーディング方針.md",
+    "docs/design/DOC-2608020715-b_テスト方針.md"
+  ]
+}

--- a/tests/deploy_smoke.sh
+++ b/tests/deploy_smoke.sh
@@ -128,7 +128,7 @@ has_tool() {
 
 # list_repo_skills
 # claude/skills/ 配下の実ディレクトリ名を列挙する（1行1件）。ハードコード
-# すると、孫6で claude/skills/repo-baseline/ 等が増えたときにテストが
+# すると、孫7で claude/skills/repo-baseline/ 等が増えたときにテストが
 # それを検証しないまま緑になり続けるため、claude/deploy.sh 自身と同じ
 # 「ディレクトリを見て自動検出する」入力からテストの期待値を導く。
 list_repo_skills() {

--- a/tools/doc-id/lib/doc_id/tool.rb
+++ b/tools/doc-id/lib/doc_id/tool.rb
@@ -4,7 +4,7 @@ require "open3"
 require "fileutils"
 
 module DocId
-  # 参照検証の走査対象ディレクトリ名。孫6でテンプレート変数化する際にここだけ差し替える想定
+  # 参照検証の走査対象ディレクトリ名。孫7でテンプレート変数化する際にここだけ差し替える想定
   DOCS_DIR_NAME = "docs"
   # テストフィクスチャに意図的な壊れ参照が含まれうるため、参照検証・参照更新の対象から除外するディレクトリ名
   EXCLUDED_DIR_NAMES = %w[test tests spec].freeze


### PR DESCRIPTION
## 背景

dotfilesは、macOS / Linux / WSL2 で共通の開発環境を再現するための設定リポジトリです。
このリポジトリを開発するときにAIエージェントが従うべきルールは `AGENTS.md` にまとまっていますが、
そのルールを実際にAIエージェントへ渡す「配線」の部分が未整備でした。具体的には、このリポジトリで
作業するAI自身に許可してよい操作の一覧（`.claude/settings.json`）が `.gitignore` により追跡対象外
のままになっており、また Claude Code 以外のAI製品（opencode）向けの設定もありませんでした。

## このプルリクエストの目的

このリポジトリで作業するAIエージェント向けの設定を整備し、`AGENTS.md` を唯一のルールの本体として
各AI製品の設定ファイルがそこを参照するだけの構成にします。

## 実装内容

- `.gitignore`: `!/.claude/settings.json` を追加し、追跡対象にしました（`/.claude/*` の除外行自体は
  変更していません。`settings.local.json` は引き続き無視されます）
- `.claude/settings.json`（新規）: このリポジトリで頻出する読み取り・検証系のコマンド
  （`pre-commit run`、`doc-id check/verify`、`deploy-all.sh --dry-run`、`shellcheck`、`shfmt` など）
  を `permissions.allow` に列挙しました。マシン固有の絶対パスや、実HOMEを書き換えうる
  `deploy-all.sh` の非dry-run実行は含めていません
- `opencode.json`（新規）: `instructions` に `AGENTS.md` と、`docs/design/` 配下の3つの規約文書
  （プルリクエストの作法・シェルスクリプトコーディング方針・テスト方針）を列挙しました
- `AGENTS.md`: 「AI 支援ツールの設定」節を追加し、ルールの本体は `AGENTS.md` に一本化し、
  各AI製品の設定ファイルはそこへの参照に徹する方針を明記しました。あわせて「3つの領域」表の
  `.claude/settings.json` の説明から、この作業が未完了であることを示す注記を外しました
- `README.md`: Directory Structure に `.claude/settings.json` と `opencode.json` を追加し、
  配布物である `claude/` ディレクトリと混同しないよう1行添えました

## レビューで見てほしいところ

- `opencode.json` の `instructions` に、`docs/reference/` 配下の文書（ocw-meterのイベントスキーマ等）
  はあえて含めていません。opencodeの `instructions` は起動のたびに毎回読み込まれるため、
  dotfiles全般の開発では出番が少ないこれらの文書を常時読ませるとコンテキストを圧迫すると判断した
  ためです。この判断に異論がないか確認をお願いします
- `docs/README.md` は今回変更していません。「Directory Structure」という節を持つのはルートの
  `README.md` のみで、`docs/README.md` 側には `.claude/` や `opencode.json` について追記すべき
  索引項目が見当たらなかったためです。見落としがあれば指摘してください
- `.claude/settings.json` の `permissions.allow` に列挙したコマンドの過不足を確認してください

## テスト結果

`pre-commit run --all-files` は全項目Passedでした。今回の変更にデプロイ関連スクリプトの変更は
含まれないため `tests/deploy_smoke.sh` は対象外です。

## 今後の予定

このプルリクエストが承認され次第、傘ブランチ `ai/repo-baseline` へ統合します。