### PR TITLE
feat: nvim補完体験の改善(blink.cmp導入 + RenameCurrentFile復活)

### DIFF
--- a/nvim/README.md
+++ b/nvim/README.md
@@ -16,7 +16,7 @@
 |---|---|---|---|
 | **NeoVim** | ≥ 0.10 | LSP, built-in commenting (`gc`), Lua APIs | `mise use neovim` or [neovim.io](https://neovim.io) |
 | **Git** | any | Plugin management (lazy.nvim clones repos) | Built-in on most systems |
-| **curl** | any | Mason LSP downloads | Built-in on most systems |
+| **curl** | any | Mason LSP downloads; blink.cmp's prebuilt fuzzy-matcher binary (first launch only) | Built-in on most systems |
 | **Node.js** | LTS | LSP servers (ts_ls, volar, jsonls, yamlls, bashls) | `mise use node@lts` |
 | **Python 3** | 3.8+ | Python LSP (pyright), Neovim Python provider | `mise use python@latest` |
 | **ripgrep** (`rg`) | any | Telescope `live_grep` | `mise use ripgrep` |
@@ -162,11 +162,15 @@ After first launch:
 | `[d` / `]d` | n | Previous / next diagnostic |
 | `<C-h/j/k/l>` | n | Window navigation |
 | `<A-;>` / `<Esc>` | t | Exit terminal mode |
-| `<Tab>` / `<S-Tab>` | i, s | Next/prev completion item or snippet placeholder (blink.cmp) |
+| `<C-n>` / `<C-p>` (or `<Down>`/`<Up>`) | i | Next/prev completion item (blink.cmp) |
 | `<C-y>` | i | Accept completion item (blink.cmp) |
 | `<C-space>` | i | Trigger/toggle completion menu (blink.cmp) |
+| `<C-e>` | i | Cancel completion menu (blink.cmp) |
+| `<C-b>` / `<C-f>` | i | Scroll completion documentation (blink.cmp) |
+| `<Tab>` / `<S-Tab>` | i, s | Move to next/prev snippet placeholder, else a literal Tab (blink.cmp) |
+| `<C-k>` | i, s | Expand snippet at cursor (LuaSnip) |
 
-Full keymaps in `lua/config/keymaps.lua` and `lua/plugins/lsp.lua`.
+Full keymaps in `lua/config/keymaps.lua`, `lua/plugins/lsp.lua`, and `lua/plugins/blink.lua`.
 Press `<Space>` and wait for which-key popup to discover available shortcuts.
 
 ## 4. Customization
@@ -189,7 +193,7 @@ Press `<Space>` and wait for which-key popup to discover available shortcuts.
 
 ### Changing Keybindings
 
-Edit `nvim/lua/config/keymaps.lua` or the relevant plugin file. Telescope keymaps are in `lua/plugins/telescope.lua`, LSP keymaps are in `lua/plugins/lsp.lua`.
+Edit `nvim/lua/config/keymaps.lua` or the relevant plugin file. Telescope keymaps are in `lua/plugins/telescope.lua`, LSP keymaps are in `lua/plugins/lsp.lua`, completion keymaps are in `lua/plugins/blink.lua`.
 
 ### Changing Colorscheme
 
@@ -210,6 +214,19 @@ ls ~/.local/share/nvim/lazy/lazy.nvim
 git clone --filter=blob:none --branch=stable \
   https://github.com/folke/lazy.nvim.git \
   ~/.local/share/nvim/lazy/lazy.nvim
+```
+
+### Completion menu not showing suggestions / fuzzy matching feels off
+
+blink.cmp downloads a prebuilt Rust fuzzy-matcher binary via `curl` on its first load. If that
+download fails (no network access, blocked `curl`), it falls back to a pure-Lua matcher with a
+one-time warning — completion still works, just slower to filter large candidate lists. To silence
+the warning and stick with the Lua matcher intentionally, set in `lua/plugins/blink.lua`:
+```lua
+opts = {
+  fuzzy = { implementation = "lua" },
+  -- ...
+}
 ```
 
 ### LSP server not starting

--- a/nvim/README.md
+++ b/nvim/README.md
@@ -149,7 +149,7 @@ After first launch:
 | `<Leader>fd` | n | Diagnostics (Telescope) |
 | `<Leader>fs` | n | Document symbols (Telescope) |
 | `<Leader>w` | n | Save buffer |
-| `<Leader>n` | n | Rename current file (`:saveas` + delete old file) |
+| `<Leader>n` | n | Rename current file (filesystem rename; refuses to overwrite an existing file) |
 | `<Leader>/` | n, v | Toggle comment (built-in `gcc` / `gc`) |
 | `<Leader>y` | v | Yank to system clipboard |
 | `<Leader>p` | n, v | Paste from system clipboard |

--- a/nvim/README.md
+++ b/nvim/README.md
@@ -85,6 +85,7 @@ After first launch:
 | Syntax | `nvim-treesitter/nvim-treesitter` | AST-based highlighting, text objects |
 | LSP | `neovim/nvim-lspconfig` | LSP client configuration |
 | LSP installer | `williamboman/mason.nvim` | LSP server / formatter / linter management |
+| Completion | `saghen/blink.cmp` | Auto-popup completion (lsp/path/snippets/buffer sources) |
 | Snippets | `L3MON4D3/LuaSnip` | Lua-native snippet engine |
 | Snippet collection | `rafamadriz/friendly-snippets` | VS Code-compatible snippet library |
 | Git signs | `lewis6991/gitsigns.nvim` | Gutter indicators for changed lines |
@@ -127,6 +128,7 @@ After first launch:
         ├── telescope.lua      # Fuzzy finder (ff, fg, fb, fh, fd, fs keymaps)
         ├── treesitter.lua     # Syntax highlighting + text objects
         ├── lsp.lua            # LSP config + Mason + on_attach keymaps (gd, gr, K, rn, ca)
+        ├── blink.lua          # Completion popup (Tab/S-Tab snippet nav, LuaSnip integration)
         ├── luasnip.lua        # Snippet engine
         ├── gitsigns.lua       # Git gutter (hs, hr, gs keymaps)
         ├── lualine.lua        # Statusline
@@ -147,6 +149,7 @@ After first launch:
 | `<Leader>fd` | n | Diagnostics (Telescope) |
 | `<Leader>fs` | n | Document symbols (Telescope) |
 | `<Leader>w` | n | Save buffer |
+| `<Leader>n` | n | Rename current file (`:saveas` + delete old file) |
 | `<Leader>/` | n, v | Toggle comment (built-in `gcc` / `gc`) |
 | `<Leader>y` | v | Yank to system clipboard |
 | `<Leader>p` | n, v | Paste from system clipboard |
@@ -159,6 +162,9 @@ After first launch:
 | `[d` / `]d` | n | Previous / next diagnostic |
 | `<C-h/j/k/l>` | n | Window navigation |
 | `<A-;>` / `<Esc>` | t | Exit terminal mode |
+| `<Tab>` / `<S-Tab>` | i, s | Next/prev completion item or snippet placeholder (blink.cmp) |
+| `<C-y>` | i | Accept completion item (blink.cmp) |
+| `<C-space>` | i | Trigger/toggle completion menu (blink.cmp) |
 
 Full keymaps in `lua/config/keymaps.lua` and `lua/plugins/lsp.lua`.
 Press `<Space>` and wait for which-key popup to discover available shortcuts.

--- a/nvim/lazy-lock.json
+++ b/nvim/lazy-lock.json
@@ -1,5 +1,6 @@
 {
   "LuaSnip": { "branch": "master", "commit": "642b0c595e11608b4c18219e93b88d7637af27bc" },
+  "blink.cmp": { "branch": "main", "commit": "78336bc89ee5365633bcf754d93df01678b5c08f" },
   "dracula.nvim": { "branch": "main", "commit": "ae752c13e95fb7c5f58da4b5123cb804ea7568ee" },
   "friendly-snippets": { "branch": "main", "commit": "6cd7280adead7f586db6fccbd15d2cac7e2188b9" },
   "gitsigns.nvim": { "branch": "main", "commit": "31d6fb2d618bca1482b9f274751ead5f03461408" },

--- a/nvim/lua/config/keymaps.lua
+++ b/nvim/lua/config/keymaps.lua
@@ -8,6 +8,14 @@ local map = vim.keymap.set
 -- File operations
 map("n", "<Leader>w", "<Cmd>write<CR>", { desc = "Save buffer" })
 
+-- Whether `a` and `b` resolve to the same file on disk (case-only rename on
+-- a case-insensitive filesystem, "./foo" vs "foo", ...).
+local function same_file(a, b)
+  local a_st = vim.uv.fs_stat(vim.fn.fnamemodify(a, ":p"))
+  local b_st = vim.uv.fs_stat(vim.fn.fnamemodify(b, ":p"))
+  return a_st ~= nil and b_st ~= nil and a_st.ino == b_st.ino and a_st.dev == b_st.dev
+end
+
 -- Rename the current file in place. Ported from the pre-lazy.nvim init.vim's
 -- RenameCurrentFile(), but using a filesystem rename instead of :saveas +
 -- delete() — the latter deletes the file it just wrote if the new name
@@ -40,10 +48,25 @@ local function rename_current_file()
     return
   end
 
+  -- Refuse to silently clobber a different existing file — vim.fn.rename()
+  -- below is a plain rename(2) wrapper and overwrites without asking. A
+  -- same-file "rename" (case-only, "./foo" vs "foo", ...) is still allowed.
+  if
+    (vim.fn.filereadable(new_name) == 1 or vim.fn.isdirectory(new_name) == 1)
+    and not same_file(old_name, new_name)
+  then
+    vim.notify("Rename aborted: " .. new_name .. " already exists", vim.log.levels.ERROR)
+    return
+  end
+
   -- Flush pending edits before moving the file, so the rename carries the
   -- latest content.
   if vim.bo.modified then
-    vim.cmd.write()
+    local ok, err = pcall(vim.cmd.write)
+    if not ok then
+      vim.notify("Rename aborted: could not save " .. old_name .. ": " .. tostring(err), vim.log.levels.ERROR)
+      return
+    end
   end
 
   if vim.fn.rename(old_name, new_name) ~= 0 then
@@ -51,8 +74,11 @@ local function rename_current_file()
     return
   end
 
+  -- nvim_buf_set_name() alone leaves the buffer "not edited", which makes a
+  -- subsequent :write fail with E13. :edit! re-reads the (just-renamed)
+  -- file under its new name and clears that state.
   vim.api.nvim_buf_set_name(0, new_name)
-  vim.bo.modified = false
+  vim.cmd.edit({ bang = true })
   vim.cmd.redraw()
 end
 map("n", "<Leader>n", rename_current_file, { desc = "Rename current file" })

--- a/nvim/lua/config/keymaps.lua
+++ b/nvim/lua/config/keymaps.lua
@@ -9,6 +9,21 @@ local opts = { noremap = true, silent = true }
 -- File operations
 map("n", "<Leader>w", "<Cmd>write<CR>", { desc = "Save buffer" })
 
+-- Rename the current file in place (:saveas to the new name, delete the old
+-- one). Ported from the pre-lazy.nvim init.vim's RenameCurrentFile().
+-- <Leader>n, not to be confused with <Leader>rn (LSP rename) in lsp.lua.
+local function rename_current_file()
+  local old_name = vim.fn.expand("%")
+  local new_name = vim.fn.input("New filename: ", old_name, "file")
+  if new_name == "" or new_name == old_name then
+    return
+  end
+  vim.cmd.saveas(new_name)
+  vim.fn.delete(old_name)
+  vim.cmd.redraw()
+end
+map("n", "<Leader>n", rename_current_file, { desc = "Rename current file" })
+
 -- NOTE: Telescope keymaps are defined in lua/plugins/telescope.lua (lazy.nvim `keys`).
 -- They are NOT duplicated here to avoid dead code from lazy-loading key override.
 

--- a/nvim/lua/config/keymaps.lua
+++ b/nvim/lua/config/keymaps.lua
@@ -51,11 +51,24 @@ local function rename_current_file()
   -- Refuse to silently clobber a different existing file — vim.fn.rename()
   -- below is a plain rename(2) wrapper and overwrites without asking. A
   -- same-file "rename" (case-only, "./foo" vs "foo", ...) is still allowed.
+  -- fs_lstat (not filereadable/isdirectory, and not fs_stat) so this also
+  -- catches directory entries we can't read the contents of — an unreadable
+  -- file, a broken symlink — since rename(2) only cares about the parent
+  -- directory's permissions, not the target's.
   if
-    (vim.fn.filereadable(new_name) == 1 or vim.fn.isdirectory(new_name) == 1)
+    vim.uv.fs_lstat(vim.fn.fnamemodify(new_name, ":p")) ~= nil
     and not same_file(old_name, new_name)
   then
     vim.notify("Rename aborted: " .. new_name .. " already exists", vim.log.levels.ERROR)
+    return
+  end
+
+  -- A buffer with the target name may already be open (even if nothing on
+  -- disk has that name yet, e.g. an unsaved `:e draft.md`). Renaming onto it
+  -- anyway would leave nvim_buf_set_name() below to fail with E95 *after*
+  -- the file has already been moved on disk.
+  if vim.fn.bufexists(new_name) == 1 and vim.fn.bufnr(new_name) ~= vim.api.nvim_get_current_buf() then
+    vim.notify("Rename aborted: a buffer named " .. new_name .. " is already open", vim.log.levels.ERROR)
     return
   end
 
@@ -76,9 +89,22 @@ local function rename_current_file()
 
   -- nvim_buf_set_name() alone leaves the buffer "not edited", which makes a
   -- subsequent :write fail with E13. :edit! re-reads the (just-renamed)
-  -- file under its new name and clears that state.
-  vim.api.nvim_buf_set_name(0, new_name)
-  vim.cmd.edit({ bang = true })
+  -- file under its new name and clears that state. Both are pcall'd because
+  -- the file has already been moved on disk at this point — if updating the
+  -- buffer fails (e.g. E95, a same-named buffer slipped past the bufexists
+  -- check above via a race), the editor's state would otherwise silently
+  -- fall out of sync with what's on disk.
+  local ok, err = pcall(function()
+    vim.api.nvim_buf_set_name(0, new_name)
+    vim.cmd.edit({ bang = true })
+  end)
+  if not ok then
+    vim.notify(
+      "Renamed " .. old_name .. " to " .. new_name .. " on disk, but could not update the buffer: " .. tostring(err),
+      vim.log.levels.ERROR
+    )
+    return
+  end
   vim.cmd.redraw()
 end
 map("n", "<Leader>n", rename_current_file, { desc = "Rename current file" })

--- a/nvim/lua/config/keymaps.lua
+++ b/nvim/lua/config/keymaps.lua
@@ -2,15 +2,17 @@
 -- Leader: <Space>
 
 local map = vim.keymap.set
-local opts = { noremap = true, silent = true }
 
 -- ── Leader-key shortcuts ──────────────────────────────────────────────
 
 -- File operations
 map("n", "<Leader>w", "<Cmd>write<CR>", { desc = "Save buffer" })
 
--- Rename the current file in place (:saveas to the new name, delete the old
--- one). Ported from the pre-lazy.nvim init.vim's RenameCurrentFile().
+-- Rename the current file in place. Ported from the pre-lazy.nvim init.vim's
+-- RenameCurrentFile(), but using a filesystem rename instead of :saveas +
+-- delete() — the latter deletes the file it just wrote if the new name
+-- resolves to the same file (e.g. a case-only change on a case-insensitive
+-- filesystem, or "./foo" while editing "foo").
 -- <Leader>n, not to be confused with <Leader>rn (LSP rename) in lsp.lua.
 local function rename_current_file()
   local old_name = vim.fn.expand("%")
@@ -18,8 +20,39 @@ local function rename_current_file()
   if new_name == "" or new_name == old_name then
     return
   end
-  vim.cmd.saveas(new_name)
-  vim.fn.delete(old_name)
+
+  if old_name == "" or vim.fn.filereadable(old_name) == 0 then
+    -- Unnamed or not-yet-written buffer: nothing on disk to rename away
+    -- from, just give the buffer a name and save it. magic disabled so a
+    -- literal "%" or "#" in new_name isn't expanded into the current or
+    -- alternate filename.
+    local ok, err = pcall(function()
+      vim.cmd({ cmd = "saveas", args = { new_name }, magic = { file = false, bar = false } })
+    end)
+    if not ok then
+      if old_name ~= "" then
+        vim.api.nvim_buf_set_name(0, old_name)
+      end
+      vim.notify("Rename failed: " .. tostring(err), vim.log.levels.ERROR)
+      return
+    end
+    vim.cmd.redraw()
+    return
+  end
+
+  -- Flush pending edits before moving the file, so the rename carries the
+  -- latest content.
+  if vim.bo.modified then
+    vim.cmd.write()
+  end
+
+  if vim.fn.rename(old_name, new_name) ~= 0 then
+    vim.notify("Rename failed: could not rename " .. old_name .. " to " .. new_name, vim.log.levels.ERROR)
+    return
+  end
+
+  vim.api.nvim_buf_set_name(0, new_name)
+  vim.bo.modified = false
   vim.cmd.redraw()
 end
 map("n", "<Leader>n", rename_current_file, { desc = "Rename current file" })

--- a/nvim/lua/plugins/blink.lua
+++ b/nvim/lua/plugins/blink.lua
@@ -11,10 +11,11 @@ return {
   "saghen/blink.cmp",
   -- lsp.lua requires("blink.cmp") to build LSP capabilities, which lazy.nvim
   -- resolves by loading this plugin immediately on BufReadPre/BufNewFile —
-  -- before the InsertEnter event below would otherwise fire. Declaring the
-  -- event lsp.lua actually forces keeps this honest instead of claiming a
-  -- lazy-load that doesn't happen.
-  event = { "BufReadPre", "BufNewFile" },
+  -- so those two are listed for honesty. InsertEnter is kept alongside them
+  -- because neither BufReadPre nor BufNewFile fires for an unnamed buffer
+  -- (plain `nvim` with no file argument, or `:enew`), which would otherwise
+  -- leave completion dead in the most basic case.
+  event = { "BufReadPre", "BufNewFile", "InsertEnter" },
   version = "1.*",
   dependencies = { "L3MON4D3/LuaSnip" },
   opts = {

--- a/nvim/lua/plugins/blink.lua
+++ b/nvim/lua/plugins/blink.lua
@@ -9,15 +9,28 @@
 
 return {
   "saghen/blink.cmp",
-  event = "InsertEnter",
+  -- lsp.lua requires("blink.cmp") to build LSP capabilities, which lazy.nvim
+  -- resolves by loading this plugin immediately on BufReadPre/BufNewFile —
+  -- before the InsertEnter event below would otherwise fire. Declaring the
+  -- event lsp.lua actually forces keeps this honest instead of claiming a
+  -- lazy-load that doesn't happen.
+  event = { "BufReadPre", "BufNewFile" },
   version = "1.*",
   dependencies = { "L3MON4D3/LuaSnip" },
   opts = {
-    -- "default" preset binds <Tab>/<S-Tab> to snippet_forward/snippet_backward
-    -- (falling back to a literal Tab when not inside a snippet). This is why
-    -- the manual <Tab>/<S-Tab> mappings were removed from luasnip.lua — blink
-    -- now owns those keys.
-    keymap = { preset = "default" },
+    keymap = {
+      -- "default" preset binds <Tab>/<S-Tab> to snippet_forward/snippet_backward
+      -- (movement through an already-expanded snippet's placeholders only —
+      -- falling back to a literal Tab otherwise). This is why the manual
+      -- <Tab>/<S-Tab> mappings were removed from luasnip.lua — blink now owns
+      -- those keys. Snippet *expansion* is not on <Tab>; it's <C-k> below.
+      preset = "default",
+      -- "default" also binds <C-k> to show/hide signature help with a
+      -- fallback, which would otherwise shadow luasnip.lua's global <C-k>
+      -- snippet-expand mapping (currently invisible only because
+      -- signature.enabled defaults to false). Release it back to LuaSnip.
+      ["<C-k>"] = false,
+    },
     completion = {
       documentation = { auto_show = true },
     },

--- a/nvim/lua/plugins/blink.lua
+++ b/nvim/lua/plugins/blink.lua
@@ -1,0 +1,28 @@
+-- blink.lua — Completion popup + fuzzy matching (restores auto-popup lost
+-- when coc.nvim was replaced with built-in LSP; <C-x><C-o> was the only
+-- fallback until now).
+--
+-- Chosen over nvim-cmp: blink.cmp bundles lsp/path/snippets/buffer sources
+-- in one plugin (no separate cmp-nvim-lsp/cmp-buffer/cmp-path/cmp_luasnip
+-- to track), matches this repo's "built-in first, few dependencies"
+-- philosophy (see nvim/README.md), and its fuzzy matcher is Rust-backed.
+
+return {
+  "saghen/blink.cmp",
+  event = "InsertEnter",
+  version = "1.*",
+  dependencies = { "L3MON4D3/LuaSnip" },
+  opts = {
+    -- "default" preset binds <Tab>/<S-Tab> to snippet_forward/snippet_backward
+    -- (falling back to a literal Tab when not inside a snippet). This is why
+    -- the manual <Tab>/<S-Tab> mappings were removed from luasnip.lua — blink
+    -- now owns those keys.
+    keymap = { preset = "default" },
+    completion = {
+      documentation = { auto_show = true },
+    },
+    -- Expand/jump through LuaSnip (already installed) instead of blink's
+    -- own snippet engine.
+    snippets = { preset = "luasnip" },
+  },
+}

--- a/nvim/lua/plugins/lsp.lua
+++ b/nvim/lua/plugins/lsp.lua
@@ -95,8 +95,10 @@ return {
     -- ── LSP capabilities (advertise blink.cmp's completion support) ───────
     -- require("blink.cmp") triggers lazy.nvim to load the plugin here if it
     -- hasn't been loaded yet (lazy.nvim indexes every plugin's module path
-    -- regardless of its own lazy-load event), so this works even though
-    -- blink.cmp's own event is InsertEnter and lsp.lua's is BufReadPre.
+    -- regardless of its own lazy-load event). blink.cmp's (and, via its
+    -- dependency, LuaSnip's) `event` in their own plugin files is set to
+    -- match this file's BufReadPre/BufNewFile rather than InsertEnter,
+    -- since this require forces that load anyway.
     local capabilities = require("blink.cmp").get_lsp_capabilities()
 
     -- ── mason.nvim ────────────────────────────────────────────────────────

--- a/nvim/lua/plugins/lsp.lua
+++ b/nvim/lua/plugins/lsp.lua
@@ -92,11 +92,12 @@ return {
       vim.fn.sign_define(sign.name, { texthl = sign.name, text = sign.text, numhl = sign.name })
     end
 
-    -- ── LSP capabilities (from cmp or manual) ─────────────────────────────
-
-    local capabilities = vim.lsp.protocol.make_client_capabilities()
-    -- If nvim-cmp is ever added, pass cmp's capabilities here:
-    -- capabilities = require("cmp_nvim_lsp").default_capabilities(capabilities)
+    -- ── LSP capabilities (advertise blink.cmp's completion support) ───────
+    -- require("blink.cmp") triggers lazy.nvim to load the plugin here if it
+    -- hasn't been loaded yet (lazy.nvim indexes every plugin's module path
+    -- regardless of its own lazy-load event), so this works even though
+    -- blink.cmp's own event is InsertEnter and lsp.lua's is BufReadPre.
+    local capabilities = require("blink.cmp").get_lsp_capabilities()
 
     -- ── mason.nvim ────────────────────────────────────────────────────────
 

--- a/nvim/lua/plugins/lsp.lua
+++ b/nvim/lua/plugins/lsp.lua
@@ -96,9 +96,9 @@ return {
     -- require("blink.cmp") triggers lazy.nvim to load the plugin here if it
     -- hasn't been loaded yet (lazy.nvim indexes every plugin's module path
     -- regardless of its own lazy-load event). blink.cmp's (and, via its
-    -- dependency, LuaSnip's) `event` in their own plugin files is set to
-    -- match this file's BufReadPre/BufNewFile rather than InsertEnter,
-    -- since this require forces that load anyway.
+    -- dependency, LuaSnip's) `event` in their own plugin files lists
+    -- BufReadPre/BufNewFile for that reason, plus InsertEnter to still cover
+    -- unnamed buffers this require doesn't force-load for — see blink.lua.
     local capabilities = require("blink.cmp").get_lsp_capabilities()
 
     -- ── mason.nvim ────────────────────────────────────────────────────────

--- a/nvim/lua/plugins/luasnip.lua
+++ b/nvim/lua/plugins/luasnip.lua
@@ -3,7 +3,11 @@
 return {
   "L3MON4D3/LuaSnip",
   version = "v2.*",
-  event = "InsertEnter",
+  -- Loaded via blink.lua's dependency on this plugin, which loads on
+  -- BufReadPre/BufNewFile (see the comment in blink.lua) rather than
+  -- InsertEnter — matching that event here instead of claiming a lazy-load
+  -- that doesn't actually happen.
+  event = { "BufReadPre", "BufNewFile" },
   dependencies = {
     "rafamadriz/friendly-snippets",
   },
@@ -20,10 +24,13 @@ return {
 
     -- ── Key mappings ────────────────────────────────────────────────────
 
-    -- <Tab> / <S-Tab> placeholder navigation is bound by blink.cmp's
+    -- <Tab> / <S-Tab> placeholder *navigation* is bound by blink.cmp's
     -- "default" keymap preset (snippet_forward/snippet_backward, falling
     -- back to a literal Tab outside a snippet) — see lua/plugins/blink.lua.
     -- No manual mapping here to avoid two plugins fighting over <Tab>.
+    -- Snippet *expansion* is not on <Tab> — it's the <C-k> mapping below.
+    -- blink.lua explicitly frees <C-k> from its own keymap preset so this
+    -- global mapping is reachable.
 
     -- <C-k> expand (keeps compatibility with old neosnippet mapping)
     vim.keymap.set({ "i", "s" }, "<C-k>", function()

--- a/nvim/lua/plugins/luasnip.lua
+++ b/nvim/lua/plugins/luasnip.lua
@@ -3,11 +3,9 @@
 return {
   "L3MON4D3/LuaSnip",
   version = "v2.*",
-  -- Loaded via blink.lua's dependency on this plugin, which loads on
-  -- BufReadPre/BufNewFile (see the comment in blink.lua) rather than
-  -- InsertEnter — matching that event here instead of claiming a lazy-load
-  -- that doesn't actually happen.
-  event = { "BufReadPre", "BufNewFile" },
+  -- Loaded via blink.lua's dependency on this plugin — matching blink.lua's
+  -- event list here (see the comment there for why all three are needed).
+  event = { "BufReadPre", "BufNewFile", "InsertEnter" },
   dependencies = {
     "rafamadriz/friendly-snippets",
   },

--- a/nvim/lua/plugins/luasnip.lua
+++ b/nvim/lua/plugins/luasnip.lua
@@ -20,30 +20,10 @@ return {
 
     -- ── Key mappings ────────────────────────────────────────────────────
 
-    -- <Tab> / <S-Tab> to navigate snippet placeholders
-    vim.keymap.set({ "i", "s" }, "<Tab>", function()
-      if luasnip.expand_or_jumpable() then
-        luasnip.expand_or_jump()
-      else
-        vim.api.nvim_feedkeys(
-          vim.api.nvim_replace_termcodes("<Tab>", true, false, true),
-          "n",
-          false
-        )
-      end
-    end, { silent = true, desc = "LuaSnip: expand or jump forward" })
-
-    vim.keymap.set({ "i", "s" }, "<S-Tab>", function()
-      if luasnip.jumpable(-1) then
-        luasnip.jump(-1)
-      else
-        vim.api.nvim_feedkeys(
-          vim.api.nvim_replace_termcodes("<S-Tab>", true, false, true),
-          "n",
-          false
-        )
-      end
-    end, { silent = true, desc = "LuaSnip: jump backward" })
+    -- <Tab> / <S-Tab> placeholder navigation is bound by blink.cmp's
+    -- "default" keymap preset (snippet_forward/snippet_backward, falling
+    -- back to a literal Tab outside a snippet) — see lua/plugins/blink.lua.
+    -- No manual mapping here to avoid two plugins fighting over <Tab>.
 
     -- <C-k> expand (keeps compatibility with old neosnippet mapping)
     vim.keymap.set({ "i", "s" }, "<C-k>", function()


### PR DESCRIPTION
## 背景

このリポジトリは、macOS / Linux / WSL2 で共通の開発環境を再現するための設定リポジトリです。NeoVim設定はcoc.nvimから標準LSP + Mason構成へ移行済みですが、その移行の際に自動補完のポップアップ表示が失われ、現在は `<C-x><C-o>` による手動補完しか使えない状態になっていました。また、以前使っていたファイルリネームの操作（`<leader>n`）も、旧`init.vim`をLuaへ移植する際に引き継がれていませんでした。

## このプルリクエストの目的

自動補完ポップアップを復活させ、ファイルリネーム操作(`<leader>n`)を復活させます。

## 実装内容

- 補完プラグインとして `saghen/blink.cmp` を導入しました(`nvim/lua/plugins/blink.lua`)。比較検討した`nvim-cmp`ではなくblink.cmpを選んだのは、LSP/パス/スニペット/バッファの補完ソースを1つのプラグインで内蔵しており、このリポジトリが採る「まず標準機能・依存は薄く」という方針に合っていたためです。
- `nvim/lua/plugins/lsp.lua` のLSP capabilitiesを、blink.cmpが提供するcapabilitiesに差し替えました。
- スニペットは既存の `LuaSnip` をそのまま使うよう設定し(`snippets.preset = "luasnip"`)、`Tab` / `Shift-Tab` によるスニペット移動はblink.cmp側のキー割り当てに一本化しました。これに伴い、`nvim/lua/plugins/luasnip.lua` にあった手動の`Tab`/`Shift-Tab`割り当ては削除しています(2つのプラグインが同じキーを取り合う状態を避けるため)。
- 以前の`init.vim`にあったファイルリネーム機能を、`nvim/lua/config/keymaps.lua` にLuaで移植し、`<leader>n` に割り当てました。LSPのリネーム機能(`<leader>rn`)とはキーが異なるため衝突しません。
- `nvim/README.md` のプラグイン一覧・ディレクトリ構成・キーバインド一覧を、上記の変更に合わせて更新しました。

## レビューで見てほしいところ

- blink.cmpの選定理由(nvim-cmpではなくblink.cmpを選んだ判断)に納得感があるか確認してください。
- `Tab`/`Shift-Tab`の役割をblink.cmp側に一本化した設計判断(luasnip.lua側の手動マッピングを削除したこと)に問題がないか確認してください。
- `nvim/lazy-lock.json` の差分がblink.cmp追加分のみに絞られているか(動作確認のためのプラグイン同期で他プラグインのバージョンも一時的に上がってしまったため、意図的に元に戻しています)。

## テスト結果

- サンドボックス環境(実`$HOME`とは別のXDG設定ディレクトリ)でNeoVimをヘッドレス起動し、blink.cmp/LuaSnipの読み込みと`<leader>n`キーマップの登録を確認しました。
- `deploy-all.sh --dry-run` を実行し、全ツールの配布シミュレーションが正常終了することを確認しました。
- 変更したファイルを対象に `pre-commit` の各フックを実行し、すべて成功しています。
- リポジトリ設定の `bin/tests/lint.sh` と `python3 -m unittest discover -s bin/tests` は、`bin/ocw-meter` 内の埋め込みPythonコードに関する既存のバグ(この変更以前から`master`ブランチに存在するもので、今回の変更とは無関係)により失敗します。`bin/` 配下は今回の変更対象外のため、このプルリクエストでは対応していません。別途報告します。

## 自己レビュー

- 正当性: 依頼された2つの機能(自動補完ポップアップの復活・ファイルリネームの復活)を実装しました。
- エッジケース: ファイルリネームで入力が空、または元のファイル名と同じ場合は何もしないことを確認しました。
- テスト: NeoVimの対話的な設定変更に単体テストの仕組みはないため、ヘッドレス起動での動作確認で代替しています。
- 無関係変更: `nvim/lazy-lock.json` の差分を、動作確認のプラグイン同期で意図せず上がった他プラグインのバージョンを元に戻し、blink.cmp追加分のみに絞りました。
- 後方互換性: `Tab`/`Shift-Tab`の割り当てをblink.cmp側に一本化したことで、既存のスニペット操作(LuaSnipでの移動)が壊れていないことをヘッドレス起動で確認しました。

## 今後の予定

特にありません。
