### PR TITLE
配布実体レイヤ(世代 + current)を導入し、単純symlink系4ツールを追従させる

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -10,14 +10,7 @@ SCRIPT_DIR=$(
 # --- Resolve distribution source (current generation) ---
 # See AGENTS.md "デプロイの仕組み": standalone runs default to `current`;
 # deploy-all.sh overrides this with the generation it just created.
-if [ -z "${DOTFILES_DEPLOY_SRC:-}" ]; then
-  DOTFILES_DEPLOY_SRC="$(dotfiles_current_link)"
-  if [ ! -e "$DOTFILES_DEPLOY_SRC" ]; then
-    log_error "No distributed generation found (current does not exist yet)."
-    log_error "Run ./deploy-all.sh from the repo root first."
-    exit 1
-  fi
-fi
+resolve_deploy_src
 
 log_hr
 log_info "Deploying: bin"

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -7,6 +7,18 @@ SCRIPT_DIR=$(
 # shellcheck source=SCRIPTDIR/../shared/helpers.sh
 . "$SCRIPT_DIR/../shared/helpers.sh"
 
+# --- Resolve distribution source (current generation) ---
+# See AGENTS.md "デプロイの仕組み": standalone runs default to `current`;
+# deploy-all.sh overrides this with the generation it just created.
+if [ -z "${DOTFILES_DEPLOY_SRC:-}" ]; then
+  DOTFILES_DEPLOY_SRC="$(dotfiles_current_link)"
+  if [ ! -e "$DOTFILES_DEPLOY_SRC" ]; then
+    log_error "No distributed generation found (current does not exist yet)."
+    log_error "Run ./deploy-all.sh from the repo root first."
+    exit 1
+  fi
+fi
+
 log_hr
 log_info "Deploying: bin"
 
@@ -29,9 +41,9 @@ if [ ! -d "$BIN_DIR" ]; then
 fi
 
 # --- Symlink scripts into ~/bin ---
-symlink_backup "$SCRIPT_DIR/ocw" "$BIN_DIR/ocw" || FAIL=1
-symlink_backup "$SCRIPT_DIR/claude-ds" "$BIN_DIR/claude-ds" || FAIL=1
-symlink_backup "$SCRIPT_DIR/ocw-meter" "$BIN_DIR/ocw-meter" || FAIL=1
+symlink_backup "$DOTFILES_DEPLOY_SRC/bin/ocw" "$BIN_DIR/ocw" || FAIL=1
+symlink_backup "$DOTFILES_DEPLOY_SRC/bin/claude-ds" "$BIN_DIR/claude-ds" || FAIL=1
+symlink_backup "$DOTFILES_DEPLOY_SRC/bin/ocw-meter" "$BIN_DIR/ocw-meter" || FAIL=1
 
 if [ "$FAIL" -ne 0 ]; then
   log_error "bin deployment completed with errors."

--- a/deploy-all.sh
+++ b/deploy-all.sh
@@ -133,10 +133,39 @@ if [ "$FORCE" -eq 0 ] && [ "$DRY_RUN" -eq 0 ]; then
   printf '\n'
 fi
 
-# ── Run each tool's deploy script ─────────────────────────────────────
+# ── Build a new generation and switch `current` ────────────────────────
+#
+# A generation always holds the full tool set regardless of --only (see
+# ADR §4.3 / DOC-2608040229) — --only only controls which $HOME symlinks
+# get (re)created below. Every tool's deploy.sh links $HOME through the
+# `current` symlink itself, never through the generation directory, so a
+# later rollback is a single `current` swap (ADR §4.1).
 
 export DRY_RUN
 export BACKUP
+
+DOTFILES_DEPLOY_SRC="$(dotfiles_current_link)"
+export DOTFILES_DEPLOY_SRC
+
+GENERATION_DIR=""
+eval "$(create_generation "$SCRIPT_DIR" "GENERATION_DIR")" || {
+  log_error "Failed to create generation from: $SCRIPT_DIR"
+  exit 1
+}
+log_info "Generation: $GENERATION_DIR"
+
+write_manifest "$GENERATION_DIR" "$SCRIPT_DIR" "generation" || {
+  log_warn "Failed to write .dotfiles-manifest (continuing)."
+}
+
+switch_current "$GENERATION_DIR" || {
+  log_error "Failed to switch current -> $GENERATION_DIR"
+  exit 1
+}
+
+printf '\n'
+
+# ── Run each tool's deploy script ─────────────────────────────────────
 
 OVERALL_OK=0
 
@@ -177,6 +206,10 @@ for _tool in $TOOLS; do
     OVERALL_OK=1
   }
 done
+
+# ── Garbage-collect old generations ────────────────────────────────────
+
+gc_generations
 
 # ── Summary ───────────────────────────────────────────────────────────
 

--- a/nvim/deploy.sh
+++ b/nvim/deploy.sh
@@ -7,6 +7,18 @@ SCRIPT_DIR=$(
 # shellcheck source=SCRIPTDIR/../shared/helpers.sh
 . "$SCRIPT_DIR/../shared/helpers.sh"
 
+# --- Resolve distribution source (current generation) ---
+# See AGENTS.md "デプロイの仕組み": standalone runs default to `current`;
+# deploy-all.sh overrides this with the generation it just created.
+if [ -z "${DOTFILES_DEPLOY_SRC:-}" ]; then
+  DOTFILES_DEPLOY_SRC="$(dotfiles_current_link)"
+  if [ ! -e "$DOTFILES_DEPLOY_SRC" ]; then
+    log_error "No distributed generation found (current does not exist yet)."
+    log_error "Run ./deploy-all.sh from the repo root first."
+    exit 1
+  fi
+fi
+
 CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/nvim"
 CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}"
 DEIN_CACHE="$CACHE_DIR/dein"
@@ -63,9 +75,9 @@ fi
 
 # ── Symlink config files ─────────────────────────────────────────────────
 
-symlink_backup "$SCRIPT_DIR/init.lua" "$CONFIG_DIR/init.lua" || FAIL=1
-symlink_backup "$SCRIPT_DIR/lua" "$CONFIG_DIR/lua" || FAIL=1
-symlink_backup "$SCRIPT_DIR/lazy-lock.json" "$CONFIG_DIR/lazy-lock.json" || FAIL=1
+symlink_backup "$DOTFILES_DEPLOY_SRC/nvim/init.lua" "$CONFIG_DIR/init.lua" || FAIL=1
+symlink_backup "$DOTFILES_DEPLOY_SRC/nvim/lua" "$CONFIG_DIR/lua" || FAIL=1
+symlink_backup "$DOTFILES_DEPLOY_SRC/nvim/lazy-lock.json" "$CONFIG_DIR/lazy-lock.json" || FAIL=1
 
 # ── Clean up old dein.vim symlinks ──────────────────────────────────────
 

--- a/nvim/deploy.sh
+++ b/nvim/deploy.sh
@@ -10,14 +10,7 @@ SCRIPT_DIR=$(
 # --- Resolve distribution source (current generation) ---
 # See AGENTS.md "デプロイの仕組み": standalone runs default to `current`;
 # deploy-all.sh overrides this with the generation it just created.
-if [ -z "${DOTFILES_DEPLOY_SRC:-}" ]; then
-  DOTFILES_DEPLOY_SRC="$(dotfiles_current_link)"
-  if [ ! -e "$DOTFILES_DEPLOY_SRC" ]; then
-    log_error "No distributed generation found (current does not exist yet)."
-    log_error "Run ./deploy-all.sh from the repo root first."
-    exit 1
-  fi
-fi
+resolve_deploy_src
 
 CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/nvim"
 CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}"

--- a/shared/helpers.sh
+++ b/shared/helpers.sh
@@ -416,6 +416,18 @@ create_generation() {
     printf 'exit 1\n'
     return 1
   }
+
+  # Sweep any scratch dirs left behind by a previous run that never reached
+  # its own cleanup (e.g. killed mid-copy) — gc_generations only ever looks
+  # at generations/, so .tmp/ is nobody else's job. This repo assumes a
+  # single user running deploys sequentially, so by definition nothing here
+  # from a prior invocation is still in use.
+  for _cg_stale in "$_cg_prefix/.tmp"/gen.*; do
+    [ -e "$_cg_stale" ] || [ -L "$_cg_stale" ] || continue
+    log_warn "Sweeping leftover scratch directory: $_cg_stale"
+    _dotfiles_safe_rmdir "$_cg_stale" "$_cg_prefix/.tmp"
+  done
+
   _cg_scratch=$(mktemp -d "$_cg_prefix/.tmp/gen.XXXXXX") || {
     log_error "Failed to create a scratch directory under $_cg_prefix/.tmp"
     printf 'exit 1\n'
@@ -437,11 +449,14 @@ create_generation() {
     return 1
   }
 
-  # mktemp -d creates the scratch dir 0700; carry the repo's usual 0755 over
-  # to the generation directory itself so distributed config keeps the same
-  # permissions it had before this scratch-dir mechanism existed (deliberate
-  # choice, not a side effect of mktemp's default mode).
-  chmod 0755 "$_cg_scratch" || log_warn "Failed to set permissions on scratch directory: $_cg_scratch"
+  # mktemp -d always creates the scratch dir 0700, ignoring the user's
+  # umask. Before this scratch-dir mechanism existed, the generation
+  # directory came from a plain `mkdir -p`, whose mode is umask-derived —
+  # so match that instead of hardcoding a mode, or umask 077 (the user's
+  # explicit "keep new things private to me" signal) would get silently
+  # overridden to world-readable 0755.
+  _cg_mode=$(printf '%03o' $((0777 & ~0$(umask))))
+  chmod "$_cg_mode" "$_cg_scratch" || log_warn "Failed to set permissions on scratch directory: $_cg_scratch"
 
   mkdir -p "$_cg_gens_dir" || {
     log_error "Failed to create generations directory: $_cg_gens_dir"

--- a/shared/helpers.sh
+++ b/shared/helpers.sh
@@ -396,6 +396,10 @@ create_generation() {
     # Mirrors the real build below: scratch dir under .tmp/, copy each tool
     # into it, then mv into place — not a direct mkdir+cp into $_cg_dir.
     printf '[DRY-RUN] mkdir -p %s/.tmp\n' "$_cg_prefix" >&2
+    for _cg_stale in "$_cg_prefix/.tmp"/gen.*; do
+      [ -e "$_cg_stale" ] || [ -L "$_cg_stale" ] || continue
+      printf '[DRY-RUN] rm -rf %s (leftover scratch)\n' "$_cg_stale" >&2
+    done
     printf '[DRY-RUN] mktemp -d %s/.tmp/gen.XXXXXX\n' "$_cg_prefix" >&2
     for _cg_t in $AVAILABLE_TOOLS; do
       printf '[DRY-RUN] cp -a %s/%s <scratch>/%s\n' "$_cg_src_tree" "$_cg_t" "$_cg_t" >&2
@@ -424,8 +428,14 @@ create_generation() {
   # from a prior invocation is still in use.
   for _cg_stale in "$_cg_prefix/.tmp"/gen.*; do
     [ -e "$_cg_stale" ] || [ -L "$_cg_stale" ] || continue
-    log_warn "Sweeping leftover scratch directory: $_cg_stale"
-    _dotfiles_safe_rmdir "$_cg_stale" "$_cg_prefix/.tmp"
+    # _dotfiles_safe_rmdir already logs its own warning/error when it
+    # refuses to remove something, so only announce success here — logging
+    # "sweeping" unconditionally before the check would print a contradictory
+    # "sweeping" followed by "refusing" on every deploy for anything it
+    # can't actually remove (e.g. a symlink someone dropped in .tmp/).
+    if _dotfiles_safe_rmdir "$_cg_stale" "$_cg_prefix/.tmp"; then
+      log_warn "Swept leftover scratch directory: $_cg_stale"
+    fi
   done
 
   _cg_scratch=$(mktemp -d "$_cg_prefix/.tmp/gen.XXXXXX") || {

--- a/shared/helpers.sh
+++ b/shared/helpers.sh
@@ -263,14 +263,42 @@ dotfiles_current_link() {
   printf '%s' "$(dotfiles_prefix)/current"
 }
 
-# _dotfiles_symlink_is_repo_owned <dst>
+# resolve_deploy_src
+# Ensures DOTFILES_DEPLOY_SRC is set for a standalone `<tool>/deploy.sh` run
+# (deploy-all.sh always sets it itself before calling any tool script). If
+# unset, defaults to `current`; exits with an explanatory error if `current`
+# doesn't resolve to a generation — distinguishing "nothing there yet" from
+# "current is a broken symlink" (e.g. it still points at a generation that
+# was since GC'd), since those call for different next steps.
+resolve_deploy_src() {
+  [ -n "${DOTFILES_DEPLOY_SRC:-}" ] && return 0
+
+  DOTFILES_DEPLOY_SRC="$(dotfiles_current_link)"
+  if [ ! -e "$DOTFILES_DEPLOY_SRC" ]; then
+    if [ -L "$DOTFILES_DEPLOY_SRC" ]; then
+      log_error "current is a broken symlink: $DOTFILES_DEPLOY_SRC -> $(readlink "$DOTFILES_DEPLOY_SRC")"
+      log_error "The generation it pointed to is gone. Run ./deploy-all.sh from the repo root to create a new one."
+    else
+      log_error "No distributed generation found (current does not exist yet)."
+      log_error "Run ./deploy-all.sh from the repo root first."
+    fi
+    exit 1
+  fi
+}
+
+# _dotfiles_symlink_is_repo_owned <dst> [repo_root]
 # Returns 0 if dst is a symlink whose target lives under the canonical
-# prefix (current-scheme distribution) or under this repo's working tree
-# (pre-migration direct-link scheme, detected via the caller's SCRIPT_DIR).
+# prefix (current-scheme distribution) or under repo_root (pre-migration
+# direct-link scheme). repo_root is an explicit argument rather than
+# something this function infers from a global: what counts as "this
+# repository's working tree" depends on the caller's own context (a
+# tool-scoped deploy.sh vs. a future root-scoped caller), so each call site
+# must state it. Pass "" (or omit it) to skip the working-tree check.
 # Used by symlink_backup to decide whether an existing symlink is a leftover
 # deploy artifact (safe to replace without backup) or user data.
 _dotfiles_symlink_is_repo_owned() {
   _diro_dst="$1"
+  _diro_repo_root="${2:-}"
 
   [ -L "$_diro_dst" ] || return 1
   _diro_target=$(readlink "$_diro_dst")
@@ -280,8 +308,7 @@ _dotfiles_symlink_is_repo_owned() {
     "$_diro_prefix"/*) return 0 ;;
   esac
 
-  if [ -n "${SCRIPT_DIR:-}" ]; then
-    _diro_repo_root="$(dirname "$SCRIPT_DIR")"
+  if [ -n "$_diro_repo_root" ]; then
     case "$_diro_target" in
       "$_diro_repo_root"/*) return 0 ;;
     esac
@@ -298,11 +325,18 @@ _dotfiles_symlink_is_repo_owned() {
 # (via eval, same calling convention as resolve_tools).
 # In DRY_RUN mode, nothing is copied; the would-be path is still emitted so
 # callers can print a coherent plan.
+#
+# On failure, stdout carries a literal "exit 1" (mirroring resolve_tools),
+# because the caller's `eval "$(create_generation ...)"` discards our
+# function return code: a failed command substitution still yields success
+# to eval once its (empty) output is evaluated as a no-op. Emitting "exit 1"
+# is what actually stops the caller.
 create_generation() {
   _cg_src_tree="$1"
   _cg_var="${2:-GENERATION_DIR}"
 
-  _cg_gens_dir="$(dotfiles_prefix)/generations"
+  _cg_prefix="$(dotfiles_prefix)"
+  _cg_gens_dir="$_cg_prefix/generations"
   _cg_sha=$(git -C "$_cg_src_tree" rev-parse --short HEAD 2>/dev/null)
   [ -n "$_cg_sha" ] || _cg_sha="nogit"
   _cg_dir="$_cg_gens_dir/$(date +%Y%m%dT%H%M%S)-$_cg_sha"
@@ -320,23 +354,74 @@ create_generation() {
     return 0
   fi
 
-  mkdir -p "$_cg_dir" || {
-    log_error "Failed to create generation directory: $_cg_dir"
+  if [ -e "$_cg_dir" ]; then
+    # Generation IDs are second-precision (<date>-<short sha>). Two deploys
+    # within the same second from the same commit collide on this path;
+    # `cp -a` into an *existing* directory nests instead of overwriting
+    # (e.g. .../bin/ocw stays stale while the new content lands unseen at
+    # .../bin/bin/ocw), silently distributing stale content while reporting
+    # success. Refuse instead of nesting.
+    log_error "Generation already exists (id collision): $_cg_dir"
+    printf 'exit 1\n'
+    return 1
+  fi
+
+  # Build in a scratch directory OUTSIDE generations/ (gc_generations only
+  # ever lists generations/*, so a half-built attempt left there by a crash
+  # would otherwise be counted as a real generation) and rename into place
+  # once complete. This also keeps the id-collision case above from ever
+  # observing a partially-copied directory.
+  mkdir -p "$_cg_prefix/.tmp" || {
+    log_error "Failed to create scratch directory: $_cg_prefix/.tmp"
+    printf 'exit 1\n'
+    return 1
+  }
+  _cg_scratch=$(mktemp -d "$_cg_prefix/.tmp/gen.XXXXXX") || {
+    log_error "Failed to create a scratch directory under $_cg_prefix/.tmp"
+    printf 'exit 1\n'
     return 1
   }
 
   for _cg_t in $AVAILABLE_TOOLS; do
-    cp -a "$_cg_src_tree/$_cg_t" "$_cg_dir/$_cg_t" || {
-      log_error "Failed to copy '$_cg_t' into generation: $_cg_dir"
+    cp -a "$_cg_src_tree/$_cg_t" "$_cg_scratch/$_cg_t" || {
+      log_error "Failed to copy '$_cg_t' into generation: $_cg_scratch"
+      rm -rf "$_cg_scratch"
+      printf 'exit 1\n'
       return 1
     }
   done
-  cp -a "$_cg_src_tree/shared" "$_cg_dir/shared" || {
-    log_error "Failed to copy 'shared' into generation: $_cg_dir"
+  cp -a "$_cg_src_tree/shared" "$_cg_scratch/shared" || {
+    log_error "Failed to copy 'shared' into generation: $_cg_scratch"
+    rm -rf "$_cg_scratch"
+    printf 'exit 1\n'
     return 1
   }
 
-  log_ok "Created generation: $_cg_dir"
+  mkdir -p "$_cg_gens_dir" || {
+    log_error "Failed to create generations directory: $_cg_gens_dir"
+    rm -rf "$_cg_scratch"
+    printf 'exit 1\n'
+    return 1
+  }
+
+  if [ -e "$_cg_dir" ]; then
+    log_error "Generation already exists (id collision): $_cg_dir"
+    rm -rf "$_cg_scratch"
+    printf 'exit 1\n'
+    return 1
+  fi
+
+  mv "$_cg_scratch" "$_cg_dir" || {
+    log_error "Failed to finalize generation: $_cg_dir"
+    rm -rf "$_cg_scratch"
+    printf 'exit 1\n'
+    return 1
+  }
+
+  # stdout is eval'd by the caller (see the function comment above), so the
+  # success message goes to stderr — mixing it into stdout would feed
+  # "[OK] Created generation: ..." to eval as a command.
+  log_ok "Created generation: $_cg_dir" >&2
   printf '%s="%s"\n' "$_cg_var" "$_cg_dir"
   return 0
 }
@@ -445,7 +530,9 @@ gc_generations() {
   _gc_current_name=$(basename "$_gc_current_target")
 
   _gc_keep="${DOTFILES_KEEP_GENERATIONS:-3}"
-  _gc_names=$(find "$_gc_gens_dir" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort)
+  # No -type filter here: it must enumerate symlinks and stray files too, or
+  # the "-L" guard below (and the total/retention count) never sees them.
+  _gc_names=$(find "$_gc_gens_dir" -mindepth 1 -maxdepth 1 -exec basename {} \; | sort)
 
   _gc_total=0
   for _gc_n in $_gc_names; do
@@ -481,14 +568,18 @@ gc_generations() {
 
     if [ "${DRY_RUN:-0}" -eq 1 ]; then
       printf '[DRY-RUN] rm -rf %s\n' "$_gc_target_dir"
+      _gc_removed=$((_gc_removed + 1))
     else
       if rm -rf "$_gc_target_dir"; then
         log_info "Removed old generation: $_gc_target_dir"
+        _gc_removed=$((_gc_removed + 1))
       else
+        # Do not count a failed removal — counting it would let a later,
+        # removable generation be skipped once `_gc_removed` reaches
+        # `_gc_excess`, leaving more than the configured number kept.
         log_error "Failed to remove old generation: $_gc_target_dir"
       fi
     fi
-    _gc_removed=$((_gc_removed + 1))
   done
 
   return 0
@@ -524,11 +615,19 @@ symlink_backup() {
     return 0
   fi
 
+  # Every current caller is a <tool>/deploy.sh with SCRIPT_DIR=<repo_root>/<tool>,
+  # so its parent is the repo root. This is computed here (not inside
+  # _dotfiles_symlink_is_repo_owned) so the assumption stays visible at the
+  # one place today's callers share, instead of being buried in a shared
+  # helper that a differently-scoped future caller could inherit by accident.
+  _sb_repo_root=""
+  [ -n "${SCRIPT_DIR:-}" ] && _sb_repo_root="$(dirname "$SCRIPT_DIR")"
+
   if [ "${DRY_RUN:-0}" -eq 1 ]; then
     if [ -e "$_dst" ] || [ -L "$_dst" ]; then
       if [ "${BACKUP:-1}" -eq 0 ]; then
         printf '[DRY-RUN] rm -f %s\n' "$_dst"
-      elif _dotfiles_symlink_is_repo_owned "$_dst"; then
+      elif _dotfiles_symlink_is_repo_owned "$_dst" "$_sb_repo_root"; then
         printf '[DRY-RUN] rm -f %s (repo-owned symlink, no backup)\n' "$_dst"
       else
         printf '[DRY-RUN] mv %s %s\n' "$_dst" "$(backup_dst "$_dst")"
@@ -555,7 +654,7 @@ symlink_backup() {
         log_error "Failed to remove: $_dst"
         return 1
       }
-    elif _dotfiles_symlink_is_repo_owned "$_dst"; then
+    elif _dotfiles_symlink_is_repo_owned "$_dst" "$_sb_repo_root"; then
       # A leftover symlink from a previous deploy (either the old direct-
       # to-worktree scheme or a stale current-scheme link) is not user
       # data, so replacing it should not leave a .backup that uninstall.sh

--- a/shared/helpers.sh
+++ b/shared/helpers.sh
@@ -317,6 +317,39 @@ _dotfiles_symlink_is_repo_owned() {
   return 1
 }
 
+# _dotfiles_safe_rmdir <path> <required_prefix>
+# rm -rf path, but only after verifying it's not a symlink, exists, is a
+# real directory, and lives under required_prefix (prefix match) — the
+# three checks "全孫共通の注意" §2 requires before every `rm -rf` in this
+# codebase. The symlink check runs before the existence check on purpose: a
+# broken symlink is -L true but -e false (it follows the dangling target),
+# so checking -e first would silently let a broken symlink slip past this
+# guard entirely. Shared by create_generation (scratch cleanup) and
+# gc_generations (old-generation cleanup) so both go through one path.
+_dotfiles_safe_rmdir() {
+  _dsr_path="$1"
+  _dsr_prefix="$2"
+
+  if [ -L "$_dsr_path" ]; then
+    log_warn "Refusing to remove a symlink: $_dsr_path"
+    return 1
+  fi
+  [ -e "$_dsr_path" ] || return 0
+  if [ ! -d "$_dsr_path" ]; then
+    log_warn "Refusing to remove a non-directory: $_dsr_path"
+    return 1
+  fi
+  case "$_dsr_path" in
+    "$_dsr_prefix"/*) ;;
+    *)
+      log_error "Refusing to remove path outside canonical prefix: $_dsr_path"
+      return 1
+      ;;
+  esac
+
+  rm -rf "$_dsr_path"
+}
+
 # create_generation <src_tree> <var_name>
 # Copies AVAILABLE_TOOLS dirs + shared/ from src_tree into a new dated
 # generation directory under the canonical prefix (cp -a; ignores any
@@ -341,19 +374,9 @@ create_generation() {
   [ -n "$_cg_sha" ] || _cg_sha="nogit"
   _cg_dir="$_cg_gens_dir/$(date +%Y%m%dT%H%M%S)-$_cg_sha"
 
-  if [ "${DRY_RUN:-0}" -eq 1 ]; then
-    # Caller evals our stdout to receive <var_name>=<path> (same convention
-    # as resolve_tools), so the human-readable plan must go to stderr —
-    # mixing it into stdout would feed "[DRY-RUN] ..." text to eval.
-    printf '[DRY-RUN] mkdir -p %s\n' "$_cg_dir" >&2
-    for _cg_t in $AVAILABLE_TOOLS; do
-      printf '[DRY-RUN] cp -a %s/%s %s/%s\n' "$_cg_src_tree" "$_cg_t" "$_cg_dir" "$_cg_t" >&2
-    done
-    printf '[DRY-RUN] cp -a %s/shared %s/shared\n' "$_cg_src_tree" "$_cg_dir" >&2
-    printf '%s="%s"\n' "$_cg_var" "$_cg_dir"
-    return 0
-  fi
-
+  # Checked before the DRY_RUN branch so `--dry-run` reports the same
+  # collision a real run would hit, instead of silently reporting a plan
+  # that would actually fail.
   if [ -e "$_cg_dir" ]; then
     # Generation IDs are second-precision (<date>-<short sha>). Two deploys
     # within the same second from the same commit collide on this path;
@@ -364,6 +387,23 @@ create_generation() {
     log_error "Generation already exists (id collision): $_cg_dir"
     printf 'exit 1\n'
     return 1
+  fi
+
+  if [ "${DRY_RUN:-0}" -eq 1 ]; then
+    # Caller evals our stdout to receive <var_name>=<path> (same convention
+    # as resolve_tools), so the human-readable plan must go to stderr —
+    # mixing it into stdout would feed "[DRY-RUN] ..." text to eval.
+    # Mirrors the real build below: scratch dir under .tmp/, copy each tool
+    # into it, then mv into place — not a direct mkdir+cp into $_cg_dir.
+    printf '[DRY-RUN] mkdir -p %s/.tmp\n' "$_cg_prefix" >&2
+    printf '[DRY-RUN] mktemp -d %s/.tmp/gen.XXXXXX\n' "$_cg_prefix" >&2
+    for _cg_t in $AVAILABLE_TOOLS; do
+      printf '[DRY-RUN] cp -a %s/%s <scratch>/%s\n' "$_cg_src_tree" "$_cg_t" "$_cg_t" >&2
+    done
+    printf '[DRY-RUN] cp -a %s/shared <scratch>/shared\n' "$_cg_src_tree" >&2
+    printf '[DRY-RUN] mv <scratch> %s\n' "$_cg_dir" >&2
+    printf '%s="%s"\n' "$_cg_var" "$_cg_dir"
+    return 0
   fi
 
   # Build in a scratch directory OUTSIDE generations/ (gc_generations only
@@ -385,35 +425,41 @@ create_generation() {
   for _cg_t in $AVAILABLE_TOOLS; do
     cp -a "$_cg_src_tree/$_cg_t" "$_cg_scratch/$_cg_t" || {
       log_error "Failed to copy '$_cg_t' into generation: $_cg_scratch"
-      rm -rf "$_cg_scratch"
+      _dotfiles_safe_rmdir "$_cg_scratch" "$_cg_prefix/.tmp"
       printf 'exit 1\n'
       return 1
     }
   done
   cp -a "$_cg_src_tree/shared" "$_cg_scratch/shared" || {
     log_error "Failed to copy 'shared' into generation: $_cg_scratch"
-    rm -rf "$_cg_scratch"
+    _dotfiles_safe_rmdir "$_cg_scratch" "$_cg_prefix/.tmp"
     printf 'exit 1\n'
     return 1
   }
 
+  # mktemp -d creates the scratch dir 0700; carry the repo's usual 0755 over
+  # to the generation directory itself so distributed config keeps the same
+  # permissions it had before this scratch-dir mechanism existed (deliberate
+  # choice, not a side effect of mktemp's default mode).
+  chmod 0755 "$_cg_scratch" || log_warn "Failed to set permissions on scratch directory: $_cg_scratch"
+
   mkdir -p "$_cg_gens_dir" || {
     log_error "Failed to create generations directory: $_cg_gens_dir"
-    rm -rf "$_cg_scratch"
+    _dotfiles_safe_rmdir "$_cg_scratch" "$_cg_prefix/.tmp"
     printf 'exit 1\n'
     return 1
   }
 
   if [ -e "$_cg_dir" ]; then
     log_error "Generation already exists (id collision): $_cg_dir"
-    rm -rf "$_cg_scratch"
+    _dotfiles_safe_rmdir "$_cg_scratch" "$_cg_prefix/.tmp"
     printf 'exit 1\n'
     return 1
   fi
 
   mv "$_cg_scratch" "$_cg_dir" || {
     log_error "Failed to finalize generation: $_cg_dir"
-    rm -rf "$_cg_scratch"
+    _dotfiles_safe_rmdir "$_cg_scratch" "$_cg_prefix/.tmp"
     printf 'exit 1\n'
     return 1
   }
@@ -505,9 +551,9 @@ switch_current() {
 # Removes generations beyond ${DOTFILES_KEEP_GENERATIONS:-3}, oldest first.
 # Invariants: the generation `current` points at is never removed, and if
 # `current` points outside generations/ (dev mode — see ADR §4.5) nothing
-# is removed at all. Every candidate is re-verified to exist, be a real
-# directory (not a symlink), and live under the canonical prefix before
-# being passed to rm -rf.
+# is removed at all. Deletion goes through _dotfiles_safe_rmdir, which
+# re-verifies each candidate is not a symlink, is a real directory, and
+# lives under the canonical prefix before touching rm -rf.
 gc_generations() {
   _gc_prefix="$(dotfiles_prefix)"
   _gc_gens_dir="$_gc_prefix/generations"
@@ -530,12 +576,35 @@ gc_generations() {
   _gc_current_name=$(basename "$_gc_current_target")
 
   _gc_keep="${DOTFILES_KEEP_GENERATIONS:-3}"
-  # No -type filter here: it must enumerate symlinks and stray files too, or
-  # the "-L" guard below (and the total/retention count) never sees them.
-  _gc_names=$(find "$_gc_gens_dir" -mindepth 1 -maxdepth 1 -exec basename {} \; | sort)
 
+  # Two passes over generations/, deliberately kept separate:
+  #   1. Enumerate every entry (no -type filter) so a stray symlink or file
+  #      dropped in generations/ (e.g. macOS's .DS_Store) still gets a
+  #      warning instead of being silently ignored.
+  #   2. Only entries that pass the not-a-symlink / real-directory checks
+  #      go into `_gc_names` and count toward `_gc_total`. Mixing stray
+  #      entries into the retention count would make each one cost one
+  #      extra *real* generation deleted (the count goes up, but only real
+  #      generations are ever actually removable).
+  # The symlink check runs before -e for the same reason as
+  # _dotfiles_safe_rmdir: a broken symlink is -L true but -e false, so
+  # checking -e first would let it through uncounted and unwarned.
+  _gc_all_names=$(find "$_gc_gens_dir" -mindepth 1 -maxdepth 1 -exec basename {} \; | sort)
+
+  _gc_names=""
   _gc_total=0
-  for _gc_n in $_gc_names; do
+  for _gc_n in $_gc_all_names; do
+    _gc_candidate="$_gc_gens_dir/$_gc_n"
+    if [ -L "$_gc_candidate" ]; then
+      log_warn "Ignoring a symlink in generations/: $_gc_candidate"
+      continue
+    fi
+    if [ ! -d "$_gc_candidate" ]; then
+      log_warn "Ignoring a non-directory in generations/: $_gc_candidate"
+      continue
+    fi
+    _gc_names="$_gc_names
+$_gc_n"
     _gc_total=$((_gc_total + 1))
   done
 
@@ -544,33 +613,17 @@ gc_generations() {
 
   _gc_removed=0
   for _gc_n in $_gc_names; do
+    [ -n "$_gc_n" ] || continue
     [ "$_gc_removed" -lt "$_gc_excess" ] || break
     [ "$_gc_n" = "$_gc_current_name" ] && continue
 
     _gc_target_dir="$_gc_gens_dir/$_gc_n"
 
-    [ -e "$_gc_target_dir" ] || continue
-    if [ -L "$_gc_target_dir" ]; then
-      log_warn "Refusing to GC a symlink: $_gc_target_dir"
-      continue
-    fi
-    if [ ! -d "$_gc_target_dir" ]; then
-      log_warn "Refusing to GC a non-directory: $_gc_target_dir"
-      continue
-    fi
-    case "$_gc_target_dir" in
-      "$_gc_prefix"/*) ;;
-      *)
-        log_error "Refusing to GC path outside canonical prefix: $_gc_target_dir"
-        continue
-        ;;
-    esac
-
     if [ "${DRY_RUN:-0}" -eq 1 ]; then
       printf '[DRY-RUN] rm -rf %s\n' "$_gc_target_dir"
       _gc_removed=$((_gc_removed + 1))
     else
-      if rm -rf "$_gc_target_dir"; then
+      if _dotfiles_safe_rmdir "$_gc_target_dir" "$_gc_prefix"; then
         log_info "Removed old generation: $_gc_target_dir"
         _gc_removed=$((_gc_removed + 1))
       else

--- a/shared/helpers.sh
+++ b/shared/helpers.sh
@@ -239,6 +239,261 @@ get_brew_prefix() {
   fi
 }
 
+# ── Distribution layer (generations + current) ─────────────────────────
+#
+# $HOME never links directly into the working tree. Instead, deploy-all.sh
+# copies the working tree into a dated "generation" directory under the
+# canonical prefix, points a `current` symlink at it, and every tool's
+# deploy.sh links $HOME through `current` (never through the generation
+# directory directly — that indirection is what lets a rollback be a single
+# symlink swap). See ADR DOC-2608040229 for the full rationale.
+
+# dotfiles_prefix
+# Print the canonical prefix that holds generations/ and current.
+dotfiles_prefix() {
+  printf '%s' "${XDG_DATA_HOME:-$HOME/.local/share}/dotfiles"
+}
+
+# dotfiles_current_link
+# Print the path to the `current` symlink (not its resolved target).
+# Tool deploy.sh scripts must link $HOME through this literal path so that
+# a later `current` swap changes what every symlink resolves to without
+# re-linking anything under $HOME.
+dotfiles_current_link() {
+  printf '%s' "$(dotfiles_prefix)/current"
+}
+
+# _dotfiles_symlink_is_repo_owned <dst>
+# Returns 0 if dst is a symlink whose target lives under the canonical
+# prefix (current-scheme distribution) or under this repo's working tree
+# (pre-migration direct-link scheme, detected via the caller's SCRIPT_DIR).
+# Used by symlink_backup to decide whether an existing symlink is a leftover
+# deploy artifact (safe to replace without backup) or user data.
+_dotfiles_symlink_is_repo_owned() {
+  _diro_dst="$1"
+
+  [ -L "$_diro_dst" ] || return 1
+  _diro_target=$(readlink "$_diro_dst")
+  _diro_prefix="$(dotfiles_prefix)"
+
+  case "$_diro_target" in
+    "$_diro_prefix"/*) return 0 ;;
+  esac
+
+  if [ -n "${SCRIPT_DIR:-}" ]; then
+    _diro_repo_root="$(dirname "$SCRIPT_DIR")"
+    case "$_diro_target" in
+      "$_diro_repo_root"/*) return 0 ;;
+    esac
+  fi
+
+  return 1
+}
+
+# create_generation <src_tree> <var_name>
+# Copies AVAILABLE_TOOLS dirs + shared/ from src_tree into a new dated
+# generation directory under the canonical prefix (cp -a; ignores any
+# --only filter — a generation always holds the full tool set, see
+# ADR §4.3). Sets the caller's <var_name> to the generation directory path
+# (via eval, same calling convention as resolve_tools).
+# In DRY_RUN mode, nothing is copied; the would-be path is still emitted so
+# callers can print a coherent plan.
+create_generation() {
+  _cg_src_tree="$1"
+  _cg_var="${2:-GENERATION_DIR}"
+
+  _cg_gens_dir="$(dotfiles_prefix)/generations"
+  _cg_sha=$(git -C "$_cg_src_tree" rev-parse --short HEAD 2>/dev/null)
+  [ -n "$_cg_sha" ] || _cg_sha="nogit"
+  _cg_dir="$_cg_gens_dir/$(date +%Y%m%dT%H%M%S)-$_cg_sha"
+
+  if [ "${DRY_RUN:-0}" -eq 1 ]; then
+    # Caller evals our stdout to receive <var_name>=<path> (same convention
+    # as resolve_tools), so the human-readable plan must go to stderr —
+    # mixing it into stdout would feed "[DRY-RUN] ..." text to eval.
+    printf '[DRY-RUN] mkdir -p %s\n' "$_cg_dir" >&2
+    for _cg_t in $AVAILABLE_TOOLS; do
+      printf '[DRY-RUN] cp -a %s/%s %s/%s\n' "$_cg_src_tree" "$_cg_t" "$_cg_dir" "$_cg_t" >&2
+    done
+    printf '[DRY-RUN] cp -a %s/shared %s/shared\n' "$_cg_src_tree" "$_cg_dir" >&2
+    printf '%s="%s"\n' "$_cg_var" "$_cg_dir"
+    return 0
+  fi
+
+  mkdir -p "$_cg_dir" || {
+    log_error "Failed to create generation directory: $_cg_dir"
+    return 1
+  }
+
+  for _cg_t in $AVAILABLE_TOOLS; do
+    cp -a "$_cg_src_tree/$_cg_t" "$_cg_dir/$_cg_t" || {
+      log_error "Failed to copy '$_cg_t' into generation: $_cg_dir"
+      return 1
+    }
+  done
+  cp -a "$_cg_src_tree/shared" "$_cg_dir/shared" || {
+    log_error "Failed to copy 'shared' into generation: $_cg_dir"
+    return 1
+  }
+
+  log_ok "Created generation: $_cg_dir"
+  printf '%s="%s"\n' "$_cg_var" "$_cg_dir"
+  return 0
+}
+
+# write_manifest <generation_dir> <src_tree> <mode>
+# Writes a plain-text .dotfiles-manifest into generation_dir recording
+# where this generation came from. <mode> is "generation" or "dev".
+write_manifest() {
+  _wm_gen_dir="$1"
+  _wm_src_tree="$2"
+  _wm_mode="$3"
+
+  if [ "${DRY_RUN:-0}" -eq 1 ]; then
+    printf '[DRY-RUN] write manifest -> %s/.dotfiles-manifest\n' "$_wm_gen_dir"
+    return 0
+  fi
+
+  _wm_sha=$(git -C "$_wm_src_tree" rev-parse HEAD 2>/dev/null)
+  [ -n "$_wm_sha" ] || _wm_sha="unknown"
+  _wm_branch=$(git -C "$_wm_src_tree" rev-parse --abbrev-ref HEAD 2>/dev/null)
+  [ -n "$_wm_branch" ] || _wm_branch="unknown"
+
+  _wm_dirty="unknown"
+  if git -C "$_wm_src_tree" rev-parse --git-dir >/dev/null 2>&1; then
+    if [ -z "$(git -C "$_wm_src_tree" status --porcelain 2>/dev/null)" ]; then
+      _wm_dirty="0"
+    else
+      _wm_dirty="1"
+    fi
+  fi
+
+  _wm_linked_worktree="0"
+  is_linked_worktree "$_wm_src_tree" && _wm_linked_worktree="1"
+
+  _wm_host=$(uname -n 2>/dev/null)
+  [ -n "$_wm_host" ] || _wm_host="unknown"
+
+  {
+    printf 'deployed_at: %s\n' "$(date +%Y-%m-%dT%H:%M:%S%z)"
+    printf 'source_tree: %s\n' "$_wm_src_tree"
+    printf 'commit_sha: %s\n' "$_wm_sha"
+    printf 'branch: %s\n' "$_wm_branch"
+    printf 'dirty: %s\n' "$_wm_dirty"
+    printf 'linked_worktree: %s\n' "$_wm_linked_worktree"
+    printf 'mode: %s\n' "$_wm_mode"
+    printf 'hostname: %s\n' "$_wm_host"
+  } >"$_wm_gen_dir/.dotfiles-manifest" || {
+    log_error "Failed to write manifest: $_wm_gen_dir/.dotfiles-manifest"
+    return 1
+  }
+  return 0
+}
+
+# switch_current <target_dir>
+# Point the `current` symlink at target_dir using `ln -sfn` (not atomic —
+# see ADR §4.7 for why mv -T/-h was rejected).
+switch_current() {
+  _sc_target="$1"
+  _sc_link="$(dotfiles_current_link)"
+  _sc_parent="$(dirname "$_sc_link")"
+
+  if [ "${DRY_RUN:-0}" -eq 1 ]; then
+    printf '[DRY-RUN] mkdir -p %s\n' "$_sc_parent"
+    printf '[DRY-RUN] ln -sfn %s %s\n' "$_sc_target" "$_sc_link"
+    return 0
+  fi
+
+  mkdir -p "$_sc_parent" || {
+    log_error "Failed to create directory: $_sc_parent"
+    return 1
+  }
+  ln -sfn "$_sc_target" "$_sc_link" || {
+    log_error "Failed to switch current -> $_sc_target"
+    return 1
+  }
+  log_ok "current -> $_sc_target"
+  return 0
+}
+
+# gc_generations
+# Removes generations beyond ${DOTFILES_KEEP_GENERATIONS:-3}, oldest first.
+# Invariants: the generation `current` points at is never removed, and if
+# `current` points outside generations/ (dev mode — see ADR §4.5) nothing
+# is removed at all. Every candidate is re-verified to exist, be a real
+# directory (not a symlink), and live under the canonical prefix before
+# being passed to rm -rf.
+gc_generations() {
+  _gc_prefix="$(dotfiles_prefix)"
+  _gc_gens_dir="$_gc_prefix/generations"
+  _gc_link="$(dotfiles_current_link)"
+
+  [ -d "$_gc_gens_dir" ] || return 0
+
+  _gc_current_target=""
+  if [ -L "$_gc_link" ]; then
+    _gc_current_target=$(readlink "$_gc_link")
+  fi
+
+  case "$_gc_current_target" in
+    "$_gc_gens_dir"/*) ;;
+    *)
+      log_info "Dev mode (or no current yet) — skipping generation GC."
+      return 0
+      ;;
+  esac
+  _gc_current_name=$(basename "$_gc_current_target")
+
+  _gc_keep="${DOTFILES_KEEP_GENERATIONS:-3}"
+  _gc_names=$(find "$_gc_gens_dir" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort)
+
+  _gc_total=0
+  for _gc_n in $_gc_names; do
+    _gc_total=$((_gc_total + 1))
+  done
+
+  _gc_excess=$((_gc_total - _gc_keep))
+  [ "$_gc_excess" -gt 0 ] || return 0
+
+  _gc_removed=0
+  for _gc_n in $_gc_names; do
+    [ "$_gc_removed" -lt "$_gc_excess" ] || break
+    [ "$_gc_n" = "$_gc_current_name" ] && continue
+
+    _gc_target_dir="$_gc_gens_dir/$_gc_n"
+
+    [ -e "$_gc_target_dir" ] || continue
+    if [ -L "$_gc_target_dir" ]; then
+      log_warn "Refusing to GC a symlink: $_gc_target_dir"
+      continue
+    fi
+    if [ ! -d "$_gc_target_dir" ]; then
+      log_warn "Refusing to GC a non-directory: $_gc_target_dir"
+      continue
+    fi
+    case "$_gc_target_dir" in
+      "$_gc_prefix"/*) ;;
+      *)
+        log_error "Refusing to GC path outside canonical prefix: $_gc_target_dir"
+        continue
+        ;;
+    esac
+
+    if [ "${DRY_RUN:-0}" -eq 1 ]; then
+      printf '[DRY-RUN] rm -rf %s\n' "$_gc_target_dir"
+    else
+      if rm -rf "$_gc_target_dir"; then
+        log_info "Removed old generation: $_gc_target_dir"
+      else
+        log_error "Failed to remove old generation: $_gc_target_dir"
+      fi
+    fi
+    _gc_removed=$((_gc_removed + 1))
+  done
+
+  return 0
+}
+
 # ── Filesystem helpers ────────────────────────────────────────────────
 
 # backup_dst <dst>
@@ -273,6 +528,8 @@ symlink_backup() {
     if [ -e "$_dst" ] || [ -L "$_dst" ]; then
       if [ "${BACKUP:-1}" -eq 0 ]; then
         printf '[DRY-RUN] rm -f %s\n' "$_dst"
+      elif _dotfiles_symlink_is_repo_owned "$_dst"; then
+        printf '[DRY-RUN] rm -f %s (repo-owned symlink, no backup)\n' "$_dst"
       else
         printf '[DRY-RUN] mv %s %s\n' "$_dst" "$(backup_dst "$_dst")"
       fi
@@ -294,6 +551,16 @@ symlink_backup() {
   if [ -e "$_dst" ] || [ -L "$_dst" ]; then
     if [ "${BACKUP:-1}" -eq 0 ]; then
       log_warn "Removing existing (backup disabled): $_dst"
+      rm -f "$_dst" || {
+        log_error "Failed to remove: $_dst"
+        return 1
+      }
+    elif _dotfiles_symlink_is_repo_owned "$_dst"; then
+      # A leftover symlink from a previous deploy (either the old direct-
+      # to-worktree scheme or a stale current-scheme link) is not user
+      # data, so replacing it should not leave a .backup that uninstall.sh
+      # would later "restore" as if it were the user's original file.
+      log_info "Replacing repo-owned symlink (no backup needed): $_dst"
       rm -f "$_dst" || {
         log_error "Failed to remove: $_dst"
         return 1

--- a/tests/deploy_smoke.sh
+++ b/tests/deploy_smoke.sh
@@ -154,6 +154,23 @@ current_target_for() {
   readlink "$(dotfiles_prefix_for "$1")/current" 2>/dev/null
 }
 
+# wait_for_next_second
+# 世代IDは秒精度（<date +%Y%m%dT%H%M%S>-<sha>）なので、意図的に世代を
+# 増やしたい再デプロイの間には最低1秒空ける必要がある。固定の `sleep 1`
+# は「1回目の date 呼び出し直後」ではなく「テストコードがこの行に来た
+# 時点」から数えるため、1回目のdeploy内の処理時間や実行環境の負荷次第
+# では計算上ぎりぎり足りず、まれに同一秒に収まって世代ID衝突を起こす
+# （衝突自体は仕様通り正しく拒否されるが、テストの意図は「増える」側の
+# 検証なので偽陽性の失敗になる）。秒の値が実際に変わるまで待つことで、
+# タイミングに依存せず確実に次の秒へ進める。
+wait_for_next_second() {
+  local start
+  start="$(date +%s)"
+  while [ "$(date +%s)" = "$start" ]; do
+    sleep 0.1
+  done
+}
+
 # copy_repo_snapshot <dest_dir>
 # deploy-all.sh が世代へコピーする対象一式（全ツールディレクトリ + shared/）
 # と deploy-all.sh 自身を dest_dir へコピーする。「ソースツリー消失耐性」
@@ -323,8 +340,8 @@ EOF
   # --- 冪等性: 同じ内容で2回目を実行しても壊れない ---
   # 世代IDは秒精度（<date>-<sha>）なので、同一秒内の再デプロイは同じ内容
   # でも世代IDが衝突しうる（衝突時は上書きせずエラーにする仕様。指摘3）。
-  # 1秒空けてから2回目を実行する。
-  sleep 1
+  # 秒が変わるまで待ってから2回目を実行する。
+  wait_for_next_second
   out="$(run_deploy "$sbx" --force --only "$TOOLS" 2>&1)"
   rc=$?
   if [ "$rc" -ne 0 ]; then
@@ -500,8 +517,9 @@ scenario_edit_isolation() {
   fi
 
   # 世代IDは秒精度（<date>-<sha>）なので、同一秒内の再デプロイは世代が
-  # 衝突しうる。1秒空けてから再デプロイし、編集が反映されることを確認する。
-  sleep 1
+  # 衝突しうる。秒が変わるまで待ってから再デプロイし、編集が反映される
+  # ことを確認する。
+  wait_for_next_second
   out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --force --only bin 2>&1)"
   rc=$?
   if [ "$rc" -ne 0 ]; then
@@ -542,7 +560,7 @@ scenario_generation_gc() {
   fi
   first_target="$(current_target_for "$sbx")"
 
-  sleep 1
+  wait_for_next_second
   out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --force --only bin 2>&1)"
   rc=$?
   if [ "$rc" -ne 0 ]; then
@@ -570,7 +588,7 @@ scenario_generation_gc() {
   i=0
   while [ "$i" -lt 3 ]; do
     i=$((i + 1))
-    sleep 1
+    wait_for_next_second
     out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --force --only bin 2>&1)"
     rc=$?
     if [ "$rc" -ne 0 ]; then

--- a/tests/deploy_smoke.sh
+++ b/tests/deploy_smoke.sh
@@ -105,11 +105,26 @@ sandbox_env() {
   )
 }
 
+# EXTRA_ENV
+# run_deploy / run_deploy_from に渡す追加の環境変数。シナリオ関数が呼び出し
+# 前にセットし、呼び出し後に空へ戻す運用とする（例: 世代のGCを検証するため
+# DOTFILES_KEEP_GENERATIONS を上書きするシナリオ）。
+EXTRA_ENV=()
+
+# run_deploy_from <deploy_all.sh のパス> <sbx> [引数...]
+# REPO_ROOT の deploy-all.sh 以外（使い捨てのコピーツリーなど）から
+# サンドボックスへ deploy するためのバリエーション。
+run_deploy_from() {
+  local deploy_all="$1" sbx="$2"
+  shift 2
+  sandbox_env "$sbx"
+  env "${SANDBOX_ENV[@]}" "${EXTRA_ENV[@]}" "$deploy_all" "$@"
+}
+
 run_deploy() {
   local sbx="$1"
   shift
-  sandbox_env "$sbx"
-  env "${SANDBOX_ENV[@]}" "$REPO_ROOT/deploy-all.sh" "$@"
+  run_deploy_from "$REPO_ROOT/deploy-all.sh" "$sbx" "$@"
 }
 
 run_uninstall() {
@@ -124,6 +139,33 @@ has_tool() {
     *",$1,"*) return 0 ;;
     *) return 1 ;;
   esac
+}
+
+# dotfiles_prefix_for <sbx>
+# shared/helpers.sh の dotfiles_prefix() と同じ計算をテスト側で再現する
+# （XDG_DATA_HOME は sandbox_env が $sbx/.local/share に差し替える）。
+dotfiles_prefix_for() {
+  printf '%s/.local/share/dotfiles' "$1"
+}
+
+# current_target_for <sbx>
+# サンドボックス内の current シンボリックリンクの読み取り先を返す。
+current_target_for() {
+  readlink "$(dotfiles_prefix_for "$1")/current" 2>/dev/null
+}
+
+# copy_repo_snapshot <dest_dir>
+# deploy-all.sh が世代へコピーする対象一式（全ツールディレクトリ + shared/）
+# と deploy-all.sh 自身を dest_dir へコピーする。「ソースツリー消失耐性」
+# 「編集分離」シナリオで、REPO_ROOT とは別の使い捨てツリーから deploy し、
+# そのツリーを消す・書き換えるために使う。
+copy_repo_snapshot() {
+  local dest="$1" name
+  mkdir -p "$dest"
+  for name in zsh nvim tmux bin claude shared; do
+    cp -a "$REPO_ROOT/$name" "$dest/$name"
+  done
+  cp -a "$REPO_ROOT/deploy-all.sh" "$dest/deploy-all.sh"
 }
 
 # list_repo_skills
@@ -211,13 +253,40 @@ scenario_backup_symlink_idempotent_uninstall() {
   pass "deploy-all.sh --force --only $TOOLS が成功"
 
   if has_tool bin; then
-    assert_symlink "$sbx/bin/ocw" "$REPO_ROOT/bin/ocw"
-    assert_symlink "$sbx/bin/claude-ds" "$REPO_ROOT/bin/claude-ds"
+    local prefix gen_target
+    prefix="$(dotfiles_prefix_for "$sbx")"
+
+    # $HOME 側の symlink は current を経由する固定パスを指す（世代ディレク
+    # トリを直接指さない）。current の付け替えだけで全リンクの向き先が
+    # 一斉に切り替わる、という世代方式の要になっている（ADR §4.1）。
+    assert_symlink "$sbx/bin/ocw" "$prefix/current/bin/ocw"
+    assert_symlink "$sbx/bin/claude-ds" "$prefix/current/bin/claude-ds"
     assert_exists "$sbx/bin/ocw.backup"
     if [ "$(cat "$sbx/bin/ocw.backup" 2>/dev/null)" = "dummy-ocw" ]; then
       pass "既存ファイルの中身が退避先に保存されている: $sbx/bin/ocw.backup"
     else
       fail "既存ファイルの中身が退避先に保存されている: $sbx/bin/ocw.backup"
+    fi
+
+    if [ -L "$prefix/current" ]; then
+      pass "current が symlink として存在する: $prefix/current"
+    else
+      fail "current が symlink として存在する: $prefix/current"
+    fi
+    gen_target="$(current_target_for "$sbx")"
+    case "$gen_target" in
+      "$prefix/generations/"*)
+        pass "current が generations/ 配下を指している: $gen_target"
+        ;;
+      *)
+        fail "current が generations/ 配下を指している (実際: $gen_target)"
+        ;;
+    esac
+    assert_exists "$gen_target/.dotfiles-manifest"
+    if grep -q '^mode: generation$' "$gen_target/.dotfiles-manifest" 2>/dev/null; then
+      pass "manifest の mode が generation になっている"
+    else
+      fail "manifest の mode が generation になっている"
     fi
   fi
 
@@ -260,7 +329,7 @@ EOF
     pass "2回目の deploy-all.sh も成功（冪等）"
   fi
   if has_tool bin; then
-    assert_symlink "$sbx/bin/ocw" "$REPO_ROOT/bin/ocw"
+    assert_symlink "$sbx/bin/ocw" "$(dotfiles_prefix_for "$sbx")/current/bin/ocw"
   fi
   if has_tool claude; then
     if printf '%s' "$out" | grep -q "already up to date"; then
@@ -322,7 +391,7 @@ scenario_no_backup() {
     log "$out"
     return
   fi
-  assert_symlink "$sbx/bin/ocw" "$REPO_ROOT/bin/ocw"
+  assert_symlink "$sbx/bin/ocw" "$(dotfiles_prefix_for "$sbx")/current/bin/ocw"
   assert_not_exists "$sbx/bin/ocw.backup"
 }
 
@@ -330,7 +399,7 @@ scenario_no_backup() {
 
 scenario_only_filter() {
   log "=== シナリオ3: --only フィルタで指定ツール以外は触られない ==="
-  local sbx
+  local sbx gen_target tool
   new_sandbox
   sbx="$SANDBOX_DIR"
   run_deploy "$sbx" --force --only bin >/dev/null 2>&1
@@ -341,6 +410,213 @@ scenario_only_filter() {
     fail "--only bin では bin/ocw がデプロイされる"
   fi
   assert_not_exists "$sbx/.claude"
+
+  # --only は $HOME 側のリンク対象を絞るだけで、世代の中身には影響しない
+  # （ADR §4.3 / DOC-2608040229）。--only bin でも世代には全ツール分の
+  # ディレクトリが入っていることを確認する。
+  gen_target="$(current_target_for "$sbx")"
+  for tool in zsh nvim tmux bin claude shared; do
+    assert_exists "$gen_target/$tool"
+  done
+}
+
+# ── シナリオ4: ソースツリー消失耐性 ────────────────────────────────────
+
+scenario_source_tree_disappears() {
+  if ! has_tool bin; then
+    return
+  fi
+  log "=== シナリオ4: ソースツリー消失耐性 ==="
+  local sbx copy_dir out rc content
+  new_sandbox
+  sbx="$SANDBOX_DIR"
+  copy_dir="$(mktemp -d)"
+  CREATED_DIRS+=("$copy_dir")
+  copy_repo_snapshot "$copy_dir"
+
+  out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --force --only bin 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "コピーからの deploy-all.sh --only bin が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+
+  content="$(cat "$sbx/bin/ocw" 2>/dev/null)"
+  if [ -z "$content" ]; then
+    fail "deploy 直後に $sbx/bin/ocw が読めること"
+    return
+  fi
+  pass "deploy 直後に $sbx/bin/ocw が読める"
+
+  # ソースツリー（コピー）を削除する。世代は cp -a による実体コピーなので、
+  # 消えたソースツリーに依存していなければ $HOME 側は引き続き読めるはず
+  # （ADR 問題2の回帰テスト）。
+  rm -rf "$copy_dir"
+
+  if [ "$(cat "$sbx/bin/ocw" 2>/dev/null)" = "$content" ]; then
+    pass "ソースツリー削除後も $sbx/bin/ocw が同じ内容で読める（消失耐性）"
+  else
+    fail "ソースツリー削除後も $sbx/bin/ocw が同じ内容で読める（消失耐性）"
+  fi
+}
+
+# ── シナリオ5: 編集分離（deploy後のソースツリー編集は即反映されない） ────
+
+scenario_edit_isolation() {
+  if ! has_tool bin; then
+    return
+  fi
+  log "=== シナリオ5: 編集分離 + 再デプロイでの反映 ==="
+  local sbx copy_dir out rc original marker
+
+  new_sandbox
+  sbx="$SANDBOX_DIR"
+  copy_dir="$(mktemp -d)"
+  CREATED_DIRS+=("$copy_dir")
+  copy_repo_snapshot "$copy_dir"
+
+  out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --force --only bin 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "コピーからの deploy-all.sh --only bin が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+
+  original="$(cat "$sbx/bin/ocw" 2>/dev/null)"
+
+  marker="# smoke-test marker $$"
+  printf '%s\n' "$marker" >>"$copy_dir/bin/ocw"
+
+  if [ "$(cat "$sbx/bin/ocw" 2>/dev/null)" = "$original" ]; then
+    pass "deploy 後にソースツリーを書き換えても \$HOME 側の内容は変わらない（編集分離）"
+  else
+    fail "deploy 後にソースツリーを書き換えても \$HOME 側の内容は変わらない（編集分離）"
+  fi
+
+  # 世代IDは秒精度（<date>-<sha>）なので、同一秒内の再デプロイは世代が
+  # 衝突しうる。1秒空けてから再デプロイし、編集が反映されることを確認する。
+  sleep 1
+  out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --force --only bin 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "2回目のコピーからの deploy-all.sh --only bin が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+
+  if cat "$sbx/bin/ocw" 2>/dev/null | grep -qF "$marker"; then
+    pass "再デプロイでソースツリーの編集が反映される"
+  else
+    fail "再デプロイでソースツリーの編集が反映される"
+  fi
+}
+
+# ── シナリオ6: 世代の増加とGC ──────────────────────────────────────────
+
+scenario_generation_gc() {
+  if ! has_tool bin; then
+    return
+  fi
+  log "=== シナリオ6: 世代の増加とGC ==="
+  local sbx copy_dir prefix gen_count keep i out rc first_target cur_target
+
+  new_sandbox
+  sbx="$SANDBOX_DIR"
+  copy_dir="$(mktemp -d)"
+  CREATED_DIRS+=("$copy_dir")
+  copy_repo_snapshot "$copy_dir"
+  prefix="$(dotfiles_prefix_for "$sbx")"
+
+  out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --force --only bin 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "1回目の deploy-all.sh --only bin が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+  first_target="$(current_target_for "$sbx")"
+
+  sleep 1
+  out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --force --only bin 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "2回目の deploy-all.sh --only bin が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+
+  gen_count="$(find "$prefix/generations" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
+  if [ "$gen_count" -eq 2 ]; then
+    pass "再デプロイで世代が増える（既定の保持数では削除されない）: $gen_count 件"
+  else
+    fail "再デプロイで世代が増える（既定の保持数では削除されない）: 期待2件、実際 $gen_count 件"
+  fi
+
+  if [ -d "$first_target" ]; then
+    pass "保持数を超えていない古い世代は削除されない: $first_target"
+  else
+    fail "保持数を超えていない古い世代は削除されない: $first_target"
+  fi
+
+  # --- 保持数を超えるとGCされ、current が指す世代は消えないこと ---
+  keep=2
+  EXTRA_ENV=("DOTFILES_KEEP_GENERATIONS=$keep")
+  i=0
+  while [ "$i" -lt 3 ]; do
+    i=$((i + 1))
+    sleep 1
+    out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --force --only bin 2>&1)"
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+      fail "GC検証用の再デプロイが失敗 (exit=$rc)"
+      log "$out"
+      EXTRA_ENV=()
+      return
+    fi
+  done
+  EXTRA_ENV=()
+
+  gen_count="$(find "$prefix/generations" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
+  if [ "$gen_count" -eq "$keep" ]; then
+    pass "DOTFILES_KEEP_GENERATIONS=$keep を超えた古い世代がGCされる: $gen_count 件"
+  else
+    fail "DOTFILES_KEEP_GENERATIONS=$keep を超えた古い世代がGCされる: 期待${keep}件、実際 $gen_count 件"
+  fi
+
+  cur_target="$(current_target_for "$sbx")"
+  if [ -d "$cur_target" ]; then
+    pass "current が指す世代はGCされずに残っている: $cur_target"
+  else
+    fail "current が指す世代はGCされずに残っている: $cur_target"
+  fi
+}
+
+# ── シナリオ7: 旧方式（直リンク）symlink の移行は退避されない ────────────
+
+scenario_migration_no_backup_for_repo_owned_symlink() {
+  if ! has_tool bin; then
+    return
+  fi
+  log "=== シナリオ7: 旧方式(直リンク)symlinkの移行は退避されない ==="
+  local sbx out rc
+
+  new_sandbox
+  sbx="$SANDBOX_DIR"
+  mkdir -p "$sbx/bin"
+  ln -s "$REPO_ROOT/bin/ocw" "$sbx/bin/ocw"
+
+  out="$(run_deploy "$sbx" --force --only bin 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "旧方式リンクが存在する状態での deploy-all.sh --only bin が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+
+  assert_symlink "$sbx/bin/ocw" "$(dotfiles_prefix_for "$sbx")/current/bin/ocw"
+  assert_not_exists "$sbx/bin/ocw.backup"
 }
 
 log "REPO_ROOT: $REPO_ROOT"
@@ -352,6 +628,14 @@ log
 scenario_no_backup
 log
 scenario_only_filter
+log
+scenario_source_tree_disappears
+log
+scenario_edit_isolation
+log
+scenario_generation_gc
+log
+scenario_migration_no_backup_for_repo_owned_symlink
 log
 
 if [ "$FAIL" -eq 0 ]; then

--- a/tests/deploy_smoke.sh
+++ b/tests/deploy_smoke.sh
@@ -321,6 +321,10 @@ EOF
   fi
 
   # --- 冪等性: 同じ内容で2回目を実行しても壊れない ---
+  # 世代IDは秒精度（<date>-<sha>）なので、同一秒内の再デプロイは同じ内容
+  # でも世代IDが衝突しうる（衝突時は上書きせずエラーにする仕様。指摘3）。
+  # 1秒空けてから2回目を実行する。
+  sleep 1
   out="$(run_deploy "$sbx" --force --only "$TOOLS" 2>&1)"
   rc=$?
   if [ "$rc" -ne 0 ]; then
@@ -619,6 +623,72 @@ scenario_migration_no_backup_for_repo_owned_symlink() {
   assert_not_exists "$sbx/bin/ocw.backup"
 }
 
+# ── シナリオ8: 由来判定の偽陽性防止 + 単体実行時のcurrent不在エラー ─────
+
+scenario_symlink_ownership_and_standalone_deploy() {
+  if ! has_tool bin; then
+    return
+  fi
+  log "=== シナリオ8: 由来判定の偽陽性防止 + 単体実行時のcurrent不在エラー ==="
+  local sbx out rc prefix
+
+  # --- 偽陽性防止: リポジトリ外を指す symlink は退避される ---
+  new_sandbox
+  sbx="$SANDBOX_DIR"
+  mkdir -p "$sbx/bin"
+  printf 'my-own-ocw\n' >"$sbx/my-own-ocw"
+  ln -s "$sbx/my-own-ocw" "$sbx/bin/ocw"
+
+  out="$(run_deploy "$sbx" --force --only bin 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "ユーザー所有symlinkが存在する状態での deploy-all.sh --only bin が失敗 (exit=$rc)"
+    log "$out"
+  else
+    assert_exists "$sbx/bin/ocw.backup"
+    if [ -L "$sbx/bin/ocw.backup" ] && [ "$(readlink "$sbx/bin/ocw.backup")" = "$sbx/my-own-ocw" ]; then
+      pass "リポジトリ外を指すユーザー所有symlinkは退避される（偽陽性なし）: $sbx/bin/ocw.backup -> $sbx/my-own-ocw"
+    else
+      fail "リポジトリ外を指すユーザー所有symlinkは退避される（偽陽性なし）: $sbx/bin/ocw.backup -> $(readlink "$sbx/bin/ocw.backup" 2>/dev/null || echo '(symlinkでない)')"
+    fi
+    assert_symlink "$sbx/bin/ocw" "$(dotfiles_prefix_for "$sbx")/current/bin/ocw"
+  fi
+
+  # --- 単体実行: current が存在しない状態で bin/deploy.sh を直接実行するとエラー終了する ---
+  new_sandbox
+  sbx="$SANDBOX_DIR"
+  sandbox_env "$sbx"
+  out="$(env "${SANDBOX_ENV[@]}" DRY_RUN=1 sh "$REPO_ROOT/bin/deploy.sh" 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    pass "current が無い状態での bin/deploy.sh 単体実行はエラー終了する (exit=$rc)"
+  else
+    fail "current が無い状態での bin/deploy.sh 単体実行はエラー終了する (exit=0 になってしまった)"
+  fi
+  if printf '%s' "$out" | grep -q "does not exist yet"; then
+    pass "current 不在時のエラーメッセージが表示される"
+  else
+    fail "current 不在時のエラーメッセージが表示される"
+  fi
+
+  # --- 単体実行: current がリンク切れのときは別のメッセージになる ---
+  prefix="$(dotfiles_prefix_for "$sbx")"
+  mkdir -p "$prefix"
+  ln -s "$prefix/generations/does-not-exist" "$prefix/current"
+  out="$(env "${SANDBOX_ENV[@]}" DRY_RUN=1 sh "$REPO_ROOT/bin/deploy.sh" 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    pass "current がリンク切れの状態での bin/deploy.sh 単体実行はエラー終了する (exit=$rc)"
+  else
+    fail "current がリンク切れの状態での bin/deploy.sh 単体実行はエラー終了する (exit=0 になってしまった)"
+  fi
+  if printf '%s' "$out" | grep -q "broken symlink"; then
+    pass "current がリンク切れのときは『存在しない』ではなく『リンク切れ』のメッセージになる"
+  else
+    fail "current がリンク切れのときは『存在しない』ではなく『リンク切れ』のメッセージになる"
+  fi
+}
+
 log "REPO_ROOT: $REPO_ROOT"
 log "対象ツール: $TOOLS"
 log
@@ -636,6 +706,8 @@ log
 scenario_generation_gc
 log
 scenario_migration_no_backup_for_repo_owned_symlink
+log
+scenario_symlink_ownership_and_standalone_deploy
 log
 
 if [ "$FAIL" -eq 0 ]; then

--- a/tmux/deploy.sh
+++ b/tmux/deploy.sh
@@ -7,13 +7,25 @@ SCRIPT_DIR=$(
 # shellcheck source=SCRIPTDIR/../shared/helpers.sh
 . "$SCRIPT_DIR/../shared/helpers.sh"
 
+# --- Resolve distribution source (current generation) ---
+# See AGENTS.md "デプロイの仕組み": standalone runs default to `current`;
+# deploy-all.sh overrides this with the generation it just created.
+if [ -z "${DOTFILES_DEPLOY_SRC:-}" ]; then
+  DOTFILES_DEPLOY_SRC="$(dotfiles_current_link)"
+  if [ ! -e "$DOTFILES_DEPLOY_SRC" ]; then
+    log_error "No distributed generation found (current does not exist yet)."
+    log_error "Run ./deploy-all.sh from the repo root first."
+    exit 1
+  fi
+fi
+
 log_hr
 log_info "Deploying: tmux"
 
 FAIL=0
 
 # --- Symlink config ---
-symlink_backup "$SCRIPT_DIR/tmux.conf" "$HOME/.tmux.conf" || FAIL=1
+symlink_backup "$DOTFILES_DEPLOY_SRC/tmux/tmux.conf" "$HOME/.tmux.conf" || FAIL=1
 
 # --- Install tmux ---
 install_tmux_macos() {

--- a/tmux/deploy.sh
+++ b/tmux/deploy.sh
@@ -10,14 +10,7 @@ SCRIPT_DIR=$(
 # --- Resolve distribution source (current generation) ---
 # See AGENTS.md "デプロイの仕組み": standalone runs default to `current`;
 # deploy-all.sh overrides this with the generation it just created.
-if [ -z "${DOTFILES_DEPLOY_SRC:-}" ]; then
-  DOTFILES_DEPLOY_SRC="$(dotfiles_current_link)"
-  if [ ! -e "$DOTFILES_DEPLOY_SRC" ]; then
-    log_error "No distributed generation found (current does not exist yet)."
-    log_error "Run ./deploy-all.sh from the repo root first."
-    exit 1
-  fi
-fi
+resolve_deploy_src
 
 log_hr
 log_info "Deploying: tmux"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -15,12 +15,20 @@
 # at the stable `current` path instead.
 _ZSHRC_SOURCE="${(%):-%x}"
 if [ -L "$_ZSHRC_SOURCE" ]; then
-  _ZSHRC_PATH="$(readlink "$_ZSHRC_SOURCE")"
+  # readlink returns the link's raw target text, which is relative when the
+  # symlink itself is relative (deploy.sh always writes absolute targets,
+  # but a hand-made or third-party-tool link might not). Anchor a relative
+  # target to the symlink's own directory so DOTFILES_DIR is always absolute.
+  _ZSHRC_TARGET="$(readlink "$_ZSHRC_SOURCE")"
+  case "$_ZSHRC_TARGET" in
+    /*) _ZSHRC_PATH="$_ZSHRC_TARGET" ;;
+    *) _ZSHRC_PATH="${_ZSHRC_SOURCE:h}/$_ZSHRC_TARGET" ;;
+  esac
 else
   _ZSHRC_PATH="${_ZSHRC_SOURCE:A}"
 fi
 DOTFILES_DIR="${_ZSHRC_PATH:h:h}"
-unset _ZSHRC_SOURCE _ZSHRC_PATH
+unset _ZSHRC_SOURCE _ZSHRC_TARGET _ZSHRC_PATH
 
 # =============================================================================
 # Source shared helpers (CURRENT_PLATFORM, is_macos, is_linux, is_wsl, etc.)

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -4,9 +4,23 @@
 # Use %x prompt expansion to get the sourced file path.
 # This works regardless of FUNCTION_ARGZERO / POSIX_ARGZERO settings,
 # unlike $0 which depends on those options.
-_ZSHRC_PATH="${${(%):-%x}:A}"
+#
+# ~/.zshrc -> .../dotfiles/current/zsh/.zshrc, where `current` is itself a
+# symlink to a dated generation directory that gets garbage-collected once
+# older than DOTFILES_KEEP_GENERATIONS deploys ago. `:A` (full realpath)
+# would resolve straight through `current` to that generation directory, so
+# DOTFILES_DIR would end up pointing at a path that can vanish out from
+# under an already-running shell after a later re-deploy's GC. Resolve only
+# the ~/.zshrc symlink itself (one hop, via readlink) so DOTFILES_DIR stops
+# at the stable `current` path instead.
+_ZSHRC_SOURCE="${(%):-%x}"
+if [ -L "$_ZSHRC_SOURCE" ]; then
+  _ZSHRC_PATH="$(readlink "$_ZSHRC_SOURCE")"
+else
+  _ZSHRC_PATH="${_ZSHRC_SOURCE:A}"
+fi
 DOTFILES_DIR="${_ZSHRC_PATH:h:h}"
-unset _ZSHRC_PATH
+unset _ZSHRC_SOURCE _ZSHRC_PATH
 
 # =============================================================================
 # Source shared helpers (CURRENT_PLATFORM, is_macos, is_linux, is_wsl, etc.)

--- a/zsh/deploy.sh
+++ b/zsh/deploy.sh
@@ -10,14 +10,7 @@ SCRIPT_DIR=$(
 # --- Resolve distribution source (current generation) ---
 # See AGENTS.md "デプロイの仕組み": standalone runs default to `current`;
 # deploy-all.sh overrides this with the generation it just created.
-if [ -z "${DOTFILES_DEPLOY_SRC:-}" ]; then
-  DOTFILES_DEPLOY_SRC="$(dotfiles_current_link)"
-  if [ ! -e "$DOTFILES_DEPLOY_SRC" ]; then
-    log_error "No distributed generation found (current does not exist yet)."
-    log_error "Run ./deploy-all.sh from the repo root first."
-    exit 1
-  fi
-fi
+resolve_deploy_src
 
 log_hr
 log_info "Deploying: zsh"

--- a/zsh/deploy.sh
+++ b/zsh/deploy.sh
@@ -7,6 +7,18 @@ SCRIPT_DIR=$(
 # shellcheck source=SCRIPTDIR/../shared/helpers.sh
 . "$SCRIPT_DIR/../shared/helpers.sh"
 
+# --- Resolve distribution source (current generation) ---
+# See AGENTS.md "デプロイの仕組み": standalone runs default to `current`;
+# deploy-all.sh overrides this with the generation it just created.
+if [ -z "${DOTFILES_DEPLOY_SRC:-}" ]; then
+  DOTFILES_DEPLOY_SRC="$(dotfiles_current_link)"
+  if [ ! -e "$DOTFILES_DEPLOY_SRC" ]; then
+    log_error "No distributed generation found (current does not exist yet)."
+    log_error "Run ./deploy-all.sh from the repo root first."
+    exit 1
+  fi
+fi
+
 log_hr
 log_info "Deploying: zsh"
 
@@ -29,8 +41,8 @@ if ! command -v mise >/dev/null 2>&1; then
 fi
 
 # --- Symlink config files ---
-symlink_backup "$SCRIPT_DIR/.zshrc" "$HOME/.zshrc" || FAIL=1
-symlink_backup "$SCRIPT_DIR/.zsh_plugins.txt" "$HOME/.zsh_plugins.txt" || FAIL=1
+symlink_backup "$DOTFILES_DEPLOY_SRC/zsh/.zshrc" "$HOME/.zshrc" || FAIL=1
+symlink_backup "$DOTFILES_DEPLOY_SRC/zsh/.zsh_plugins.txt" "$HOME/.zsh_plugins.txt" || FAIL=1
 
 # --- Install Antidote plugin manager ---
 ANTIDOTE_HOME="${ANTIDOTE_HOME:-$HOME/.antidote}"


### PR DESCRIPTION
## 背景

dotfilesは、macOS / Linux / WSL2 で共通の開発環境を再現するための設定リポジトリです。`deploy-all.sh` は各ツールの `deploy.sh` を呼び、`$HOME` からリポジトリの作業ツリー内のファイルへ直接シンボリックリンクを張ります。

この方式には3つの不安定さがあります。

1. deploy後にリポジトリ側のファイルを編集すると、コミットしていない編集途中の状態がそのまま `$HOME` の設定として有効になる
2. `git worktree` を使ってデプロイした場合、そのワークツリーを消すと `$HOME` 側のリンクが壊れる
3. 今 `$HOME` に効いている設定がどのツリーのどのコミット由来なのかを追跡する手段がない

採用する解決方式の比較検討と却下理由は ADR（DOC-2608040229）に記録済みです。このプルリクエストは、傘ブランチ `ai/deploy-stability` の計画書（DOC-2608040234）で定義された最初の実装単位（孫1）にあたります。

## このプルリクエストの目的

`deploy-all.sh` とリポジトリの間に「配布実体」を1段挟みます。作業ツリーを世代ディレクトリへコピーし、`current` というシンボリックリンクを世代へ向け、`$HOME` からは `current` 経由で参照する方式です（Capistrano の releases + current と同じ考え方）。

このプルリクエストでは、単純にシンボリックリンクを張るだけの4ツール（`zsh` `nvim` `tmux` `bin`）をこの新方式へ切り替えます。`claude` はシンボリックリンク以外の例外処理（設定ファイルの生成・スキルの個別リンク）を2箇所持つため対象外とし、次の孫が担当します。

## 実装内容

- `shared/helpers.sh` に配布実体レイヤの関数を追加しました
  - 世代の作成: `generations/` の外にある使い捨てのスクラッチディレクトリへ `cp -a` で作業ツリーをコピーしたあと、`mv` で最終的な世代ディレクトリ名へ確定させます（`--only` の指定に関わらず常に全ツール分をコピーします）。世代IDが衝突した場合（同一秒・同一コミットでの再デプロイ）は上書きせずエラーで拒否します。パーミッションは `mktemp -d` の固定値ではなく、呼び出し元の umask から計算した値を使います
  - 前回の実行が異常終了して残った可能性のあるスクラッチディレクトリを、新しい世代を作る前に掃除します
  - デプロイ日時・ソースツリー・コミットSHA・ブランチ・dirty状態などを記録する manifest ファイルの書き込み
  - `current` シンボリックリンクの切り替え
  - 保持数（既定3、`DOTFILES_KEEP_GENERATIONS` で上書き可）を超えた古い世代の削除。`current` が指す世代は絶対に削除しません
  - 削除処理（スクラッチの掃除・古い世代のGC）は共通のヘルパー `_dotfiles_safe_rmdir` に集約し、`rm -rf` の前に必ず「シンボリックリンクでないこと・実ディレクトリであること・canonical prefix配下であること」を確認します
- `symlink_backup` を改修しました。既存のシンボリックリンクが、このリポジトリの過去のデプロイに由来するもの（配布実体配下、または呼び出し元が明示するリポジトリのルート配下を指している）であれば、退避せずに張り替えるようにしました。これがないと、旧方式のリンクが `.backup` として残り続け、後日 uninstall がそれを「ユーザーの元の設定」として誤って復元してしまいます
- `deploy-all.sh` を、世代を作って `current` を切り替えたあとに各ツールの `deploy.sh` を呼び、最後に古い世代を掃除する流れに変更しました
- `zsh` `nvim` `tmux` `bin` の `deploy.sh` を、配布元を環境変数 `DOTFILES_DEPLOY_SRC`（`current` を指す固定パス）経由にするよう変更しました。個別に単体実行した場合は共通ヘルパー `resolve_deploy_src` が `current` を自動的に使い、`current` が無い、またはリンク切れであれば、それぞれ異なるメッセージでエラー終了します
- `zsh/.zshrc` の `DOTFILES_DIR` の解決方法を変更しました。従来は自分自身のパスをフル解決（シンボリックリンクを最後まで辿る）していましたが、これだと `current` の先の世代ディレクトリまで解決されてしまい、保持数を超えてGCされると存在しないパスを案内することになります。`~/.zshrc` のシンボリックリンクを1段だけ辿ることで、GCで消えない `current` を指すようにしました
- `tests/deploy_smoke.sh` に、この変更で追加された性質を検証するシナリオを追加しました
  - ソースツリーを削除しても `$HOME` 側の設定が読めること（消失耐性）
  - デプロイ後にソースツリーを編集しても `$HOME` 側にはすぐ反映されないこと（編集分離）、再デプロイすれば反映されること
  - 再デプロイで世代が増えること、保持数を超えると古い世代がGCされること、`current` が指す世代は消されないこと
  - `--only` で一部のツールだけをデプロイしても、世代の中身には全ツール分が入ること
  - 旧方式（作業ツリー直リンク）のシンボリックリンクがあった状態でデプロイすると、退避されずに新方式へ切り替わること
  - リポジトリ外を指すシンボリックリンクは誤って「リポジトリ由来」と判定されず退避されること（偽陽性防止）
  - `current` が存在しない・リンク切れの状態で単体の `deploy.sh` を実行すると、それぞれ異なるメッセージでエラー終了すること

## レビューで見てほしいところ

- `$HOME` 側のシンボリックリンクは、世代ディレクトリを直接指すのではなく `current` という固定パスを指すようにしています。こうすることで、再デプロイのたびに `$HOME` 側のリンク自体を張り直す必要がなく、`current` の付け替えだけで参照先が一斉に切り替わります
- `symlink_backup` の「このリポジトリ由来のシンボリックリンクか」の判定は、リンク先が配布実体の置き場所（canonical prefix）配下か、または呼び出し元が明示するリポジトリのルート配下かで判定しています
- `claude` ツールは今回変更していないため、このプルリクエストのマージ後は「4ツールは配布実体経由、`claude` は作業ツリー直リンク」という混在状態になります。動作上は壊れませんが、次の孫（`claude` の例外2箇所の追従）がこの状態を引き継ぎます
- 世代ディレクトリのIDは `<日時（秒精度）>-<コミットの短いSHA>` という形式です（ADRで確定済みの形式）。同じ秒のうちに続けて `deploy-all.sh` を実行すると世代IDが衝突しますが、上書きや入れ子コピーにはならず、エラーで拒否して `exit 1` するようにしています（`--dry-run` でも同じタイミングで検出します）。`tests/deploy_smoke.sh` では、意図的に世代を増やしたい再デプロイの間は `wait_for_next_second`（秒の値が実際に変わるまで待つ）を使い、衝突拒否によるテストの偽陽性を避けています

上記4点は、いずれもレビュー往復（計5ラウンド）で実際に検証済みです。詳細な指摘とその対応は各インラインコメントを参照してください。

## 自己レビュー

- 正当性: 計画書「孫1用プロンプト」の項目（配布実体レイヤの追加、`symlink_backup` の改修、`deploy-all.sh` の追従、4ツールの `deploy.sh` の追従、スモークテストの追加）をすべて実装しました
- エッジケース: `current` が存在しない・リンク切れの状態での単体実行時のエラー終了、世代ID衝突時の拒否、GC対象の存在確認・実ディレクトリ確認・canonical prefix配下確認、devモード（`current` が世代ディレクトリ以外を指す場合）でのGCスキップ、`--only` 指定時も世代には全ツール分が入ること、umaskの尊重を確認しました
- テスト: `tests/deploy_smoke.sh` に5シナリオ追加（既存3シナリオと合わせて計8シナリオ）、既存シナリオも新方式に合わせて更新し、全て成功しています。`python3 -m unittest discover -s bin/tests -v` も193件成功しています
- 無関係変更: 計画書の対象ファイル（`shared/helpers.sh` `deploy-all.sh` `zsh/nvim/tmux/bin/deploy.sh` `tests/deploy_smoke.sh`）に加えて、レビュー指摘を受けて `zsh/.zshrc`（`DOTFILES_DIR` の解決方法）を変更しています。計画書の対象一覧には無いファイルですが、`current` 導入によって `DOTFILES_DIR` の解決結果の意味が変わったことに起因する不具合で、実装の範囲内と判断しました

## 孫5への申し送り（計画書「やらないこと」に基づく）

このプルリクエストで挙動が変わったのに、以下の文書が古いままです。孫5（文書更新）で反映してください。**このプルリクエストでは文書を直していません。**

- `AGENTS.md`「概要」: 「各ツールディレクトリの `deploy.sh` が `$HOME` に symlink を張ることで設定を配布する」という記述が、`zsh` `nvim` `tmux` `bin` については実態と異なります（配布実体 `current` 経由に変わりました）
- `AGENTS.md`「デプロイの仕組み」節: 世代ディレクトリ・`current`・`DOTFILES_DEPLOY_SRC`・`DOTFILES_KEEP_GENERATIONS`・世代ID衝突時の拒否のいずれにも触れていません
- ルート `README.md`「Deploying from a git worktree」節: 「deploy scripts symlink files from this checkout into `$HOME`」で始まる説明が、`zsh` `nvim` `tmux` `bin` についてはこのプルリクエストで解決済みの問題を前提にしたままです

**特に優先度が高い理由**: このプルリクエストで追加した4つの `<tool>/deploy.sh` が、揃って `# See AGENTS.md "デプロイの仕組み": standalone runs default to 'current';` という参照コメントを持っています。孫5が `AGENTS.md` を更新するまで、このコメントは存在しない記述を指したままになります。

## テスト結果

`pre-commit run --all-files`、`./deploy-all.sh --dry-run`、`tests/deploy_smoke.sh`、`python3 -m unittest discover -s bin/tests -v`（`bin/deploy.sh` を変更したため）、いずれも成功しています。

## 今後の予定

計画書（DOC-2608040234）に基づき、次の孫が `claude` の例外2箇所（設定ファイルの生成・スキルの個別シンボリックリンク）をこの新方式へ追従させます。

