### PR TITLE
claude の配布元を作業ツリー直リンクから配布実体経由へ揃える

### DIFF
--- a/claude/deploy.sh
+++ b/claude/deploy.sh
@@ -7,6 +7,11 @@ SCRIPT_DIR=$(
 # shellcheck source=SCRIPTDIR/../shared/helpers.sh
 . "$SCRIPT_DIR/../shared/helpers.sh"
 
+# --- Resolve distribution source (current generation) ---
+# See AGENTS.md "デプロイの仕組み": standalone runs default to `current`;
+# deploy-all.sh overrides this with the generation it just created.
+resolve_deploy_src
+
 log_hr
 log_info "Deploying: claude (Claude Code config)"
 
@@ -36,7 +41,7 @@ else
 fi
 
 # --- Symlink CLAUDE.md ---
-symlink_backup "$SCRIPT_DIR/CLAUDE.md" "$CLAUDE_DIR/CLAUDE.md" || FAIL=1
+symlink_backup "$DOTFILES_DEPLOY_SRC/claude/CLAUDE.md" "$CLAUDE_DIR/CLAUDE.md" || FAIL=1
 
 # --- Generate settings.json (NOT a symlink) ---
 # Claude Code does NOT read ~/.claude/settings.local.json at the user level
@@ -45,8 +50,8 @@ symlink_backup "$SCRIPT_DIR/CLAUDE.md" "$CLAUDE_DIR/CLAUDE.md" || FAIL=1
 # (not tracked in git — copy from settings.machine.json.example).
 # deploy.sh merges base + machine overrides into ~/.claude/settings.json.
 
-SETTINGS_SRC="$SCRIPT_DIR/settings.json"
-MACHINE_SRC="$SCRIPT_DIR/settings.machine.json"
+SETTINGS_SRC="$DOTFILES_DEPLOY_SRC/claude/settings.json"
+MACHINE_SRC="$DOTFILES_DEPLOY_SRC/claude/settings.machine.json"
 SETTINGS_DST="$CLAUDE_DIR/settings.json"
 
 if [ -f "$MACHINE_SRC" ]; then
@@ -185,7 +190,7 @@ fi
 #
 # Uses an independent _skills_fail flag so that a prior failure in CLAUDE.md
 # or settings.json does not silently skip skill deployment.
-SKILLS_SRC_DIR="$SCRIPT_DIR/skills"
+SKILLS_SRC_DIR="$DOTFILES_DEPLOY_SRC/claude/skills"
 SKILLS_DST_DIR="$CLAUDE_DIR/skills"
 SKILLS_BACKUP_DIR="$CLAUDE_DIR/skills-backup"
 _skills_fail=0

--- a/claude/deploy.sh
+++ b/claude/deploy.sh
@@ -208,6 +208,13 @@ fi
 # Uses an independent _skills_fail flag so that a prior failure in CLAUDE.md
 # or settings.json does not silently skip skill deployment.
 SKILLS_SRC_DIR="$CLAUDE_SRC_DIR/skills"
+# Distinct from SKILLS_SRC_DIR on purpose: SKILLS_SRC_DIR is only the
+# enumeration input (which skills exist, per CLAUDE_SRC_DIR's DRY_RUN
+# branching above). SKILLS_DEPLOY_DIR is what symlinks actually get pointed
+# at, and that must always be the real distribution source regardless of
+# DRY_RUN — otherwise a dry-run plan would propose linking through the
+# working tree, which is exactly the pre-migration scheme this PR retires.
+SKILLS_DEPLOY_DIR="$DOTFILES_DEPLOY_SRC/claude/skills"
 SKILLS_DST_DIR="$CLAUDE_DIR/skills"
 SKILLS_BACKUP_DIR="$CLAUDE_DIR/skills-backup"
 _skills_fail=0
@@ -244,9 +251,11 @@ if [ -d "$SKILLS_SRC_DIR" ]; then
     for _skill_dir in "$SKILLS_SRC_DIR"/*/; do
       [ -d "$_skill_dir" ] || continue
       _skill_name=$(basename "$_skill_dir")
-      # Use $SKILLS_SRC_DIR/$_skill_name (no trailing slash) so the symlink
-      # target is clean and consistent with other links (e.g. CLAUDE.md).
-      _skill_src="$SKILLS_SRC_DIR/$_skill_name"
+      # Use $SKILLS_DEPLOY_DIR/$_skill_name (no trailing slash) so the
+      # symlink target is clean and consistent with other links (e.g.
+      # CLAUDE.md). Deliberately SKILLS_DEPLOY_DIR, not SKILLS_SRC_DIR — see
+      # the SKILLS_DEPLOY_DIR comment above.
+      _skill_src="$SKILLS_DEPLOY_DIR/$_skill_name"
       _skill_dst="$SKILLS_DST_DIR/$_skill_name"
 
       # Safety: if dst and src resolve to the same path, skip to avoid
@@ -326,19 +335,24 @@ if [ -d "$SKILLS_SRC_DIR" ]; then
     fi
 
     # Clean up stale symlinks inside ~/.claude/skills/ that point into
-    # SKILLS_SRC_DIR but whose targets no longer exist (renamed / removed).
-    # Also recognizes the pre-migration direct-to-worktree scheme
-    # ($SCRIPT_DIR/skills/<name>) so skills removed/renamed before this
-    # machine adopted the current-scheme distribution still get swept
-    # (ADR §4.8 / DOC-2608040229 asks uninstall.sh's ownership check to
-    # recognize both schemes for the same reason). Only touches symlinks
-    # whose target starts with one of these two prefixes, leaving
-    # user-owned and Herdr-managed symlinks alone.
+    # SKILLS_DEPLOY_DIR but whose targets no longer exist (renamed /
+    # removed). Uses SKILLS_DEPLOY_DIR, not SKILLS_SRC_DIR, for the same
+    # reason the symlink target above does: in DRY_RUN mode SKILLS_SRC_DIR
+    # is the working tree, so matching against it would miss stale
+    # current-scheme links (the ones this deploy actually created) and the
+    # plan would silently propose nothing to sweep. Also recognizes the
+    # pre-migration direct-to-worktree scheme ($SCRIPT_DIR/skills/<name>)
+    # so skills removed/renamed before this machine adopted the
+    # current-scheme distribution still get swept (ADR §4.8 /
+    # DOC-2608040229 asks uninstall.sh's ownership check to recognize both
+    # schemes for the same reason). Only touches symlinks whose target
+    # starts with one of these two prefixes, leaving user-owned and
+    # Herdr-managed symlinks alone.
     for _dst_link in "$SKILLS_DST_DIR"/*; do
       [ -L "$_dst_link" ] || continue
       _target=$(readlink "$_dst_link")
       case "$_target" in
-        "$SKILLS_SRC_DIR"/* | "$SCRIPT_DIR/skills"/*)
+        "$SKILLS_DEPLOY_DIR"/* | "$SCRIPT_DIR/skills"/*)
           if [ ! -d "$_target" ]; then
             if [ "${DRY_RUN:-0}" -eq 1 ]; then
               log_info "[DRY-RUN] Would remove stale skill symlink: $_dst_link → $_target"

--- a/claude/deploy.sh
+++ b/claude/deploy.sh
@@ -43,6 +43,23 @@ fi
 # --- Symlink CLAUDE.md ---
 symlink_backup "$DOTFILES_DEPLOY_SRC/claude/CLAUDE.md" "$CLAUDE_DIR/CLAUDE.md" || FAIL=1
 
+# --- Resolve where to read claude/'s own contents from for THIS run ---
+# symlink_backup (used for CLAUDE.md above) always links through
+# DOTFILES_DEPLOY_SRC regardless of DRY_RUN — its DRY-RUN branch only prints
+# a planned `ln -fs`, so the source never needs to exist yet. But the code
+# below branches on "-f $MACHINE_SRC" / "-d $SKILLS_SRC_DIR" to decide what
+# to do, and in DRY_RUN mode DOTFILES_DEPLOY_SRC/claude may not exist yet
+# (current not switched, or create_generation's own DRY-RUN branch never
+# actually copies anything) — so those existence checks would silently see
+# "nothing to merge" / "no skills" even when the real run will create both.
+# A generation is a cp -a snapshot of the working tree (see
+# create_generation), so the working tree is what the plan should describe.
+if [ "${DRY_RUN:-0}" -eq 1 ]; then
+  CLAUDE_SRC_DIR="$SCRIPT_DIR"
+else
+  CLAUDE_SRC_DIR="$DOTFILES_DEPLOY_SRC/claude"
+fi
+
 # --- Generate settings.json (NOT a symlink) ---
 # Claude Code does NOT read ~/.claude/settings.local.json at the user level
 # (only project-level .claude/settings.local.json is supported).
@@ -50,8 +67,8 @@ symlink_backup "$DOTFILES_DEPLOY_SRC/claude/CLAUDE.md" "$CLAUDE_DIR/CLAUDE.md" |
 # (not tracked in git — copy from settings.machine.json.example).
 # deploy.sh merges base + machine overrides into ~/.claude/settings.json.
 
-SETTINGS_SRC="$DOTFILES_DEPLOY_SRC/claude/settings.json"
-MACHINE_SRC="$DOTFILES_DEPLOY_SRC/claude/settings.machine.json"
+SETTINGS_SRC="$CLAUDE_SRC_DIR/settings.json"
+MACHINE_SRC="$CLAUDE_SRC_DIR/settings.machine.json"
 SETTINGS_DST="$CLAUDE_DIR/settings.json"
 
 if [ -f "$MACHINE_SRC" ]; then
@@ -190,7 +207,7 @@ fi
 #
 # Uses an independent _skills_fail flag so that a prior failure in CLAUDE.md
 # or settings.json does not silently skip skill deployment.
-SKILLS_SRC_DIR="$DOTFILES_DEPLOY_SRC/claude/skills"
+SKILLS_SRC_DIR="$CLAUDE_SRC_DIR/skills"
 SKILLS_DST_DIR="$CLAUDE_DIR/skills"
 SKILLS_BACKUP_DIR="$CLAUDE_DIR/skills-backup"
 _skills_fail=0
@@ -249,8 +266,26 @@ if [ -d "$SKILLS_SRC_DIR" ]; then
 
       # If an existing file / directory / different symlink is in the way,
       # back it up OUTSIDE skills/ so it isn't picked up as a duplicate skill.
+      # Exception: a symlink left over from a previous deploy (either the
+      # old direct-to-worktree scheme or a stale current-scheme link) is not
+      # user data — replace it without backup, the same treatment
+      # symlink_backup gives CLAUDE.md above (ADR §4.9 / DOC-2608040229).
+      # Without this check, every pre-migration skill symlink would get
+      # "backed up" here as if it were the user's original skill, and a
+      # later uninstall would restore that backup as if it were real data.
       if [ -e "$_skill_dst" ] || [ -L "$_skill_dst" ]; then
-        if [ "${DRY_RUN:-0}" -eq 1 ]; then
+        if _dotfiles_symlink_is_repo_owned "$_skill_dst" "$(dirname "$SCRIPT_DIR")"; then
+          if [ "${DRY_RUN:-0}" -eq 1 ]; then
+            log_info "[DRY-RUN] Would replace repo-owned skill symlink (no backup): $_skill_dst"
+          else
+            log_info "Replacing repo-owned skill symlink (no backup needed): $_skill_dst"
+            rm -f "$_skill_dst" || {
+              log_error "Failed to remove: $_skill_dst"
+              _skills_fail=1
+              continue
+            }
+          fi
+        elif [ "${DRY_RUN:-0}" -eq 1 ]; then
           log_info "[DRY-RUN] Would back up existing: $_skill_dst → $SKILLS_BACKUP_DIR/"
         else
           mkdir -p "$SKILLS_BACKUP_DIR" || {
@@ -292,13 +327,18 @@ if [ -d "$SKILLS_SRC_DIR" ]; then
 
     # Clean up stale symlinks inside ~/.claude/skills/ that point into
     # SKILLS_SRC_DIR but whose targets no longer exist (renamed / removed).
-    # Only touches symlinks whose target starts with SKILLS_SRC_DIR, leaving
+    # Also recognizes the pre-migration direct-to-worktree scheme
+    # ($SCRIPT_DIR/skills/<name>) so skills removed/renamed before this
+    # machine adopted the current-scheme distribution still get swept
+    # (ADR §4.8 / DOC-2608040229 asks uninstall.sh's ownership check to
+    # recognize both schemes for the same reason). Only touches symlinks
+    # whose target starts with one of these two prefixes, leaving
     # user-owned and Herdr-managed symlinks alone.
     for _dst_link in "$SKILLS_DST_DIR"/*; do
       [ -L "$_dst_link" ] || continue
       _target=$(readlink "$_dst_link")
       case "$_target" in
-        "$SKILLS_SRC_DIR"/*)
+        "$SKILLS_SRC_DIR"/* | "$SCRIPT_DIR/skills"/*)
           if [ ! -d "$_target" ]; then
             if [ "${DRY_RUN:-0}" -eq 1 ]; then
               log_info "[DRY-RUN] Would remove stale skill symlink: $_dst_link → $_target"

--- a/tests/deploy_smoke.sh
+++ b/tests/deploy_smoke.sh
@@ -932,6 +932,72 @@ scenario_claude_dry_run_matches_deployed_state() {
   fi
 }
 
+# ── シナリオ13: current不在状態でのdry-runが配布実体の中身を計画できる ──
+
+scenario_claude_dry_run_before_first_deploy() {
+  if ! has_tool claude; then
+    return
+  fi
+  log "=== シナリオ13: current不在状態でのdry-runが配布実体の中身を計画できる ==="
+  local sbx copy_dir out rc skill prefix
+
+  new_sandbox
+  sbx="$SANDBOX_DIR"
+  copy_dir="$(mktemp -d)"
+  CREATED_DIRS+=("$copy_dir")
+  copy_repo_snapshot "$copy_dir"
+
+  # settings.machine.json を置いた状態で、まだ一度も deploy していない
+  # (current が存在しない)サンドボックスに対して --dry-run を実行する。
+  # ここが指摘1・6のバグが実際に発現していた条件そのもの: current が
+  # 無い状態では配布実体がまだ存在しないため、-f/-d による実在性判定を
+  # 素朴に配布実体へ向けると「マージ対象なし」「スキルなし」に見えて
+  # しまう(指摘1)。逆にその回避として列挙元を作業ツリーに振ったせいで
+  # リンクの向き先まで作業ツリーになってしまったのが指摘6。シナリオ12
+  # は「デプロイ済み」状態しか見ないためこの分岐を一度も通らず、この
+  # シナリオを置き換えではなく追加する。
+  cat >"$copy_dir/claude/settings.machine.json" <<'JSONEOF'
+{
+  "smokeTestMarker": "smoke-test-value"
+}
+JSONEOF
+
+  out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --dry-run --only claude 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "current不在状態での deploy-all.sh --dry-run --only claude が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+
+  if printf '%s' "$out" | grep -q "Would merge settings.json + settings.machine.json"; then
+    pass "current不在でもsettings.machine.jsonありなら『マージ』の計画になる(コピーに退化しない)"
+  else
+    fail "current不在でもsettings.machine.jsonありなら『マージ』の計画になる(コピーに退化しない)"
+  fi
+
+  while IFS= read -r skill; do
+    [ -n "$skill" ] || continue
+    if printf '%s' "$out" | grep -qF "Would symlink: $sbx/.claude/skills/$skill"; then
+      pass "current不在でも配布対象のskillが計画に列挙される: $skill"
+    else
+      fail "current不在でも配布対象のskillが計画に列挙される: $skill"
+    fi
+  done <<EOF
+$(list_repo_skills)
+EOF
+
+  # リンクの向き先は常に配布実体(current経由)でなければならない(指摘6の
+  # 回帰)。列挙元だけ直っていてリンク先が作業ツリーのままの退化を検知
+  # するため、Would symlink の行を配布実体prefixで確認する。
+  prefix="$(dotfiles_prefix_for "$sbx")"
+  if printf '%s' "$out" | grep "Would symlink:" | grep -qF "$prefix/current/claude/skills/"; then
+    pass "current不在でもskillのリンク先は配布実体(current経由)になる"
+  else
+    fail "current不在でもskillのリンク先は配布実体(current経由)になる"
+  fi
+}
+
 log "REPO_ROOT: $REPO_ROOT"
 log "対象ツール: $TOOLS"
 log
@@ -959,6 +1025,8 @@ log
 scenario_claude_skill_migration
 log
 scenario_claude_dry_run_matches_deployed_state
+log
+scenario_claude_dry_run_before_first_deploy
 log
 
 if [ "$FAIL" -eq 0 ]; then

--- a/tests/deploy_smoke.sh
+++ b/tests/deploy_smoke.sh
@@ -853,8 +853,8 @@ scenario_claude_skill_migration() {
   fi
 
   # 旧方式(作業ツリー直リンク)の skill symlink を再現する。current 経由へ
-  # 配布元が変わったことで、244行目付近の「既に正しいsymlinkか」の判定に
-  # 一致しなくなり、バックアップ処理へ落ちる経路を通る(ADR §4.9)。
+  # 配布元が変わったことで、claude/deploy.sh の「Already correct symlink?」
+  # の判定に一致しなくなり、バックアップ処理へ落ちる経路を通る(ADR §4.9)。
   ln -s "$REPO_ROOT/claude/skills/$skill_name" "$sbx/.claude/skills/$skill_name"
   # 存在しないスキルを指す旧方式リンク(stale)も再現する。
   ln -s "$REPO_ROOT/claude/skills/smoke-test-gone-skill" "$sbx/.claude/skills/smoke-test-gone-skill"
@@ -875,6 +875,60 @@ scenario_claude_skill_migration() {
     fail "存在しないスキルを指す旧方式リンクが掃除される: $sbx/.claude/skills/smoke-test-gone-skill"
   else
     pass "存在しないスキルを指す旧方式リンクが掃除される"
+  fi
+}
+
+# ── シナリオ12: デプロイ済み状態でのdry-runが作業ツリーへのリンクを提案しない ──
+
+scenario_claude_dry_run_matches_deployed_state() {
+  if ! has_tool claude; then
+    return
+  fi
+  log "=== シナリオ12: デプロイ済み状態でのdry-runが作業ツリーへのリンクを提案しない ==="
+  local sbx out rc
+
+  new_sandbox
+  sbx="$SANDBOX_DIR"
+
+  out="$(run_deploy "$sbx" --force --only claude 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "claude の初回 deploy-all.sh --force が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+
+  # 世代IDは秒精度なので、直後の --dry-run が同一秒に収まると世代ID衝突で
+  # 意図と無関係に失敗する。秒が変わるまで待ってから実行する。
+  wait_for_next_second
+
+  # デプロイ済みの状態に対して --dry-run --only claude を実行する。既に
+  # current 経由で正しくリンクされているはずなので、計画には何も変更が
+  # 無いはず。出力に作業ツリー(REPO_ROOT)のパスが混ざっていたら、dry-run
+  # が「作業ツリーへ張り替える」という誤った計画を出している証拠になる
+  # (このPRが廃止しようとしている直リンク方式そのもの)。
+  out="$(run_deploy "$sbx" --dry-run --only claude 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "デプロイ済み状態での deploy-all.sh --dry-run --only claude が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+
+  # 出力全体には create_generation の DRY-RUN 計画(cp -a REPO_ROOT/<tool> ...)
+  # が含まれ、これは作業ツリーのパスを含んでいて正常なので、出力全体に対して
+  # grep すると必ず誤検知する。見るべきは symlink の向き先を報告する行だけ。
+  if printf '%s' "$out" | grep -E "Would (symlink|replace)|Already linked" | grep -qF "$REPO_ROOT"; then
+    fail "デプロイ済み状態でのdry-run計画のsymlink向き先に作業ツリーのパスが現れない"
+    log "$out"
+  else
+    pass "デプロイ済み状態でのdry-run計画のsymlink向き先に作業ツリーのパスが現れない"
+  fi
+
+  if printf '%s' "$out" | grep -q "Already linked"; then
+    pass "デプロイ済み状態でのdry-runは『既にリンク済み』と判定する(変更を提案しない)"
+  else
+    fail "デプロイ済み状態でのdry-runは『既にリンク済み』と判定する(変更を提案しない)"
   fi
 }
 
@@ -903,6 +957,8 @@ log
 scenario_claude_settings_machine_merge
 log
 scenario_claude_skill_migration
+log
+scenario_claude_dry_run_matches_deployed_state
 log
 
 if [ "$FAIL" -eq 0 ]; then

--- a/tests/deploy_smoke.sh
+++ b/tests/deploy_smoke.sh
@@ -235,9 +235,10 @@ assert_not_exists() {
 
 scenario_backup_symlink_idempotent_uninstall() {
   log "=== シナリオ1: 退避 / symlink / 冪等性 / uninstall 復元 (対象: $TOOLS) ==="
-  local sbx out rc existing_skill
+  local sbx out rc existing_skill prefix
   new_sandbox
   sbx="$SANDBOX_DIR"
+  prefix="$(dotfiles_prefix_for "$sbx")"
 
   if has_tool bin; then
     mkdir -p "$sbx/bin"
@@ -270,8 +271,7 @@ scenario_backup_symlink_idempotent_uninstall() {
   pass "deploy-all.sh --force --only $TOOLS が成功"
 
   if has_tool bin; then
-    local prefix gen_target
-    prefix="$(dotfiles_prefix_for "$sbx")"
+    local gen_target
 
     # $HOME 側の symlink は current を経由する固定パスを指す（世代ディレク
     # トリを直接指さない）。current の付け替えだけで全リンクの向き先が
@@ -308,7 +308,10 @@ scenario_backup_symlink_idempotent_uninstall() {
   fi
 
   if has_tool claude; then
-    assert_symlink "$sbx/.claude/CLAUDE.md" "$REPO_ROOT/claude/CLAUDE.md"
+    # $HOME 側の symlink は current を経由する固定パスを指す(作業ツリーを
+    # 直接指さない)。孫2で claude も他ツールと同じ配布実体経由へ揃えた
+    # (ADR §4.8 / DOC-2608040229)。
+    assert_symlink "$sbx/.claude/CLAUDE.md" "$prefix/current/claude/CLAUDE.md"
     assert_exists "$sbx/.claude/CLAUDE.md.backup"
     assert_real_file "$sbx/.claude/settings.json"
     if grep -q '"dummy"' "$sbx/.claude/settings.json" 2>/dev/null; then
@@ -319,7 +322,7 @@ scenario_backup_symlink_idempotent_uninstall() {
     local skill
     while IFS= read -r skill; do
       [ -n "$skill" ] || continue
-      assert_symlink "$sbx/.claude/skills/$skill" "$REPO_ROOT/claude/skills/$skill"
+      assert_symlink "$sbx/.claude/skills/$skill" "$prefix/current/claude/skills/$skill"
     done <<EOF
 $(list_repo_skills)
 EOF
@@ -383,10 +386,17 @@ EOF
       fail "uninstall で claude/CLAUDE.md が元のファイルに復元された"
     fi
     if [ -n "$existing_skill" ]; then
-      if [ -d "$sbx/.claude/skills/$existing_skill" ] && [ ! -L "$sbx/.claude/skills/$existing_skill" ] && [ -f "$sbx/.claude/skills/$existing_skill/DUMMY_MARKER" ]; then
-        pass "uninstall で既存skillがskills-backupから復元された"
+      # 孫2時点では uninstall.sh の KNOWN_SKILLS_SRC_claude が作業ツリーの
+      # パスを見たままで、current 経由で張られた新方式の skill symlink を
+      # 認識できない(孫3で対応予定 — 計画書 DOC-2608040234 孫2「やらない
+      # こと」参照)。そのため uninstall はこの skill を素通りし、symlink
+      # が current 経由のまま残り、skills-backup からの復元も起きない。
+      # 孫3が由来判定を両対応させたら、この期待値は「復元される」側へ
+      # 反転させる。
+      if [ -L "$sbx/.claude/skills/$existing_skill" ] && [ "$(readlink "$sbx/.claude/skills/$existing_skill")" = "$prefix/current/claude/skills/$existing_skill" ]; then
+        pass "uninstall は新方式skillのsymlinkを未対応のまま残す(孫3で対応予定)"
       else
-        fail "uninstall で既存skillがskills-backupから復元された"
+        fail "uninstall は新方式skillのsymlinkを未対応のまま残す(孫3で対応予定)"
       fi
     fi
   fi
@@ -707,6 +717,98 @@ scenario_symlink_ownership_and_standalone_deploy() {
   fi
 }
 
+# ── シナリオ9: ソースツリー消失耐性(claude版) ──────────────────────────
+
+scenario_claude_source_tree_disappears() {
+  if ! has_tool claude; then
+    return
+  fi
+  log "=== シナリオ9: ソースツリー消失耐性(claude版) ==="
+  local sbx copy_dir out rc claude_md_content skill
+
+  new_sandbox
+  sbx="$SANDBOX_DIR"
+  copy_dir="$(mktemp -d)"
+  CREATED_DIRS+=("$copy_dir")
+  copy_repo_snapshot "$copy_dir"
+
+  out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --force --only claude 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "コピーからの deploy-all.sh --only claude が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+
+  claude_md_content="$(cat "$sbx/.claude/CLAUDE.md" 2>/dev/null)"
+  if [ -z "$claude_md_content" ]; then
+    fail "deploy 直後に $sbx/.claude/CLAUDE.md が読めること"
+    return
+  fi
+  pass "deploy 直後に $sbx/.claude/CLAUDE.md が読める"
+
+  # ソースツリー(コピー)を削除する。世代は cp -a による実体コピーなので、
+  # 消えたソースツリーに依存していなければ $HOME 側は引き続き読めるはず
+  # (ADR 問題2の回帰テスト。claude 側は孫1では未対応だったため孫2で追加)。
+  rm -rf "$copy_dir"
+
+  if [ "$(cat "$sbx/.claude/CLAUDE.md" 2>/dev/null)" = "$claude_md_content" ]; then
+    pass "ソースツリー削除後も \$HOME/.claude/CLAUDE.md が同じ内容で読める(消失耐性)"
+  else
+    fail "ソースツリー削除後も \$HOME/.claude/CLAUDE.md が同じ内容で読める(消失耐性)"
+  fi
+
+  while IFS= read -r skill; do
+    [ -n "$skill" ] || continue
+    if [ -d "$sbx/.claude/skills/$skill" ]; then
+      pass "ソースツリー削除後も skill が読める: $skill"
+    else
+      fail "ソースツリー削除後も skill が読める: $skill"
+    fi
+  done <<EOF
+$(list_repo_skills)
+EOF
+}
+
+# ── シナリオ10: settings.machine.json が世代に入りマージが効く ───────────
+
+scenario_claude_settings_machine_merge() {
+  if ! has_tool claude; then
+    return
+  fi
+  log "=== シナリオ10: settings.machine.json が世代に入りマージが効く ==="
+  local sbx copy_dir out rc
+
+  new_sandbox
+  sbx="$SANDBOX_DIR"
+  copy_dir="$(mktemp -d)"
+  CREATED_DIRS+=("$copy_dir")
+  copy_repo_snapshot "$copy_dir"
+
+  # settings.machine.json は非追跡(.gitignore)だが、create_generation は
+  # 作業ツリーのファイルコピー(cp -a)であって git archive ではないので、
+  # このコピー側に置いたファイルも世代に入るはず(ADR §2.4)。
+  cat >"$copy_dir/claude/settings.machine.json" <<'JSONEOF'
+{
+  "smokeTestMarker": "smoke-test-value"
+}
+JSONEOF
+
+  out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --force --only claude 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "settings.machine.json 付きの deploy-all.sh --only claude が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+
+  if grep -q "smokeTestMarker" "$sbx/.claude/settings.json" 2>/dev/null; then
+    pass "非追跡の settings.machine.json が世代にコピーされ、マージ結果が settings.json に反映される"
+  else
+    fail "非追跡の settings.machine.json が世代にコピーされ、マージ結果が settings.json に反映される"
+  fi
+}
+
 log "REPO_ROOT: $REPO_ROOT"
 log "対象ツール: $TOOLS"
 log
@@ -726,6 +828,10 @@ log
 scenario_migration_no_backup_for_repo_owned_symlink
 log
 scenario_symlink_ownership_and_standalone_deploy
+log
+scenario_claude_source_tree_disappears
+log
+scenario_claude_settings_machine_merge
 log
 
 if [ "$FAIL" -eq 0 ]; then

--- a/tests/deploy_smoke.sh
+++ b/tests/deploy_smoke.sh
@@ -398,6 +398,20 @@ EOF
       else
         fail "uninstall は新方式skillのsymlinkを未対応のまま残す(孫3で対応予定)"
       fi
+
+      # symlink を素通りするだけでなく、deploy 時に skills-backup へ退避した
+      # 元のスキルも失われずに残っていることを確認する。孫3が復元を実装する
+      # 前提はここに元データが残っていることなので、deploy 側の退化(取りこぼし・
+      # 上書き)が起きていないことをこのタイミングで検証しておく。
+      local backup_match_after_uninstall=""
+      for cand in "$sbx/.claude/skills-backup/$existing_skill".*; do
+        [ -e "$cand" ] && backup_match_after_uninstall="$cand" && break
+      done
+      if [ -n "$backup_match_after_uninstall" ] && [ -f "$backup_match_after_uninstall/DUMMY_MARKER" ]; then
+        pass "uninstall 後も退避された元skillがskills-backupに残っている(孫3の復元実装の前提): $backup_match_after_uninstall"
+      else
+        fail "uninstall 後も退避された元skillがskills-backupに残っている(孫3の復元実装の前提)"
+      fi
     fi
   fi
 }
@@ -807,6 +821,61 @@ JSONEOF
   else
     fail "非追跡の settings.machine.json が世代にコピーされ、マージ結果が settings.json に反映される"
   fi
+
+  # smokeTestMarker の有無だけでは、settings.machine.json を「マージ」でなく
+  # 「丸ごとコピー」する実装に退化しても緑のままになってしまう。ベース設定
+  # (claude/settings.json)側にしかないキーも一緒に残っていることを確認し、
+  # 両方が合成された結果であることを検証する。
+  if grep -q '"permissions"' "$sbx/.claude/settings.json" 2>/dev/null; then
+    pass "ベース設定(claude/settings.json)側のキーもマージ後に残っている(丸ごと上書きされていない)"
+  else
+    fail "ベース設定(claude/settings.json)側のキーもマージ後に残っている(丸ごと上書きされていない)"
+  fi
+}
+
+# ── シナリオ11: 旧方式(直リンク)skill symlinkの移行 + stale掃除(claude版) ──
+
+scenario_claude_skill_migration() {
+  if ! has_tool claude; then
+    return
+  fi
+  log "=== シナリオ11: 旧方式(直リンク)skill symlinkの移行 + stale掃除(claude版) ==="
+  local sbx out rc skill_name prefix
+
+  new_sandbox
+  sbx="$SANDBOX_DIR"
+  mkdir -p "$sbx/.claude/skills"
+
+  skill_name="$(list_repo_skills | head -n1)"
+  if [ -z "$skill_name" ]; then
+    log "  (claude/skills/ 配下にスキルが無いためスキップ)"
+    return
+  fi
+
+  # 旧方式(作業ツリー直リンク)の skill symlink を再現する。current 経由へ
+  # 配布元が変わったことで、244行目付近の「既に正しいsymlinkか」の判定に
+  # 一致しなくなり、バックアップ処理へ落ちる経路を通る(ADR §4.9)。
+  ln -s "$REPO_ROOT/claude/skills/$skill_name" "$sbx/.claude/skills/$skill_name"
+  # 存在しないスキルを指す旧方式リンク(stale)も再現する。
+  ln -s "$REPO_ROOT/claude/skills/smoke-test-gone-skill" "$sbx/.claude/skills/smoke-test-gone-skill"
+
+  out="$(run_deploy "$sbx" --force --only claude 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "旧方式skillリンクが存在する状態での deploy-all.sh --only claude が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+
+  prefix="$(dotfiles_prefix_for "$sbx")"
+  assert_symlink "$sbx/.claude/skills/$skill_name" "$prefix/current/claude/skills/$skill_name"
+  assert_not_exists "$sbx/.claude/skills-backup"
+
+  if [ -L "$sbx/.claude/skills/smoke-test-gone-skill" ] || [ -e "$sbx/.claude/skills/smoke-test-gone-skill" ]; then
+    fail "存在しないスキルを指す旧方式リンクが掃除される: $sbx/.claude/skills/smoke-test-gone-skill"
+  else
+    pass "存在しないスキルを指す旧方式リンクが掃除される"
+  fi
 }
 
 log "REPO_ROOT: $REPO_ROOT"
@@ -832,6 +901,8 @@ log
 scenario_claude_source_tree_disappears
 log
 scenario_claude_settings_machine_merge
+log
+scenario_claude_skill_migration
 log
 
 if [ "$FAIL" -eq 0 ]; then


### PR DESCRIPTION
## 背景

dotfilesは、macOS / Linux / WSL2 で共通の開発環境を再現するための設定リポジトリです。これまで `$HOME` の設定ファイルはリポジトリの作業ツリーへ直接シンボリックリンクされていましたが、この方式には「編集途中の状態がそのまま本番になる」「ワークツリーを消すとリンク切れになる」といった不安定さがあり、これを解消する傘ブランチ（世代ディレクトリ + `current` シンボリックリンクによる配布実体レイヤの導入）が進んでいます。

先行するプルリクエストで `zsh` / `nvim` / `tmux` / `bin` の4ツールは配布実体経由に切り替わりました。`claude` だけは「`settings.json` の実ファイル生成」「`skills/` の個別シンボリックリンク」という2つの例外処理があるため別対応として残されていました。

## このプルリクエストの目的

`claude` の配布元を、他の4ツールと同じく配布実体（`current` シンボリックリンク経由）へ揃えます。

## 実装内容

- `claude/deploy.sh` の配布元を、スクリプト自身の位置（作業ツリー）から `DOTFILES_DEPLOY_SRC`（`current` を指す固定パス）へ変更しました。対象は次の3箇所です。
  - `~/.claude/CLAUDE.md` のシンボリックリンク先
  - `~/.claude/settings.json` のマージ元2ファイル（`settings.json` と、マシン固有設定の非追跡ファイル `settings.machine.json`）
  - `~/.claude/skills/<スキル名>` の個別シンボリックリンク先
- `~/.claude/settings.json` が実ファイルとして生成されること、`skills/` がスキルごとの個別シンボリックリンクであることなど、既存の設計は変更していません。
- `--dry-run` のときは、まだ存在しない配布実体（`current` が未作成、または次に作られる世代）の中身を実在性チェックする形にはできないため、「何のスキルが配布対象か」「settings.machine.json はあるか」を調べる列挙元は作業ツリーを参照するようにしました。一方で、実際にシンボリックリンクが指す先（配布元そのもの）は `--dry-run` でも常に配布実体（`current` 経由）を指すようにしています。列挙元と配布元を分けなかった場合、`--dry-run` の計画が「作業ツリーへ直接リンクする」という、このプルリクエストが廃止しようとしている旧方式そのものを提案してしまうためです。
- 配布元が変わったことで、旧方式（作業ツリー直リンク）のスキルのシンボリックリンクが「既に正しいシンボリックリンクか」の判定に一致しなくなり、無条件で `skills-backup` へ退避される経路を通ってしまう問題に対応しました。退避前に「このリポジトリ由来のシンボリックリンクか」を判定し、そうであれば退避せずに張り替えるようにしています（`symlink_backup` が `CLAUDE.md` に対して行っている扱いと同じです）。
- 同様に、消えた・リネームされたスキルへの stale なシンボリックリンクを掃除する処理も、新方式（配布実体経由）と旧方式（作業ツリー直リンク）の両方のパスを認識するようにしました。
- `tests/deploy_smoke.sh` を更新しました。
  - 既存の claude 関連の検証を、新しいリンク先（`current` 経由）で通るように直しました。
  - サンドボックス内のコピーから配布し、そのコピーを削除しても `~/.claude/CLAUDE.md` とスキルが読めることを確認する検証を追加しました。
  - 非追跡の `settings.machine.json` が配布実体（世代ディレクトリ）にコピーされ、マージ結果が `~/.claude/settings.json` に反映されることを確認する検証を追加しました。マージ後もベース設定側のキーが残っていることも確認し、「マージ」が「丸ごとコピー」に退化していないことを検証します。
  - 旧方式のスキルのシンボリックリンクが退避されずに張り替えられること、stale な旧方式リンクが掃除されることを確認する検証を追加しました。
  - デプロイ済みの状態に対して `--dry-run` を実行しても、計画のシンボリックリンク向き先に作業ツリーのパスが現れないこと（＝実行結果と食い違わないこと）を確認する検証を追加しました。

## レビューで見てほしいところ

- `uninstall.sh` はまだ対応していません。`uninstall.sh` が持つ「このスキルはリポジトリ由来か」の判定は、いまだに作業ツリーのパスを見ているため、このプルリクエストの後に配布された新方式のスキルのシンボリックリンクを認識できず、`uninstall.sh` を実行してもそのまま残ります。これは対応順序上、後続の作業（`uninstall.sh` を配布実体レイヤへ追従させる作業）でまとめて直す想定です。`tests/deploy_smoke.sh` 側でも、この既知の制約を踏まえて「現時点では復元されない」ことを検証する形に変更してあります。後続の作業でこの制約を解消したら、期待値を「復元される」側へ反転させる必要があります。
- `~/.claude/skills/` の走査元・シンボリックリンク先を配布実体経由に変えたことで、既存のガード（ディレクトリ丸ごとのシンボリックリンク検出、配布元と配布先が同一パスになる場合のスキップ）が引き続き同じ意味で機能するかを確認してもらえると助かります。
- 「列挙元」（`--dry-run` 時は作業ツリー、実行時は配布実体）と「シンボリックリンクの向き先」（常に配布実体）を別の変数で分けた設計にしています。この分け方が今後の変更でも維持しやすいか、判断をお願いします。

## テスト結果

`pre-commit run --all-files`・`./deploy-all.sh --dry-run`・`tests/deploy_smoke.sh` はすべて緑です。

## 今後の予定

`uninstall.sh` を配布実体レイヤへ追従させる作業と、既知のバグ修正（`uninstall.sh` の `bin` 配下のリンク一覧に `ocw-meter` が欠けている点）を後続で行う予定です。
