### PR TITLE
uninstall.sh を配布実体経由の新方式へ追従させる

### DIFF
--- a/shared/helpers.sh
+++ b/shared/helpers.sh
@@ -324,8 +324,15 @@ _dotfiles_symlink_is_repo_owned() {
 # codebase. The symlink check runs before the existence check on purpose: a
 # broken symlink is -L true but -e false (it follows the dangling target),
 # so checking -e first would silently let a broken symlink slip past this
-# guard entirely. Shared by create_generation (scratch cleanup) and
-# gc_generations (old-generation cleanup) so both go through one path.
+# guard entirely. Shared by create_generation (scratch cleanup),
+# gc_generations (old-generation cleanup) and uninstall.sh (distribution
+# artifact cleanup) so all three go through one path.
+#
+# DRY_RUN-aware: the three guard checks above always run (so a dry-run
+# report matches what a real run would refuse), and only the final
+# `rm -rf` itself is skipped, printed instead — the same "report what a
+# real run would actually hit" policy create_generation's id-collision
+# check follows for its own DRY_RUN branch.
 _dotfiles_safe_rmdir() {
   _dsr_path="$1"
   _dsr_prefix="$2"
@@ -346,6 +353,11 @@ _dotfiles_safe_rmdir() {
       return 1
       ;;
   esac
+
+  if [ "${DRY_RUN:-0}" -eq 1 ]; then
+    printf '[DRY-RUN] rm -rf %s\n' "$_dsr_path"
+    return 0
+  fi
 
   rm -rf "$_dsr_path"
 }

--- a/tests/deploy_smoke.sh
+++ b/tests/deploy_smoke.sh
@@ -1032,23 +1032,54 @@ scenario_distribution_artifact_cleanup() {
 
   assert_not_exists "$prefix/generations"
   assert_not_exists "$prefix/current"
+  # generations/ と current だけでなく、prefix自体(.tmp/を含む)も片付く
+  # ことを確認する。create_generation はビルド用scratchを
+  # <prefix>/.tmp/ に作り(shared/helpers.sh)、成功時にgenerations/へ
+  # mvするが .tmp ディレクトリ自体は残り続けるため、これを消し忘れると
+  # prefixがいつまでも空にならない(rmdirが常に失敗する)。
+  assert_not_exists "$prefix"
 }
 
 # ── シナリオ15: devモード(currentがソースツリーを指す)でのソースツリー保護 ──
 
 scenario_dev_mode_source_tree_protection() {
+  if ! has_tool bin; then
+    return
+  fi
   log "=== シナリオ15: devモードでのuninstallはcurrentが指すソースツリーを削除しない ==="
-  local sbx dev_src prefix marker out rc
+  local sbx dev_src prefix marker out rc copy_dir
 
   new_sandbox
   sbx="$SANDBOX_DIR"
+  prefix="$(dotfiles_prefix_for "$sbx")"
+
+  # 先に世代モードで一度 deploy し、generations/ に実体を作っておく。
+  # 実運用でありうる「世代モードで運用したあと dev モードへ切り替えて
+  # uninstall する」経路を再現する。dev モードの current は実運用でも
+  # generations/ を経由しないので、この generations/ は dev モードに
+  # 切り替えたあとに uninstall で消えるべき「片付け対象」であり、
+  # 「消してはいけないソースツリー」とは別物であることを検証する。
+  copy_dir="$(mktemp -d)"
+  CREATED_DIRS+=("$copy_dir")
+  copy_repo_snapshot "$copy_dir"
+  out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --force --only bin 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "事前準備(世代モードでのdeploy-all.sh --force --only bin)が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+  if [ ! -d "$prefix/generations" ]; then
+    fail "事前準備: generations/ が作られている"
+    return
+  fi
+  pass "事前準備: 世代モードでdeployし、generations/ が存在する"
+
   dev_src="$(mktemp -d)"
   CREATED_DIRS+=("$dev_src")
   marker="dev-source-tree-marker-$$"
   printf '%s\n' "$marker" >"$dev_src/MARKER"
 
-  prefix="$(dotfiles_prefix_for "$sbx")"
-  mkdir -p "$prefix"
   # 孫4の --dev はまだ無いので、current を手でソースツリーへ向けて dev
   # モードを再現する(計画書 DOC-2608040234 孫3「dev モードの検証はサンド
   # ボックス内で current を手でソースツリーへ向ければよい」を参照)。
@@ -1067,6 +1098,12 @@ scenario_dev_mode_source_tree_protection() {
   else
     fail "devモードのソースツリーはuninstallで削除されない(実体は無傷)"
   fi
+
+  # ソースツリー自体は無傷である一方、current というリンク自体と
+  # generations/ (dev モードのcurrentが指す先ではない、別に存在していた
+  # 実体)は片付けられることを確認する。
+  assert_not_exists "$prefix/current"
+  assert_not_exists "$prefix/generations"
 }
 
 # ── シナリオ16: uninstall で ~/bin/ocw-meter が撤去される ────────────────
@@ -1154,6 +1191,10 @@ scenario_claude_new_scheme_skill_removed_and_restored() {
   else
     fail "復元後、skills-backup配下の退避データは残っていない(復元先へ移動済み): $backup_match が残存"
   fi
+
+  # 退避データそのものだけでなく、空になった skills-backup ディレクトリ
+  # 自体も片付くことを確認する。
+  assert_not_exists "$sbx/.claude/skills-backup"
 }
 
 # ── シナリオ18: deployを介さない旧方式skillリンクもuninstallが撤去する ────
@@ -1188,6 +1229,180 @@ scenario_claude_old_scheme_skill_removed_by_uninstall() {
   fi
 
   assert_not_exists "$sbx/.claude/skills/$skill_name"
+}
+
+# ── シナリオ19: スコープ外ツールが参照している間は配布実体の後片付けをスキップする ──
+
+scenario_cleanup_skipped_while_other_tool_in_scope() {
+  if ! has_tool bin || ! has_tool claude; then
+    return
+  fi
+  log "=== シナリオ19: bin,claudeをdeployし、binだけuninstallしても配布実体は残る(claudeがまだ参照している) ==="
+  local sbx prefix out rc skill_name
+
+  new_sandbox
+  sbx="$SANDBOX_DIR"
+  prefix="$(dotfiles_prefix_for "$sbx")"
+
+  skill_name="$(list_repo_skills | head -n1)"
+
+  out="$(run_deploy "$sbx" --force --only bin,claude 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "deploy-all.sh --force --only bin,claude が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+
+  out="$(run_uninstall "$sbx" --force --only bin 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "uninstall.sh --force --only bin が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+
+  assert_not_exists "$sbx/bin/ocw"
+  if [ -d "$prefix/generations" ] && [ -L "$prefix/current" ]; then
+    pass "claudeがまだ配布実体を参照しているため、bin単独のuninstallでは配布実体が残る"
+  else
+    fail "claudeがまだ配布実体を参照しているため、bin単独のuninstallでは配布実体が残る"
+  fi
+  if [ -n "$skill_name" ]; then
+    assert_symlink "$sbx/.claude/skills/$skill_name" "$prefix/current/claude/skills/$skill_name"
+  fi
+
+  # claude も uninstall してはじめて、どのツールも配布実体を参照しなくなり
+  # 後片付けが実行される。
+  out="$(run_uninstall "$sbx" --force --only claude 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "uninstall.sh --force --only claude が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+
+  assert_not_exists "$prefix/generations"
+  assert_not_exists "$prefix/current"
+}
+
+# ── シナリオ20: symlink撤去に失敗した場合は配布実体を残す ────────────────
+
+scenario_cleanup_skipped_when_symlink_removal_fails() {
+  if ! has_tool bin; then
+    return
+  fi
+  log "=== シナリオ20: symlinkの撤去に失敗した場合、配布実体を消さず生き残ったリンクをリンク切れにしない ==="
+  local sbx prefix out rc
+
+  new_sandbox
+  sbx="$SANDBOX_DIR"
+  prefix="$(dotfiles_prefix_for "$sbx")"
+
+  out="$(run_deploy "$sbx" --force --only bin 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "deploy-all.sh --force --only bin が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+
+  # ~/bin を書き込み不可にして、symlinkの削除(rm)自体を失敗させる。
+  chmod 555 "$sbx/bin"
+
+  out="$(run_uninstall "$sbx" --force --only bin 2>&1)"
+  rc=$?
+
+  # trap cleanup がサンドボックスを削除できるよう、権限を元に戻す。
+  chmod 755 "$sbx/bin"
+
+  if [ "$rc" -eq 0 ]; then
+    fail "symlink削除に失敗する状況でuninstall.shがエラー終了する (exit=0になってしまった)"
+    log "$out"
+    return
+  fi
+  pass "symlink削除に失敗する状況でuninstall.shがエラー終了する (exit=$rc)"
+
+  if [ -L "$sbx/bin/ocw" ]; then
+    pass "削除に失敗したsymlinkは(壊れずに)残っている"
+  else
+    fail "削除に失敗したsymlinkは(壊れずに)残っている"
+  fi
+
+  if [ -d "$prefix/generations" ] && [ -L "$prefix/current" ]; then
+    pass "symlinkの撤去に失敗した場合、配布実体は消されずに残る(生き残ったリンクをリンク切れにしない)"
+  else
+    fail "symlinkの撤去に失敗した場合、配布実体は消されずに残る(生き残ったリンクをリンク切れにしない)"
+  fi
+}
+
+# ── シナリオ21: 配布実体後片付けのdry-run出力が実際の挙動と一致する ────────
+
+scenario_cleanup_dry_run_matches_reality() {
+  if ! has_tool bin; then
+    return
+  fi
+  log "=== シナリオ21: 配布実体後片付けのdry-run出力が実際の挙動と一致する ==="
+  local sbx prefix out rc
+
+  new_sandbox
+  sbx="$SANDBOX_DIR"
+  prefix="$(dotfiles_prefix_for "$sbx")"
+
+  out="$(run_deploy "$sbx" --force --only bin 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "deploy-all.sh --force --only bin が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+
+  out="$(run_uninstall "$sbx" --dry-run --only bin 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "uninstall.sh --dry-run --only bin が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+
+  if [ -d "$prefix/generations" ] && [ -L "$prefix/current" ]; then
+    pass "--dry-runでは配布実体が実際には消えない"
+  else
+    fail "--dry-runでは配布実体が実際には消えない"
+  fi
+
+  if printf '%s' "$out" | grep -qF "[DRY-RUN] rm -rf $prefix/generations"; then
+    pass "dry-run出力にgenerationsの削除計画が含まれる"
+  else
+    fail "dry-run出力にgenerationsの削除計画が含まれる"
+    log "$out"
+  fi
+
+  # --- generations が(何らかの理由で)symlinkだった場合、dry-runでも
+  #     実行時と同じ拒否になること(create_generationのid衝突チェックが
+  #     dry-runでも実行時と同じ失敗を報告する方針に揃える) ---
+  new_sandbox
+  sbx="$SANDBOX_DIR"
+  prefix="$(dotfiles_prefix_for "$sbx")"
+  out="$(run_deploy "$sbx" --force --only bin 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "2回目のdeploy-all.sh --force --only bin が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+
+  rm -rf "$prefix/generations"
+  ln -s "$sbx" "$prefix/generations"
+
+  out="$(run_uninstall "$sbx" --dry-run --only bin 2>&1)"
+  if printf '%s' "$out" | grep -q "Refusing to remove a symlink"; then
+    pass "generationsがsymlinkの場合、dry-runでも実行時と同じ拒否メッセージになる"
+  else
+    fail "generationsがsymlinkの場合、dry-runでも実行時と同じ拒否メッセージになる"
+    log "$out"
+  fi
+  rm -f "$prefix/generations"
 }
 
 log "REPO_ROOT: $REPO_ROOT"
@@ -1229,6 +1444,12 @@ log
 scenario_claude_new_scheme_skill_removed_and_restored
 log
 scenario_claude_old_scheme_skill_removed_by_uninstall
+log
+scenario_cleanup_skipped_while_other_tool_in_scope
+log
+scenario_cleanup_skipped_when_symlink_removal_fails
+log
+scenario_cleanup_dry_run_matches_reality
 log
 
 if [ "$FAIL" -eq 0 ]; then

--- a/tests/deploy_smoke.sh
+++ b/tests/deploy_smoke.sh
@@ -386,31 +386,27 @@ EOF
       fail "uninstall で claude/CLAUDE.md が元のファイルに復元された"
     fi
     if [ -n "$existing_skill" ]; then
-      # 孫2時点では uninstall.sh の KNOWN_SKILLS_SRC_claude が作業ツリーの
-      # パスを見たままで、current 経由で張られた新方式の skill symlink を
-      # 認識できない(孫3で対応予定 — 計画書 DOC-2608040234 孫2「やらない
-      # こと」参照)。そのため uninstall はこの skill を素通りし、symlink
-      # が current 経由のまま残り、skills-backup からの復元も起きない。
-      # 孫3が由来判定を両対応させたら、この期待値は「復元される」側へ
-      # 反転させる。
-      if [ -L "$sbx/.claude/skills/$existing_skill" ] && [ "$(readlink "$sbx/.claude/skills/$existing_skill")" = "$prefix/current/claude/skills/$existing_skill" ]; then
-        pass "uninstall は新方式skillのsymlinkを未対応のまま残す(孫3で対応予定)"
+      # 孫3で uninstall.sh の由来判定が両対応になり、current 経由で張られた
+      # 新方式の skill symlink も認識・撤去できるようになった(ADR §4.8/§4.9
+      # / DOC-2608040229)。撤去後は deploy 時に skills-backup へ退避して
+      # おいた元のスキルが復元される。
+      if [ -d "$sbx/.claude/skills/$existing_skill" ] && [ ! -L "$sbx/.claude/skills/$existing_skill" ] && [ -f "$sbx/.claude/skills/$existing_skill/DUMMY_MARKER" ]; then
+        pass "uninstallで新方式skillのsymlinkが撤去され、元skillが復元された: $sbx/.claude/skills/$existing_skill"
       else
-        fail "uninstall は新方式skillのsymlinkを未対応のまま残す(孫3で対応予定)"
+        fail "uninstallで新方式skillのsymlinkが撤去され、元skillが復元された: $sbx/.claude/skills/$existing_skill"
       fi
 
-      # symlink を素通りするだけでなく、deploy 時に skills-backup へ退避した
-      # 元のスキルも失われずに残っていることを確認する。孫3が復元を実装する
-      # 前提はここに元データが残っていることなので、deploy 側の退化(取りこぼし・
-      # 上書き)が起きていないことをこのタイミングで検証しておく。
+      # 復元は「移動」であって「コピー」ではないので、skills-backup 配下に
+      # 退避データが残っていないことも確認する(残っていれば復元処理の
+      # 実装が mv ではなく cp 相当に退化している証拠になる)。
       local backup_match_after_uninstall=""
       for cand in "$sbx/.claude/skills-backup/$existing_skill".*; do
         [ -e "$cand" ] && backup_match_after_uninstall="$cand" && break
       done
-      if [ -n "$backup_match_after_uninstall" ] && [ -f "$backup_match_after_uninstall/DUMMY_MARKER" ]; then
-        pass "uninstall 後も退避された元skillがskills-backupに残っている(孫3の復元実装の前提): $backup_match_after_uninstall"
+      if [ -z "$backup_match_after_uninstall" ]; then
+        pass "復元後、skills-backup配下の退避データは残っていない(復元先へ移動済み)"
       else
-        fail "uninstall 後も退避された元skillがskills-backupに残っている(孫3の復元実装の前提)"
+        fail "復元後、skills-backup配下の退避データは残っていない(復元先へ移動済み): $backup_match_after_uninstall が残存"
       fi
     fi
   fi
@@ -998,6 +994,202 @@ EOF
   fi
 }
 
+# ── シナリオ14: 配布実体(generations/current)の後片付け ─────────────────
+
+scenario_distribution_artifact_cleanup() {
+  if ! has_tool bin; then
+    return
+  fi
+  log "=== シナリオ14: uninstallで配布実体(generations/current)が片付く ==="
+  local sbx prefix out rc
+
+  new_sandbox
+  sbx="$SANDBOX_DIR"
+  prefix="$(dotfiles_prefix_for "$sbx")"
+
+  out="$(run_deploy "$sbx" --force --only bin 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "deploy-all.sh --force --only bin が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+
+  if [ -d "$prefix/generations" ] && [ -L "$prefix/current" ]; then
+    pass "deploy 直後は generations/ と current が存在する"
+  else
+    fail "deploy 直後は generations/ と current が存在する"
+    return
+  fi
+
+  out="$(run_uninstall "$sbx" --force --only bin 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "uninstall.sh --force --only bin が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+
+  assert_not_exists "$prefix/generations"
+  assert_not_exists "$prefix/current"
+}
+
+# ── シナリオ15: devモード(currentがソースツリーを指す)でのソースツリー保護 ──
+
+scenario_dev_mode_source_tree_protection() {
+  log "=== シナリオ15: devモードでのuninstallはcurrentが指すソースツリーを削除しない ==="
+  local sbx dev_src prefix marker out rc
+
+  new_sandbox
+  sbx="$SANDBOX_DIR"
+  dev_src="$(mktemp -d)"
+  CREATED_DIRS+=("$dev_src")
+  marker="dev-source-tree-marker-$$"
+  printf '%s\n' "$marker" >"$dev_src/MARKER"
+
+  prefix="$(dotfiles_prefix_for "$sbx")"
+  mkdir -p "$prefix"
+  # 孫4の --dev はまだ無いので、current を手でソースツリーへ向けて dev
+  # モードを再現する(計画書 DOC-2608040234 孫3「dev モードの検証はサンド
+  # ボックス内で current を手でソースツリーへ向ければよい」を参照)。
+  ln -sfn "$dev_src" "$prefix/current"
+
+  out="$(run_uninstall "$sbx" --force 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "devモード状態での uninstall.sh --force が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+
+  if [ -d "$dev_src" ] && [ -f "$dev_src/MARKER" ] && [ "$(cat "$dev_src/MARKER")" = "$marker" ]; then
+    pass "devモードのソースツリーはuninstallで削除されない(実体は無傷)"
+  else
+    fail "devモードのソースツリーはuninstallで削除されない(実体は無傷)"
+  fi
+}
+
+# ── シナリオ16: uninstall で ~/bin/ocw-meter が撤去される ────────────────
+
+scenario_ocw_meter_removed_on_uninstall() {
+  if ! has_tool bin; then
+    return
+  fi
+  log "=== シナリオ16: uninstall で ~/bin/ocw-meter が撤去される ==="
+  local sbx out rc
+
+  new_sandbox
+  sbx="$SANDBOX_DIR"
+
+  out="$(run_deploy "$sbx" --force --only bin 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "deploy-all.sh --force --only bin が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+  assert_symlink "$sbx/bin/ocw-meter" "$(dotfiles_prefix_for "$sbx")/current/bin/ocw-meter"
+
+  out="$(run_uninstall "$sbx" --force --only bin 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "uninstall.sh --force --only bin が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+  assert_not_exists "$sbx/bin/ocw-meter"
+}
+
+# ── シナリオ17: 新方式skillの撤去とskills-backupからの復元 ───────────────
+
+scenario_claude_new_scheme_skill_removed_and_restored() {
+  if ! has_tool claude; then
+    return
+  fi
+  log "=== シナリオ17: 新方式skillのsymlinkが撤去され、元skillがskills-backupから復元される ==="
+  local sbx prefix skill_name out rc backup_match
+
+  new_sandbox
+  sbx="$SANDBOX_DIR"
+  prefix="$(dotfiles_prefix_for "$sbx")"
+
+  skill_name="$(list_repo_skills | head -n1)"
+  if [ -z "$skill_name" ]; then
+    log "  (claude/skills/ 配下にスキルが無いためスキップ)"
+    return
+  fi
+
+  mkdir -p "$sbx/.claude/skills/$skill_name"
+  printf 'dummy-existing-skill\n' >"$sbx/.claude/skills/$skill_name/DUMMY_MARKER"
+
+  out="$(run_deploy "$sbx" --force --only claude 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "deploy-all.sh --force --only claude が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+  assert_symlink "$sbx/.claude/skills/$skill_name" "$prefix/current/claude/skills/$skill_name"
+
+  out="$(run_uninstall "$sbx" --force --only claude 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "uninstall.sh --force --only claude が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+
+  if [ -d "$sbx/.claude/skills/$skill_name" ] && [ ! -L "$sbx/.claude/skills/$skill_name" ] && [ -f "$sbx/.claude/skills/$skill_name/DUMMY_MARKER" ]; then
+    pass "新方式skillのsymlinkが撤去され、元skillがskills-backupから復元された: $sbx/.claude/skills/$skill_name"
+  else
+    fail "新方式skillのsymlinkが撤去され、元skillがskills-backupから復元された: $sbx/.claude/skills/$skill_name"
+  fi
+
+  backup_match=""
+  for cand in "$sbx/.claude/skills-backup/$skill_name".*; do
+    [ -e "$cand" ] && backup_match="$cand" && break
+  done
+  if [ -z "$backup_match" ]; then
+    pass "復元後、skills-backup配下の退避データは残っていない(復元先へ移動済み)"
+  else
+    fail "復元後、skills-backup配下の退避データは残っていない(復元先へ移動済み): $backup_match が残存"
+  fi
+}
+
+# ── シナリオ18: deployを介さない旧方式skillリンクもuninstallが撤去する ────
+
+scenario_claude_old_scheme_skill_removed_by_uninstall() {
+  if ! has_tool claude; then
+    return
+  fi
+  log "=== シナリオ18: deployを介さない旧方式skillリンクもuninstallが撤去する ==="
+  local sbx skill_name out rc
+
+  new_sandbox
+  sbx="$SANDBOX_DIR"
+  mkdir -p "$sbx/.claude/skills"
+
+  skill_name="$(list_repo_skills | head -n1)"
+  if [ -z "$skill_name" ]; then
+    log "  (claude/skills/ 配下にスキルが無いためスキップ)"
+    return
+  fi
+
+  # deploy.sh を一度も実行していない(=新方式へ移行する前の)状態を再現する。
+  # 作業ツリーを直接指す旧方式のskillリンクを手で張る。
+  ln -s "$REPO_ROOT/claude/skills/$skill_name" "$sbx/.claude/skills/$skill_name"
+
+  out="$(run_uninstall "$sbx" --force --only claude 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "旧方式skillリンクのみが存在する状態での uninstall.sh --force --only claude が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+
+  assert_not_exists "$sbx/.claude/skills/$skill_name"
+}
+
 log "REPO_ROOT: $REPO_ROOT"
 log "対象ツール: $TOOLS"
 log
@@ -1027,6 +1219,16 @@ log
 scenario_claude_dry_run_matches_deployed_state
 log
 scenario_claude_dry_run_before_first_deploy
+log
+scenario_distribution_artifact_cleanup
+log
+scenario_dev_mode_source_tree_protection
+log
+scenario_ocw_meter_removed_on_uninstall
+log
+scenario_claude_new_scheme_skill_removed_and_restored
+log
+scenario_claude_old_scheme_skill_removed_by_uninstall
 log
 
 if [ "$FAIL" -eq 0 ]; then

--- a/tests/deploy_smoke.sh
+++ b/tests/deploy_smoke.sh
@@ -1405,6 +1405,34 @@ scenario_cleanup_dry_run_matches_reality() {
   rm -f "$prefix/generations"
 }
 
+# ── シナリオ22: generations/もcurrentも無くscratchだけが残っていても片付く ──
+
+scenario_cleanup_removes_orphaned_scratch_without_generation() {
+  log "=== シナリオ22: generations/もcurrentも無く.tmp/のscratchだけが残っている状態でもuninstallで片付く ==="
+  local sbx prefix out rc
+
+  new_sandbox
+  sbx="$SANDBOX_DIR"
+  prefix="$(dotfiles_prefix_for "$sbx")"
+
+  # 初回deployがコピー中に中断された状態を再現する: create_generation
+  # (shared/helpers.sh)のscratch(.tmp/gen.XXXXXX)だけが残り、コピー完了後に
+  # mvされるはずの generations/ も switch_current が作る current も
+  # まだ存在しない。
+  mkdir -p "$prefix/.tmp/gen.CRASH1/bin"
+  printf 'dummy\n' >"$prefix/.tmp/gen.CRASH1/bin/ocw"
+
+  out="$(run_uninstall "$sbx" --force 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "uninstall.sh --force が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+
+  assert_not_exists "$prefix"
+}
+
 log "REPO_ROOT: $REPO_ROOT"
 log "対象ツール: $TOOLS"
 log
@@ -1450,6 +1478,8 @@ log
 scenario_cleanup_skipped_when_symlink_removal_fails
 log
 scenario_cleanup_dry_run_matches_reality
+log
+scenario_cleanup_removes_orphaned_scratch_without_generation
 log
 
 if [ "$FAIL" -eq 0 ]; then

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -17,6 +17,13 @@ SCRIPT_DIR=$(
 # shellcheck source=SCRIPTDIR/shared/helpers.sh
 . "$SCRIPT_DIR/shared/helpers.sh"
 
+# ── Distribution layer paths ─────────────────────────────────────────
+# Computed once: dotfiles_prefix()/dotfiles_current_link() only depend on
+# $HOME / $XDG_DATA_HOME, which are stable for the life of this process.
+DOTFILES_PREFIX="$(dotfiles_prefix)"
+DOTFILES_CURRENT_LINK="$(dotfiles_current_link)"
+DOTFILES_GENERATIONS_DIR="$DOTFILES_PREFIX/generations"
+
 # ── Defaults ──────────────────────────────────────────────────────────
 
 DRY_RUN=0
@@ -47,7 +54,8 @@ KNOWN_LINKS_tmux=$(
 KNOWN_LINKS_bin=$(
   printf '%s\n' \
     "$HOME/bin/ocw" \
-    "$HOME/bin/claude-ds"
+    "$HOME/bin/claude-ds" \
+    "$HOME/bin/ocw-meter"
 )
 
 KNOWN_LINKS_claude=$(
@@ -57,7 +65,13 @@ KNOWN_LINKS_claude=$(
 
 # Skills are symlinked individually by deploy.sh (auto-detected from
 # claude/skills/).  We walk ~/.claude/skills/ at uninstall time and
-# restore any symlink whose target points into the repo's claude/skills/.
+# restore any symlink whose target is repo-owned. A symlink counts as
+# repo-owned under either scheme: the current distribution scheme
+# (target under DOTFILES_PREFIX — via `current` or a generations/ dir
+# directly, see resolve_deploy_src) or the pre-migration direct-to-worktree
+# scheme (target under the checkout itself). Both must be recognized so
+# that machines with leftover pre-migration links can still be cleaned up
+# after adopting the new scheme (ADR DOC-2608040229 §4.8/§4.9).
 KNOWN_SKILLS_SRC_claude="$SCRIPT_DIR/claude/skills"
 
 # settings.json is a generated file (not a symlink) — handled separately.
@@ -204,8 +218,13 @@ for _tool in $TOOLS; do
     for _skill_link in "$HOME/.claude/skills"/*; do
       [ -L "$_skill_link" ] || continue
       _target=$(readlink "$_skill_link")
+      # Recognize both schemes: current-scheme links go through
+      # DOTFILES_PREFIX/current/claude/skills/<name> (the normal case) or,
+      # if DOTFILES_DEPLOY_SRC was pointed at a generation directly, through
+      # DOTFILES_PREFIX/generations/<id>/claude/skills/<name>. $_skills_src
+      # (the working tree) covers pre-migration direct-to-worktree links.
       case "$_target" in
-        "$_skills_src"/*)
+        "$DOTFILES_PREFIX/current/claude/skills"/* | "$DOTFILES_GENERATIONS_DIR"/*/claude/skills/* | "$_skills_src"/*)
           _skill_name=$(basename "$_skill_link")
           symlink_restore "$_skill_link" || OVERALL_OK=1
 
@@ -297,6 +316,124 @@ for _tool in $TOOLS; do
   fi
   IFS="$_OLDIFS"
 done
+
+# ── Distribution artifact cleanup (generations/ + current) ─────────────
+#
+# The canonical prefix is shared across every tool, not owned by any single
+# one — it is not something a per-tool KNOWN_LINKS_* loop can safely tear
+# down. If this uninstall run only targeted some tools (--only), a symlink
+# belonging to a tool NOT in $TOOLS is untouched by this run and may still
+# resolve through `current`, so we must not delete the prefix out from
+# under it.
+#
+# We check membership in $TOOLS rather than re-scanning the filesystem for
+# every tool: under --dry-run nothing was actually removed above, so a
+# post-loop filesystem scan of a tool that WAS in scope would wrongly see
+# its still-intact symlink and report a false "still referenced". A tool
+# in $TOOLS is trusted to have been (or, in dry-run, to be about to be)
+# cleared; only tools NOT in $TOOLS are checked against the live
+# filesystem, since those are untouched in both real and dry-run modes.
+#
+# Deletion never touches whatever `current` resolves to. In dev mode (see
+# ADR §4.5 / DOC-2608040229) `current` points at the human's own source
+# tree; the only thing removed there is the `current` symlink itself. The
+# real, cp -a'd generation directories under generations/ are always safe
+# to remove outright (rm -rf via _dotfiles_safe_rmdir), independent of what
+# `current` happens to point at, because a dev-mode `current` never points
+# inside generations/ in the first place — see "全孫共通の注意" §2.
+
+_dfu_still_referenced=0
+_dfu_scope=" $TOOLS "
+
+for _dfu_check_tool in $AVAILABLE_TOOLS; do
+  case "$_dfu_scope" in
+    *" $_dfu_check_tool "*) continue ;; # in scope this run — trust it's handled
+  esac
+
+  _dfu_check_links=""
+  case "$_dfu_check_tool" in
+    zsh) _dfu_check_links="$KNOWN_LINKS_zsh" ;;
+    nvim) _dfu_check_links="$KNOWN_LINKS_nvim" ;;
+    tmux) _dfu_check_links="$KNOWN_LINKS_tmux" ;;
+    bin) _dfu_check_links="$KNOWN_LINKS_bin" ;;
+    claude) _dfu_check_links="$KNOWN_LINKS_claude" ;;
+  esac
+
+  _OLDIFS="$IFS"
+  IFS='
+'
+  for _dfu_dst in $_dfu_check_links; do
+    IFS="$_OLDIFS"
+    [ -z "$_dfu_dst" ] && continue
+    if [ -L "$_dfu_dst" ]; then
+      case "$(readlink "$_dfu_dst")" in
+        "$DOTFILES_PREFIX"/*) _dfu_still_referenced=1 ;;
+      esac
+    fi
+    IFS='
+'
+  done
+  IFS="$_OLDIFS"
+done
+
+case "$_dfu_scope" in
+  *" claude "*) ;; # claude in scope this run — trust its skills are handled
+  *)
+    if [ "$_dfu_still_referenced" -eq 0 ] && [ -d "$HOME/.claude/skills" ]; then
+      for _dfu_skill_link in "$HOME/.claude/skills"/*; do
+        [ -L "$_dfu_skill_link" ] || continue
+        case "$(readlink "$_dfu_skill_link")" in
+          "$DOTFILES_PREFIX"/*) _dfu_still_referenced=1 ;;
+        esac
+      done
+    fi
+    ;;
+esac
+
+if [ "$_dfu_still_referenced" -ne 0 ]; then
+  log_info "Another tool's symlink still points into the distribution prefix — skipping its cleanup."
+elif [ -L "$DOTFILES_CURRENT_LINK" ] || [ -d "$DOTFILES_GENERATIONS_DIR" ]; then
+  log_hr
+  log_info "Cleaning up distribution artifacts"
+
+  if [ -L "$DOTFILES_CURRENT_LINK" ]; then
+    _dfu_current_target=$(readlink "$DOTFILES_CURRENT_LINK")
+    case "$_dfu_current_target" in
+      "$DOTFILES_GENERATIONS_DIR"/*) ;;
+      *)
+        log_info "current is in dev mode (points at a source tree, not a generation) — only the symlink itself will be removed: $_dfu_current_target"
+        ;;
+    esac
+  fi
+
+  if [ -d "$DOTFILES_GENERATIONS_DIR" ]; then
+    if [ "${DRY_RUN:-0}" -eq 1 ]; then
+      printf '[DRY-RUN] rm -rf %s\n' "$DOTFILES_GENERATIONS_DIR"
+    elif _dotfiles_safe_rmdir "$DOTFILES_GENERATIONS_DIR" "$DOTFILES_PREFIX"; then
+      log_ok "Removed generations directory: $DOTFILES_GENERATIONS_DIR"
+    else
+      log_error "Failed to remove generations directory: $DOTFILES_GENERATIONS_DIR"
+      OVERALL_OK=1
+    fi
+  fi
+
+  if [ -L "$DOTFILES_CURRENT_LINK" ]; then
+    if [ "${DRY_RUN:-0}" -eq 1 ]; then
+      printf '[DRY-RUN] rm %s\n' "$DOTFILES_CURRENT_LINK"
+    elif rm "$DOTFILES_CURRENT_LINK"; then
+      log_ok "Removed current symlink: $DOTFILES_CURRENT_LINK"
+    else
+      log_error "Failed to remove current symlink: $DOTFILES_CURRENT_LINK"
+      OVERALL_OK=1
+    fi
+  fi
+
+  if [ "${DRY_RUN:-0}" -eq 1 ]; then
+    printf '[DRY-RUN] rmdir %s (only if empty)\n' "$DOTFILES_PREFIX"
+  elif [ -d "$DOTFILES_PREFIX" ] && rmdir "$DOTFILES_PREFIX" 2>/dev/null; then
+    log_ok "Removed empty prefix directory: $DOTFILES_PREFIX"
+  fi
+fi
 
 # ── Summary ───────────────────────────────────────────────────────────
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -91,16 +91,16 @@ KNOWN_GENERATED_claude=$(
 # surfaces as "No link list defined for '<tool>'. Skipping." ONLY when
 # <tool> is in $TOOLS AND has no KNOWN_GENERATED_* entry either — the
 # main loop below only warns when both _links and _generated come back
-# empty (uninstall.sh:211). claude is the one tool where this doesn't
-# save you: it has KNOWN_GENERATED_claude (~/.claude/settings.json), so a
-# forgotten claude arm here still leaves _generated non-empty, the warning
-# never fires, and ~/.claude/CLAUDE.md quietly stops being touched while
-# the generation it points into gets deleted out from under it. A tool
-# NOT in $TOOLS is missed silently regardless of KNOWN_GENERATED_*: it's
-# only ever passed to this function by the cleanup's cross-tool scan,
-# which has no warning path at all (the tool is treated as having no
-# links, so a live symlink into a soon-to-be-deleted generation goes
-# undetected).
+# empty (see its "No link list defined" check). claude is the one tool
+# where this doesn't save you: it has KNOWN_GENERATED_claude
+# (~/.claude/settings.json), so a forgotten claude arm here still leaves
+# _generated non-empty, the warning never fires, and ~/.claude/CLAUDE.md
+# quietly stops being touched while the generation it points into gets
+# deleted out from under it. A tool NOT in $TOOLS is missed silently
+# regardless of KNOWN_GENERATED_*: it's only ever passed to this function
+# by the cleanup's cross-tool scan, which has no warning path at all (the
+# tool is treated as having no links, so a live symlink into a
+# soon-to-be-deleted generation goes undetected).
 #
 # A function (not eval-based indirection through a "KNOWN_LINKS_$tool"
 # name) keeps each KNOWN_LINKS_* variable directly referenced, so a

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -87,12 +87,17 @@ KNOWN_GENERATED_claude=$(
 # KNOWN_LINKS_* mapping: the main per-tool loop below and the distribution
 # artifact cleanup's cross-tool scan both need it, and duplicating this
 # case statement is exactly the kind of drift that let ocw-meter go
-# unlisted from KNOWN_LINKS_bin in the first place — except a forgotten
-# arm here fails silently (the tool is treated as having no links, so a
-# live symlink into a soon-to-be-deleted generation would be missed)
-# rather than with a visible warning. A function (not eval-based
-# indirection through a "KNOWN_LINKS_$tool" name) keeps each KNOWN_LINKS_*
-# variable directly referenced, so shellcheck can still see the use.
+# unlisted from KNOWN_LINKS_bin in the first place. A forgotten arm here
+# now surfaces as "No link list defined for '<tool>'. Skipping." whenever
+# <tool> is in $TOOLS, since the main loop below already checks for an
+# empty _links. But a tool NOT in $TOOLS is only ever passed to this
+# function by the cleanup's cross-tool scan, which has no such warning
+# path — a forgotten arm for an out-of-scope tool is still missed
+# silently there (the tool is treated as having no links, so a live
+# symlink into a soon-to-be-deleted generation goes undetected). A
+# function (not eval-based indirection through a "KNOWN_LINKS_$tool"
+# name) keeps each KNOWN_LINKS_* variable directly referenced, so a
+# static analysis tool can still see the use.
 links_for_tool() {
   case "$1" in
     zsh) printf '%s\n' "$KNOWN_LINKS_zsh" ;;
@@ -373,6 +378,7 @@ done
 # inside generations/ in the first place — see "全孫共通の注意" §2.
 
 _dfu_still_referenced=0
+_dfu_reason_path=""
 _dfu_scope=" $TOOLS "
 
 for _dfu_check_tool in $AVAILABLE_TOOLS; do
@@ -390,7 +396,10 @@ for _dfu_check_tool in $AVAILABLE_TOOLS; do
     [ -z "$_dfu_dst" ] && continue
     if [ -L "$_dfu_dst" ]; then
       case "$(readlink "$_dfu_dst")" in
-        "$DOTFILES_PREFIX"/*) _dfu_still_referenced=1 ;;
+        "$DOTFILES_PREFIX"/*)
+          _dfu_still_referenced=1
+          [ -n "$_dfu_reason_path" ] || _dfu_reason_path="$_dfu_dst"
+          ;;
       esac
     fi
     IFS='
@@ -412,14 +421,21 @@ if [ "$_dfu_still_referenced" -eq 0 ] && [ "$_dfu_check_claude_skills" -eq 1 ] &
   for _dfu_skill_link in "$HOME/.claude/skills"/*; do
     [ -L "$_dfu_skill_link" ] || continue
     case "$(readlink "$_dfu_skill_link")" in
-      "$DOTFILES_PREFIX"/*) _dfu_still_referenced=1 ;;
+      "$DOTFILES_PREFIX"/*)
+        _dfu_still_referenced=1
+        [ -n "$_dfu_reason_path" ] || _dfu_reason_path="$_dfu_skill_link"
+        ;;
     esac
   done
 fi
 
 if [ "$_dfu_still_referenced" -ne 0 ]; then
-  log_info "Another tool's symlink still points into the distribution prefix — skipping its cleanup."
-elif [ -L "$DOTFILES_CURRENT_LINK" ] || [ -d "$DOTFILES_GENERATIONS_DIR" ]; then
+  # Deliberately not "another tool's" — in real mode this can just as well
+  # be a tool that WAS in scope but whose own removal above failed
+  # (OVERALL_OK=1). Naming the actual offending path lets the operator
+  # tell the two cases apart instead of guessing.
+  log_info "Still referenced: $_dfu_reason_path points into the distribution prefix — skipping its cleanup (either a tool outside --only, or removal of this link failed above)."
+elif [ -L "$DOTFILES_CURRENT_LINK" ] || [ -d "$DOTFILES_GENERATIONS_DIR" ] || [ -d "$DOTFILES_PREFIX/.tmp" ]; then
   log_hr
   log_info "Cleaning up distribution artifacts"
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -81,6 +81,28 @@ KNOWN_GENERATED_claude=$(
     "$HOME/.claude/settings.json"
 )
 
+# links_for_tool <tool>
+# Print (one per line) the KNOWN_LINKS_<tool> destinations for <tool>
+# (empty if <tool> has none). Single source of truth for the tool ->
+# KNOWN_LINKS_* mapping: the main per-tool loop below and the distribution
+# artifact cleanup's cross-tool scan both need it, and duplicating this
+# case statement is exactly the kind of drift that let ocw-meter go
+# unlisted from KNOWN_LINKS_bin in the first place — except a forgotten
+# arm here fails silently (the tool is treated as having no links, so a
+# live symlink into a soon-to-be-deleted generation would be missed)
+# rather than with a visible warning. A function (not eval-based
+# indirection through a "KNOWN_LINKS_$tool" name) keeps each KNOWN_LINKS_*
+# variable directly referenced, so shellcheck can still see the use.
+links_for_tool() {
+  case "$1" in
+    zsh) printf '%s\n' "$KNOWN_LINKS_zsh" ;;
+    nvim) printf '%s\n' "$KNOWN_LINKS_nvim" ;;
+    tmux) printf '%s\n' "$KNOWN_LINKS_tmux" ;;
+    bin) printf '%s\n' "$KNOWN_LINKS_bin" ;;
+    claude) printf '%s\n' "$KNOWN_LINKS_claude" ;;
+  esac
+}
+
 # ── Usage ─────────────────────────────────────────────────────────────
 
 usage() {
@@ -171,18 +193,10 @@ for _tool in $TOOLS; do
   log_hr
   log_info "Uninstalling: $_tool"
 
-  # Get the list of known links for this tool. A case statement (rather
-  # than eval-based indirection through a "KNOWN_LINKS_$_tool" variable
-  # name) keeps each KNOWN_LINKS_* / KNOWN_GENERATED_* variable directly
-  # referenced, so shellcheck can see the use and avoids eval entirely.
-  _links=""
-  case "$_tool" in
-    zsh) _links="$KNOWN_LINKS_zsh" ;;
-    nvim) _links="$KNOWN_LINKS_nvim" ;;
-    tmux) _links="$KNOWN_LINKS_tmux" ;;
-    bin) _links="$KNOWN_LINKS_bin" ;;
-    claude) _links="$KNOWN_LINKS_claude" ;;
-  esac
+  # Get the list of known links for this tool via links_for_tool (see its
+  # definition above). KNOWN_GENERATED_* has only one case arm (claude), so
+  # it isn't worth routing through a helper the way KNOWN_LINKS_* is.
+  _links="$(links_for_tool "$_tool")"
   _generated=""
   case "$_tool" in
     claude) _generated="$KNOWN_GENERATED_claude" ;;
@@ -249,6 +263,20 @@ for _tool in $TOOLS; do
           ;;
       esac
     done
+  fi
+
+  # skills-backup/ is where deploy.sh set aside pre-existing skills before
+  # symlinking over them (see the claude/deploy.sh backup step). Once every
+  # restorable skill above has been moved back out of it, an empty
+  # directory is the only thing left — clean it up as part of the same
+  # "undo what deploy.sh did" pass, the same way the distribution artifact
+  # cleanup below cleans up what deploy-all.sh created.
+  if [ -n "$_skills_src" ] && [ -d "$HOME/.claude/skills-backup" ]; then
+    if [ "${DRY_RUN:-0}" -eq 1 ]; then
+      printf '[DRY-RUN] rmdir %s (only if empty)\n' "$HOME/.claude/skills-backup"
+    elif rmdir "$HOME/.claude/skills-backup" 2>/dev/null; then
+      log_ok "Removed empty skills-backup directory: $HOME/.claude/skills-backup"
+    fi
   fi
 
   # Handle generated files (real files, not symlinks — e.g. claude/settings.json)
@@ -324,15 +352,17 @@ done
 # down. If this uninstall run only targeted some tools (--only), a symlink
 # belonging to a tool NOT in $TOOLS is untouched by this run and may still
 # resolve through `current`, so we must not delete the prefix out from
-# under it.
+# under it. The same is true of a tool that WAS in scope but whose
+# symlink_restore call above failed (OVERALL_OK=1): the link may still be
+# sitting there, live, pointing into the generation we're about to delete.
 #
-# We check membership in $TOOLS rather than re-scanning the filesystem for
-# every tool: under --dry-run nothing was actually removed above, so a
-# post-loop filesystem scan of a tool that WAS in scope would wrongly see
-# its still-intact symlink and report a false "still referenced". A tool
-# in $TOOLS is trusted to have been (or, in dry-run, to be about to be)
-# cleared; only tools NOT in $TOOLS are checked against the live
-# filesystem, since those are untouched in both real and dry-run modes.
+# So in real (non-DRY_RUN) mode we scan the live filesystem for every tool
+# in AVAILABLE_TOOLS, regardless of $TOOLS — a tool's links only count as
+# "cleared" if they're actually gone, not because this run merely
+# attempted them. Only under --dry-run, where the loop above never touches
+# the filesystem at all, do we instead trust that a tool in $TOOLS would be
+# cleared by a real run and skip re-checking it (checking it would just
+# see its still-intact symlink and wrongly report "still referenced").
 #
 # Deletion never touches whatever `current` resolves to. In dev mode (see
 # ADR §4.5 / DOC-2608040229) `current` points at the human's own source
@@ -346,23 +376,16 @@ _dfu_still_referenced=0
 _dfu_scope=" $TOOLS "
 
 for _dfu_check_tool in $AVAILABLE_TOOLS; do
-  case "$_dfu_scope" in
-    *" $_dfu_check_tool "*) continue ;; # in scope this run — trust it's handled
-  esac
-
-  _dfu_check_links=""
-  case "$_dfu_check_tool" in
-    zsh) _dfu_check_links="$KNOWN_LINKS_zsh" ;;
-    nvim) _dfu_check_links="$KNOWN_LINKS_nvim" ;;
-    tmux) _dfu_check_links="$KNOWN_LINKS_tmux" ;;
-    bin) _dfu_check_links="$KNOWN_LINKS_bin" ;;
-    claude) _dfu_check_links="$KNOWN_LINKS_claude" ;;
-  esac
+  if [ "${DRY_RUN:-0}" -eq 1 ]; then
+    case "$_dfu_scope" in
+      *" $_dfu_check_tool "*) continue ;; # dry-run: trust a real run would clear this
+    esac
+  fi
 
   _OLDIFS="$IFS"
   IFS='
 '
-  for _dfu_dst in $_dfu_check_links; do
+  for _dfu_dst in $(links_for_tool "$_dfu_check_tool"); do
     IFS="$_OLDIFS"
     [ -z "$_dfu_dst" ] && continue
     if [ -L "$_dfu_dst" ]; then
@@ -376,19 +399,23 @@ for _dfu_check_tool in $AVAILABLE_TOOLS; do
   IFS="$_OLDIFS"
 done
 
-case "$_dfu_scope" in
-  *" claude "*) ;; # claude in scope this run — trust its skills are handled
-  *)
-    if [ "$_dfu_still_referenced" -eq 0 ] && [ -d "$HOME/.claude/skills" ]; then
-      for _dfu_skill_link in "$HOME/.claude/skills"/*; do
-        [ -L "$_dfu_skill_link" ] || continue
-        case "$(readlink "$_dfu_skill_link")" in
-          "$DOTFILES_PREFIX"/*) _dfu_still_referenced=1 ;;
-        esac
-      done
-    fi
-    ;;
-esac
+if [ "${DRY_RUN:-0}" -eq 1 ]; then
+  case "$_dfu_scope" in
+    *" claude "*) _dfu_check_claude_skills=0 ;; # dry-run: trust claude's skills would be cleared
+    *) _dfu_check_claude_skills=1 ;;
+  esac
+else
+  _dfu_check_claude_skills=1 # real run: always verify against the live filesystem
+fi
+
+if [ "$_dfu_still_referenced" -eq 0 ] && [ "$_dfu_check_claude_skills" -eq 1 ] && [ -d "$HOME/.claude/skills" ]; then
+  for _dfu_skill_link in "$HOME/.claude/skills"/*; do
+    [ -L "$_dfu_skill_link" ] || continue
+    case "$(readlink "$_dfu_skill_link")" in
+      "$DOTFILES_PREFIX"/*) _dfu_still_referenced=1 ;;
+    esac
+  done
+fi
 
 if [ "$_dfu_still_referenced" -ne 0 ]; then
   log_info "Another tool's symlink still points into the distribution prefix — skipping its cleanup."
@@ -401,18 +428,33 @@ elif [ -L "$DOTFILES_CURRENT_LINK" ] || [ -d "$DOTFILES_GENERATIONS_DIR" ]; then
     case "$_dfu_current_target" in
       "$DOTFILES_GENERATIONS_DIR"/*) ;;
       *)
-        log_info "current is in dev mode (points at a source tree, not a generation) — only the symlink itself will be removed: $_dfu_current_target"
+        log_info "current is in dev mode: it points at a source tree ($_dfu_current_target), which will NOT be touched. Only the current symlink itself is removed here; any generations/ directory (from earlier generation-mode deploys) is still cleaned up separately below."
         ;;
     esac
   fi
 
   if [ -d "$DOTFILES_GENERATIONS_DIR" ]; then
-    if [ "${DRY_RUN:-0}" -eq 1 ]; then
-      printf '[DRY-RUN] rm -rf %s\n' "$DOTFILES_GENERATIONS_DIR"
-    elif _dotfiles_safe_rmdir "$DOTFILES_GENERATIONS_DIR" "$DOTFILES_PREFIX"; then
-      log_ok "Removed generations directory: $DOTFILES_GENERATIONS_DIR"
+    if _dotfiles_safe_rmdir "$DOTFILES_GENERATIONS_DIR" "$DOTFILES_PREFIX"; then
+      [ "${DRY_RUN:-0}" -eq 1 ] || log_ok "Removed generations directory: $DOTFILES_GENERATIONS_DIR"
     else
       log_error "Failed to remove generations directory: $DOTFILES_GENERATIONS_DIR"
+      OVERALL_OK=1
+    fi
+  fi
+
+  # create_generation's scratch workspace (mktemp -d "$DOTFILES_PREFIX/.tmp/gen.XXXXXX",
+  # then mv'd into generations/ on success — see shared/helpers.sh). The
+  # .tmp/ directory itself is created with `mkdir -p` and outlives every
+  # generation it ever scratch-built, so it's always present after at
+  # least one successful deploy; a crashed deploy can also leave a
+  # half-built gen.XXXXXX scratch dir under it that nothing else ever
+  # sweeps. Removing it here is what actually lets the final rmdir below
+  # succeed, and also clears any orphaned crash leftovers.
+  if [ -d "$DOTFILES_PREFIX/.tmp" ]; then
+    if _dotfiles_safe_rmdir "$DOTFILES_PREFIX/.tmp" "$DOTFILES_PREFIX"; then
+      [ "${DRY_RUN:-0}" -eq 1 ] || log_ok "Removed scratch directory: $DOTFILES_PREFIX/.tmp"
+    else
+      log_error "Failed to remove scratch directory: $DOTFILES_PREFIX/.tmp"
       OVERALL_OK=1
     fi
   fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -88,14 +88,21 @@ KNOWN_GENERATED_claude=$(
 # artifact cleanup's cross-tool scan both need it, and duplicating this
 # case statement is exactly the kind of drift that let ocw-meter go
 # unlisted from KNOWN_LINKS_bin in the first place. A forgotten arm here
-# now surfaces as "No link list defined for '<tool>'. Skipping." whenever
-# <tool> is in $TOOLS, since the main loop below already checks for an
-# empty _links. But a tool NOT in $TOOLS is only ever passed to this
-# function by the cleanup's cross-tool scan, which has no such warning
-# path — a forgotten arm for an out-of-scope tool is still missed
-# silently there (the tool is treated as having no links, so a live
-# symlink into a soon-to-be-deleted generation goes undetected). A
-# function (not eval-based indirection through a "KNOWN_LINKS_$tool"
+# surfaces as "No link list defined for '<tool>'. Skipping." ONLY when
+# <tool> is in $TOOLS AND has no KNOWN_GENERATED_* entry either — the
+# main loop below only warns when both _links and _generated come back
+# empty (uninstall.sh:211). claude is the one tool where this doesn't
+# save you: it has KNOWN_GENERATED_claude (~/.claude/settings.json), so a
+# forgotten claude arm here still leaves _generated non-empty, the warning
+# never fires, and ~/.claude/CLAUDE.md quietly stops being touched while
+# the generation it points into gets deleted out from under it. A tool
+# NOT in $TOOLS is missed silently regardless of KNOWN_GENERATED_*: it's
+# only ever passed to this function by the cleanup's cross-tool scan,
+# which has no warning path at all (the tool is treated as having no
+# links, so a live symlink into a soon-to-be-deleted generation goes
+# undetected).
+#
+# A function (not eval-based indirection through a "KNOWN_LINKS_$tool"
 # name) keeps each KNOWN_LINKS_* variable directly referenced, so a
 # static analysis tool can still see the use.
 links_for_tool() {


### PR DESCRIPTION
## 背景

dotfilesは、macOS / Linux / WSL2 で共通の開発環境を再現するための設定リポジトリです。これまで `$HOME` の設定ファイルは、作業ツリーのファイルへ直接シンボリックリンクを張って配布していましたが、この方式には「作業ツリーを消すとリンクが壊れる」「編集途中の状態がそのまま本番に反映される」といった不安定さがありました。そこで、リポジトリと `$HOME` の間に世代ディレクトリ（generations）と `current` シンボリックリンクからなる配布実体を1段挟む方式へ移行する作業を進めています。この移行は複数の作業に分けて進めており、これまでに配布実体レイヤの導入と単純な4ツール（zsh・nvim・tmux・bin）の追従、claudeツールの例外的な処理の追従が完了しています。

## このプルリクエストの目的

配布(`deploy-all.sh`)側は新方式へ切り替わりましたが、撤去用の `uninstall.sh` は作業ツリー直リンクを前提にしたままでした。このプルリクエストでは、`uninstall.sh` を新方式に追従させ、配布と撤去の対応関係を閉じます。あわせて、`bin/deploy.sh` が配置する `ocw-meter` が撤去対象から漏れていた不具合も直します。

## 実装内容

- **スキルの由来判定を両対応にする**: `uninstall.sh` は `~/.claude/skills/` を走査し、リンク先が自分のリポジトリ由来かどうかを見て撤去対象を決めています。これまでは作業ツリー直リンクしか認識できませんでしたが、配布実体（`current` 経由、または世代ディレクトリを直接指す場合の両方）を指すリンクも認識するようにしました。旧方式のリンクも引き続き撤去できます。
- **配布実体（世代ディレクトリ + current）の後片付け**: `uninstall.sh` は今まで `$HOME` 側のリンクを外すだけで、配布実体そのものは残っていました。これを片付けるようにしました。ただし、今回の撤去対象に含まれていない別のツールがまだ配布実体を参照している場合は、片付けを行わず安全側に倒します。また、開発中の即時反映モード（`current` が人間の作業ツリーそのものを指す状態）では、作業ツリーの実体には一切触れず、`current` というリンク自体だけを取り除きます。
- **`ocw-meter` の撤去漏れを修正**: `bin/deploy.sh` が張る3本のリンクのうち `ocw-meter` だけが撤去対象のリストから漏れていたため、追加しました。
- **テストの追加**: サンドボックス上での動作確認テストに、配布実体の後片付け・開発中モードでの作業ツリー保護・`ocw-meter` の撤去・新方式スキルの撤去と復元・旧方式スキルリンクの撤去の5つの確認項目を追加しました。あわせて、以前のテストに残っていた「まだ対応していない」という前提の確認項目を、対応済みの内容に更新しました。

## レビューで見てほしいところ

- 配布実体の後片付けは、今回の撤去対象に含まれるツールについては「処理済みとみなす」、含まれないツールについては「実際にリンクが残っているか確認する」という判定にしています。これは、確認だけを行うモード（`--dry-run`）では実際にはリンクが外れていないため、単純にリンクの現在の状態だけを見ると誤判定してしまうためです。この判定方法が妥当か確認をお願いします。
- 削除範囲を「配布実体の置き場所（canonical prefix）配下であること」を必ず確認したうえで `rm -rf` する形にしています。人間の実際の環境を壊しかねない操作なので、特に注意して見ていただきたいです。

## テスト結果

lint とサンドボックステストはすべて緑です。

## 今後の予定

配布実体の状態確認やロールバックなどの運用コマンドの追加、関連文書の更新は、それぞれ後続の作業で行う予定です。

## 自己レビュー

- 正当性: 計画書「孫3用プロンプト」の項目（スキル由来判定の両対応、配布実体の後片付け、ocw-meter欠落修正、テストシナリオ追加）を全て実装。「やらないこと」に挙げられた運用コマンド・文書更新・ocw-meter本体修正には手を付けていません。
- エッジケース: current/generationsが存在しない状態、devモード（currentがソースツリーを指す状態）、`--only`で一部ツールのみ対象にした場合の他ツールへの影響、`--dry-run`時の判定を確認済みです。
- テスト: tests/deploy_smoke.sh に5シナリオを追加し、全18シナリオ（既存13＋新規5）が緑です。孫2時点で「孫3で対応予定」としていた既存シナリオの期待値も反転済みです。`pre-commit run --all-files`、`./deploy-all.sh --dry-run`、`./uninstall.sh --dry-run` も緑です。bin/配下は変更していませんが、`bin/tests/lint.sh` と `python3 -m unittest discover -s bin/tests`（193件）も念のため実行し、緑であることを確認しました。
- 無関係変更: `uninstall.sh` と `tests/deploy_smoke.sh` のみを変更しており、無関係な変更は含まれていません。
