### PR TITLE
運用コマンド(--status/--rollback/--dev)とリンク切れ検出を追加する

### DIFF
--- a/deploy-all.sh
+++ b/deploy-all.sh
@@ -368,21 +368,25 @@ cmd_rollback() {
     log_info "[DRY-RUN] \$HOME symlinks are unaffected by rollback — they already resolve through current."
   else
     log_ok "Rollback complete. \$HOME symlinks now resolve through: $_rb_target_dir"
-    # Two things a plain "current now points here" message doesn't cover:
-    #   - the target generation may not have every symlink the one we just
-    #     left had (e.g. a claude skill added since), which leaves a
-    #     dangling $HOME symlink that this command has no way to detect
-    #     without walking every tool's links here too — --status already
-    #     does exactly that, so point at it instead of duplicating the scan
-    #   - ~/.claude/settings.json is a generated real file, not a symlink
-    #     (ADR §4.8), so switching current never touches it; without this
-    #     line a rollback silently leaves stale settings.json content in
-    #     place while claiming the rollback is "complete"
-    log_info "Run '$0 --status' to check for symlinks the target generation doesn't have."
-    log_info "Note: ~/.claude/settings.json is a generated file, not a symlink — rollback"
-    log_info "does not revert it. Re-run claude/deploy.sh from the target generation if"
-    log_info "its content also needs to go back."
   fi
+
+  # Two things a plain "current now points here" message doesn't cover, and
+  # both are exactly the kind of thing that should show up in a --dry-run
+  # preview too (that's the whole point of previewing a rollback before
+  # committing to it), so this isn't gated on DRY_RUN:
+  #   - the target generation may not have every symlink the one we just
+  #     left had (e.g. a claude skill added since), which leaves a
+  #     dangling $HOME symlink that this command has no way to detect
+  #     without walking every tool's links here too — --status already
+  #     does exactly that, so point at it instead of duplicating the scan
+  #   - ~/.claude/settings.json is a generated real file, not a symlink
+  #     (ADR §4.8), so switching current never touches it; without this
+  #     line a rollback silently leaves stale settings.json content in
+  #     place while claiming the rollback is "complete"
+  log_info "Run '$0 --status' to check for symlinks the target generation doesn't have."
+  log_info "Note: ~/.claude/settings.json is a generated file, not a symlink — rollback"
+  log_info "does not revert it. Re-run claude/deploy.sh from the target generation if"
+  log_info "its content also needs to go back."
   return 0
 }
 

--- a/deploy-all.sh
+++ b/deploy-all.sh
@@ -27,6 +27,30 @@ SCRIPT_DIR=$(
   cd "$(dirname "$0")" || exit 1
   pwd
 )
+
+# shared/helpers.sh fires a one-shot "Deploying from a linked git worktree"
+# warning the moment it's sourced (its source-time guard runs before this
+# script has parsed any arguments). That wording is only right for an
+# actual deploy: --status is documented as read-only/safe against a real
+# $HOME and shouldn't warn about anything, --rollback only ever points
+# current at an existing generation directory (never at $SCRIPT_DIR) so the
+# worktree it's invoked from is irrelevant, and --dev prints its own
+# dev-flavored warning below instead (cmd_dev). Pre-set the "already
+# warned" flag the guard checks (shared/helpers.sh's DOTFILES_WORKTREE_WARNED,
+# not DOTFILES_QUIET_WORKTREE_WARNING — that one is the user's own explicit
+# silence switch and must stay untouched here) so it never fires for these
+# three, before we even know MODE (argument parsing hasn't happened yet).
+for _dsa_arg in "$@"; do
+  case "$_dsa_arg" in
+    --status | --rollback | --dev)
+      DOTFILES_WORKTREE_WARNED=1
+      export DOTFILES_WORKTREE_WARNED
+      break
+      ;;
+  esac
+done
+unset _dsa_arg
+
 # shellcheck source=SCRIPTDIR/shared/helpers.sh
 . "$SCRIPT_DIR/shared/helpers.sh"
 
@@ -38,6 +62,9 @@ BACKUP=1
 ONLY_TOOLS=""
 MODE="deploy"
 ROLLBACK_TARGET=""
+ONLY_SEEN=0
+FORCE_SEEN=0
+BACKUP_SEEN=0
 
 # ── Usage ─────────────────────────────────────────────────────────────
 
@@ -56,7 +83,9 @@ Options:
   --no-backup       Do NOT back up existing files before overwriting.
   --status          Show what current points at, its manifest, the kept
                     generations, and whether any \$HOME symlink is broken.
-                    Read-only; safe to run against a real \$HOME.
+                    Read-only; safe to run against a real \$HOME. Exits 0
+                    if current and every \$HOME symlink are healthy, 1
+                    otherwise (broken/missing current, broken symlink).
   --rollback [id]   Switch current to the generation before it, or to
                     <id> if given. \$HOME symlinks are not re-created —
                     they already resolve through current. Combine with
@@ -87,8 +116,10 @@ EOF
 
 # cmd_status
 # Read-only. Prints what current points at (a generation, dev-mode source
-# tree, or nothing yet), that generation's manifest, the list of kept
-# generations, and a $HOME symlink health scan (via links_for_tool(),
+# tree, or nothing yet), that generation's manifest (or, in dev mode, the
+# same fields read live from the source tree's own git state — dev mode
+# never writes a manifest, see cmd_dev), the list of kept generations, and
+# a $HOME symlink health scan (via links_for_tool() + claude_skill_links(),
 # shared/helpers.sh) that flags broken symlinks. Returns 1 if current is
 # broken/missing or any $HOME symlink is broken, 0 otherwise — callers that
 # want a machine-readable health check can rely on the exit code.
@@ -137,6 +168,24 @@ cmd_status() {
         if is_linked_worktree "$_cs_target"; then
           log_warn "The dev source tree is a linked git worktree. Removing it will break every symlink under \$HOME."
         fi
+        # Dev mode never writes a .dotfiles-manifest (it would dirty the
+        # source tree — see cmd_dev), so the provenance a generation gets
+        # from its manifest has to be read live instead. Without this,
+        # dev mode was the one mode where "which commit/branch is
+        # currently live in $HOME" (ADR problem 3) stayed unanswerable —
+        # arguably the mode that needs it most, since dev mode is exactly
+        # where an uncommitted, mid-edit state is what's live.
+        if command -v git >/dev/null 2>&1 && git -C "$_cs_target" rev-parse --git-dir >/dev/null 2>&1; then
+          printf '\n'
+          log_info "Live source tree state (no manifest in dev mode):"
+          printf '  commit_sha: %s\n' "$(git -C "$_cs_target" rev-parse HEAD 2>/dev/null || printf unknown)"
+          printf '  branch: %s\n' "$(git -C "$_cs_target" rev-parse --abbrev-ref HEAD 2>/dev/null || printf unknown)"
+          if [ -z "$(git -C "$_cs_target" status --porcelain 2>/dev/null)" ]; then
+            printf '  dirty: 0\n'
+          else
+            printf '  dirty: 1\n'
+          fi
+        fi
       else
         log_error "current points at a dev source tree that no longer exists: $_cs_target"
         _cs_rc=1
@@ -150,7 +199,7 @@ cmd_status() {
     case "$_cs_target" in
       "$_cs_gens_dir"/*) _cs_cur_name="$(basename "$_cs_target")" ;;
     esac
-    log_info "Generations (kept: ${DOTFILES_KEEP_GENERATIONS:-3}):"
+    log_info "Generations (kept: $(dotfiles_keep_generations)):"
     for _cs_name in $(find "$_cs_gens_dir" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort); do
       if [ "$_cs_name" = "$_cs_cur_name" ]; then
         printf '  * %s  (current)\n' "$_cs_name"
@@ -189,6 +238,29 @@ cmd_status() {
     done
     IFS="$_cs_oldifs"
   done
+
+  # claude/skills/<name> symlinks aren't in links_for_tool()/KNOWN_LINKS_claude
+  # — claude/deploy.sh symlinks them individually, one per skill directory
+  # it auto-detects, not as a fixed list — so they need their own pass via
+  # claude_skill_links() (shared/helpers.sh) or they'd be a silent blind
+  # spot in exactly the tool with the most $HOME symlinks of any of them
+  # (ADR DOC-2608040229 §1.1).
+  _cs_oldifs="$IFS"
+  IFS='
+'
+  for _cs_dst in $(claude_skill_links "$SCRIPT_DIR"); do
+    IFS="$_cs_oldifs"
+    [ -z "$_cs_dst" ] && continue
+    if [ -e "$_cs_dst" ]; then
+      printf '  [OK]      %s\n' "$_cs_dst"
+    else
+      printf '  [BROKEN]  %s -> %s\n' "$_cs_dst" "$(readlink "$_cs_dst")"
+      _cs_broken=$((_cs_broken + 1))
+    fi
+    IFS='
+'
+  done
+  IFS="$_cs_oldifs"
 
   if [ "$_cs_broken" -gt 0 ]; then
     printf '\n'
@@ -296,6 +368,20 @@ cmd_rollback() {
     log_info "[DRY-RUN] \$HOME symlinks are unaffected by rollback — they already resolve through current."
   else
     log_ok "Rollback complete. \$HOME symlinks now resolve through: $_rb_target_dir"
+    # Two things a plain "current now points here" message doesn't cover:
+    #   - the target generation may not have every symlink the one we just
+    #     left had (e.g. a claude skill added since), which leaves a
+    #     dangling $HOME symlink that this command has no way to detect
+    #     without walking every tool's links here too — --status already
+    #     does exactly that, so point at it instead of duplicating the scan
+    #   - ~/.claude/settings.json is a generated real file, not a symlink
+    #     (ADR §4.8), so switching current never touches it; without this
+    #     line a rollback silently leaves stale settings.json content in
+    #     place while claiming the rollback is "complete"
+    log_info "Run '$0 --status' to check for symlinks the target generation doesn't have."
+    log_info "Note: ~/.claude/settings.json is a generated file, not a symlink — rollback"
+    log_info "does not revert it. Re-run claude/deploy.sh from the target generation if"
+    log_info "its content also needs to go back."
   fi
   return 0
 }
@@ -315,7 +401,24 @@ cmd_dev() {
   log_warn "No generation is created; edits to this checkout take effect immediately."
   printf '\n'
 
-  warn_if_linked_worktree "$SCRIPT_DIR"
+  # Not warn_if_linked_worktree: its one-shot flag was pre-set before
+  # shared/helpers.sh was even sourced (see the top of this script) so its
+  # deploy-flavored wording ("Symlinks will point INTO this worktree...
+  # re-run the deploy from the main worktree") never fires here — dev mode
+  # needs its own wording (removing the worktree breaks current itself, not
+  # freshly-created symlinks, and there's nothing to "re-run" — you switch
+  # back to generation mode instead). Still honours the user's own
+  # DOTFILES_QUIET_WORKTREE_WARNING, unlike the pre-set flag above which is
+  # this script's own internal suppression and not a user-facing switch.
+  if [ -z "${DOTFILES_QUIET_WORKTREE_WARNING:-}" ] && is_linked_worktree "$SCRIPT_DIR"; then
+    log_warn "This working tree is a linked git worktree:"
+    log_warn "  $SCRIPT_DIR"
+    log_warn "Dev mode makes \$HOME resolve directly into it via current. Removing this"
+    log_warn "worktree (e.g. 'ocw rm') will break every \$HOME symlink until you switch"
+    log_warn "back to generation mode."
+    log_warn "Silence this with DOTFILES_QUIET_WORKTREE_WARNING=1."
+    printf '\n'
+  fi
 
   switch_current "$SCRIPT_DIR" || {
     log_error "Failed to switch current -> $SCRIPT_DIR"
@@ -341,12 +444,15 @@ while [ $# -gt 0 ]; do
       ;;
     --force)
       FORCE=1
+      FORCE_SEEN=1
       ;;
     --backup)
       BACKUP=1
+      BACKUP_SEEN=1
       ;;
     --no-backup)
       BACKUP=0
+      BACKUP_SEEN=1
       ;;
     --only)
       if [ $# -lt 2 ]; then
@@ -354,6 +460,7 @@ while [ $# -gt 0 ]; do
         exit 1
       fi
       ONLY_TOOLS="$2"
+      ONLY_SEEN=1
       shift
       ;;
     --status)
@@ -370,11 +477,14 @@ while [ $# -gt 0 ]; do
       fi
       MODE="rollback"
       # Optional generation id: only consume $2 if it doesn't look like
-      # another option, so `--rollback --dry-run` still parses --dry-run
-      # as a flag rather than as a (bogus) generation id.
+      # another option, so `--rollback --dry-run` (or `--rollback -h`)
+      # still parses the flag as a flag rather than as a (bogus)
+      # generation id. Generation ids are `<date>-<sha>` and never start
+      # with "-", so excluding anything dash-prefixed (not just "--"
+      # long options) is safe and also catches short options like -h.
       if [ $# -ge 2 ]; then
         case "$2" in
-          --*) ;;
+          -*) ;;
           *)
             ROLLBACK_TARGET="$2"
             shift
@@ -405,6 +515,13 @@ done
 # ── Dispatch current-symlink operations ─────────────────────────────────
 # These bypass the generation-build / per-tool-deploy / GC flow below
 # entirely (see the cmd_status/cmd_rollback/cmd_dev definitions above).
+
+if [ "$MODE" != "deploy" ]; then
+  if [ "$ONLY_SEEN" -eq 1 ] || [ "$FORCE_SEEN" -eq 1 ] || [ "$BACKUP_SEEN" -eq 1 ]; then
+    log_error "--status/--rollback/--dev cannot be combined with --only/--force/--backup/--no-backup."
+    exit 1
+  fi
+fi
 
 case "$MODE" in
   status)

--- a/deploy-all.sh
+++ b/deploy-all.sh
@@ -9,10 +9,17 @@
 #   ./deploy-all.sh --only zsh,nvim   Deploy specific tools only
 #   ./deploy-all.sh --backup       Always back up existing files (on by default)
 #   ./deploy-all.sh --no-backup    Skip backing up existing files
+#   ./deploy-all.sh --status       Show current generation, manifest, GC state
+#   ./deploy-all.sh --rollback [id]  Switch current to the previous (or given) generation
+#   ./deploy-all.sh --dev          Point current at this working tree (no generation)
 #
 # Options can be combined:
 #   ./deploy-all.sh --dry-run --only tmux
 #   ./deploy-all.sh --force --only zsh,nvim
+#
+# --status/--rollback/--dev are operations on the `current` symlink itself
+# (see ADR DOC-2608040229) and cannot be combined with each other or with
+# --only/--force/--backup — --dry-run is the only modifier they honour.
 
 set -u
 
@@ -29,6 +36,8 @@ DRY_RUN=0
 FORCE=0
 BACKUP=1
 ONLY_TOOLS=""
+MODE="deploy"
+ROLLBACK_TARGET=""
 
 # ── Usage ─────────────────────────────────────────────────────────────
 
@@ -45,6 +54,17 @@ Options:
                     Available: $AVAILABLE_TOOLS
   --backup          Back up existing config files (default).
   --no-backup       Do NOT back up existing files before overwriting.
+  --status          Show what current points at, its manifest, the kept
+                    generations, and whether any \$HOME symlink is broken.
+                    Read-only; safe to run against a real \$HOME.
+  --rollback [id]   Switch current to the generation before it, or to
+                    <id> if given. \$HOME symlinks are not re-created —
+                    they already resolve through current. Combine with
+                    --dry-run to preview.
+  --dev             Point current directly at this working tree instead
+                    of a generation (no generation is created; edits to
+                    this checkout take effect immediately). Combine with
+                    --dry-run to preview.
   --help, -h        Show this help message.
 
 Examples:
@@ -52,7 +72,264 @@ Examples:
   $0 --dry-run                 # Preview everything
   $0 --only zsh,nvim           # Deploy only zsh and nvim
   $0 --force --only tmux       # Deploy tmux without prompts
+  $0 --status                  # Inspect what's currently deployed
+  $0 --rollback                # Roll back to the previous generation
+  $0 --dev                     # Switch to live-edit (dev) mode
 EOF
+}
+
+# ── current-symlink operations (--status / --rollback / --dev) ────────
+#
+# These act on the `current` symlink itself rather than deploying files,
+# so they are dispatched right after argument parsing and skip the
+# generation-build / per-tool-deploy / GC flow entirely (see ADR
+# DOC-2608040229 §4.4/§4.5).
+
+# cmd_status
+# Read-only. Prints what current points at (a generation, dev-mode source
+# tree, or nothing yet), that generation's manifest, the list of kept
+# generations, and a $HOME symlink health scan (via links_for_tool(),
+# shared/helpers.sh) that flags broken symlinks. Returns 1 if current is
+# broken/missing or any $HOME symlink is broken, 0 otherwise — callers that
+# want a machine-readable health check can rely on the exit code.
+cmd_status() {
+  _cs_prefix="$(dotfiles_prefix)"
+  _cs_link="$(dotfiles_current_link)"
+  _cs_gens_dir="$_cs_prefix/generations"
+  _cs_target=""
+  _cs_rc=0
+
+  log_hr
+  log_info "Distribution prefix: $_cs_prefix"
+  printf '\n'
+
+  if [ -L "$_cs_link" ]; then
+    _cs_target="$(readlink "$_cs_link")"
+  elif [ -e "$_cs_link" ]; then
+    log_error "current exists but is not a symlink: $_cs_link"
+    _cs_rc=1
+  else
+    log_warn "current does not exist yet — nothing has been deployed."
+  fi
+
+  case "$_cs_target" in
+    "$_cs_gens_dir"/*)
+      log_info "Mode: generation"
+      log_info "current -> $_cs_target"
+      if [ -d "$_cs_target" ]; then
+        if [ -f "$_cs_target/.dotfiles-manifest" ]; then
+          printf '\n'
+          log_info "Manifest:"
+          sed 's/^/  /' "$_cs_target/.dotfiles-manifest"
+        else
+          log_warn "No .dotfiles-manifest found in current generation."
+        fi
+      else
+        log_error "current points at a generation directory that no longer exists: $_cs_target"
+        _cs_rc=1
+      fi
+      ;;
+    "") ;;
+    *)
+      log_warn "Mode: DEV — current points directly at a source tree (not a generation)."
+      log_info "current -> $_cs_target"
+      if [ -d "$_cs_target" ]; then
+        if is_linked_worktree "$_cs_target"; then
+          log_warn "The dev source tree is a linked git worktree. Removing it will break every symlink under \$HOME."
+        fi
+      else
+        log_error "current points at a dev source tree that no longer exists: $_cs_target"
+        _cs_rc=1
+      fi
+      ;;
+  esac
+  printf '\n'
+
+  if [ -d "$_cs_gens_dir" ]; then
+    _cs_cur_name=""
+    case "$_cs_target" in
+      "$_cs_gens_dir"/*) _cs_cur_name="$(basename "$_cs_target")" ;;
+    esac
+    log_info "Generations (kept: ${DOTFILES_KEEP_GENERATIONS:-3}):"
+    for _cs_name in $(find "$_cs_gens_dir" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort); do
+      if [ "$_cs_name" = "$_cs_cur_name" ]; then
+        printf '  * %s  (current)\n' "$_cs_name"
+      else
+        printf '    %s\n' "$_cs_name"
+      fi
+    done
+  else
+    log_info "No generations directory yet."
+  fi
+  printf '\n'
+
+  log_info "Link health (\$HOME):"
+  _cs_broken=0
+  for _cs_tool in $AVAILABLE_TOOLS; do
+    _cs_oldifs="$IFS"
+    IFS='
+'
+    for _cs_dst in $(links_for_tool "$_cs_tool"); do
+      IFS="$_cs_oldifs"
+      [ -z "$_cs_dst" ] && continue
+      if [ -L "$_cs_dst" ]; then
+        if [ -e "$_cs_dst" ]; then
+          printf '  [OK]      %s\n' "$_cs_dst"
+        else
+          printf '  [BROKEN]  %s -> %s\n' "$_cs_dst" "$(readlink "$_cs_dst")"
+          _cs_broken=$((_cs_broken + 1))
+        fi
+      elif [ -e "$_cs_dst" ]; then
+        printf '  [SKIP]    %s (exists, not a symlink)\n' "$_cs_dst"
+      else
+        printf '  [MISSING] %s (not deployed)\n' "$_cs_dst"
+      fi
+      IFS='
+'
+    done
+    IFS="$_cs_oldifs"
+  done
+
+  if [ "$_cs_broken" -gt 0 ]; then
+    printf '\n'
+    log_warn "$_cs_broken broken symlink(s) found under \$HOME."
+    _cs_rc=1
+  fi
+
+  return "$_cs_rc"
+}
+
+# cmd_rollback <target_id_or_empty>
+# Switches current to <target_id_or_empty> if given (validated against the
+# generations actually on disk — rejected if it contains a "/" to rule out
+# path traversal), otherwise to the generation immediately before the one
+# current points at. $HOME symlinks are never re-created here: they already
+# resolve through the literal `current` path (see ADR §4.1), so swapping
+# what current points at is the entire operation.
+cmd_rollback() {
+  _rb_target_arg="$1"
+  _rb_prefix="$(dotfiles_prefix)"
+  _rb_link="$(dotfiles_current_link)"
+  _rb_gens_dir="$_rb_prefix/generations"
+
+  if [ ! -d "$_rb_gens_dir" ]; then
+    log_error "No generations directory found. Nothing to roll back to."
+    return 1
+  fi
+
+  _rb_names="$(find "$_rb_gens_dir" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort)"
+  if [ -z "$_rb_names" ]; then
+    log_error "No generations available to roll back to."
+    return 1
+  fi
+
+  _rb_cur_target=""
+  [ -L "$_rb_link" ] && _rb_cur_target="$(readlink "$_rb_link")"
+  _rb_cur_name=""
+  case "$_rb_cur_target" in
+    "$_rb_gens_dir"/*) _rb_cur_name="$(basename "$_rb_cur_target")" ;;
+  esac
+
+  if [ -z "$_rb_cur_name" ]; then
+    log_warn "current is in dev mode (or unset) — there is no 'current generation' to roll back from."
+    log_warn "Rolling back means leaving dev mode and switching to a generation instead."
+  fi
+
+  if [ -n "$_rb_target_arg" ]; then
+    case "$_rb_target_arg" in
+      */* | . | ..)
+        log_error "Invalid generation id: $_rb_target_arg"
+        return 1
+        ;;
+    esac
+    _rb_found=0
+    for _rb_n in $_rb_names; do
+      [ "$_rb_n" = "$_rb_target_arg" ] && _rb_found=1 && break
+    done
+    if [ "$_rb_found" -eq 0 ]; then
+      log_error "Unknown generation: $_rb_target_arg"
+      log_info "Available generations:"
+      printf '%s\n' "$_rb_names" | sed 's/^/  /'
+      return 1
+    fi
+    _rb_target_name="$_rb_target_arg"
+  elif [ -n "$_rb_cur_name" ]; then
+    _rb_cur_listed=0
+    for _rb_n in $_rb_names; do
+      [ "$_rb_n" = "$_rb_cur_name" ] && _rb_cur_listed=1 && break
+    done
+    if [ "$_rb_cur_listed" -eq 0 ]; then
+      log_error "current points at a generation that no longer exists: $_rb_cur_name"
+      log_info "Pass a generation id explicitly, e.g.: $0 --rollback <id>"
+      log_info "Available generations:"
+      printf '%s\n' "$_rb_names" | sed 's/^/  /'
+      return 1
+    fi
+
+    _rb_target_name=""
+    _rb_prev=""
+    for _rb_n in $_rb_names; do
+      if [ "$_rb_n" = "$_rb_cur_name" ]; then
+        _rb_target_name="$_rb_prev"
+        break
+      fi
+      _rb_prev="$_rb_n"
+    done
+    if [ -z "$_rb_target_name" ]; then
+      log_error "No older generation to roll back to (current is already the oldest)."
+      return 1
+    fi
+  else
+    _rb_target_name="$(printf '%s\n' "$_rb_names" | tail -n1)"
+    log_info "No generation id given — switching to the most recent generation: $_rb_target_name"
+  fi
+
+  _rb_target_dir="$_rb_gens_dir/$_rb_target_name"
+
+  log_info "Rolling back current -> $_rb_target_dir"
+  switch_current "$_rb_target_dir" || {
+    log_error "Failed to switch current -> $_rb_target_dir"
+    return 1
+  }
+
+  if [ "${DRY_RUN:-0}" -eq 1 ]; then
+    log_info "[DRY-RUN] \$HOME symlinks are unaffected by rollback — they already resolve through current."
+  else
+    log_ok "Rollback complete. \$HOME symlinks now resolve through: $_rb_target_dir"
+  fi
+  return 0
+}
+
+# cmd_dev
+# Points current directly at $SCRIPT_DIR (this working tree) instead of a
+# generation. No generation is created or GC'd. Because every $HOME symlink
+# already resolves through the literal `current` path rather than a
+# generation directory (ADR §4.1), this alone is enough to make edits to
+# the working tree take effect immediately — the same immediacy the
+# pre-migration direct-link scheme had (ADR §4.5). It does not create any
+# $HOME symlinks itself: run deploy-all.sh normally at least once first if
+# nothing has been deployed yet.
+cmd_dev() {
+  log_hr
+  log_warn "Switching to DEV mode: current will point directly at this working tree."
+  log_warn "No generation is created; edits to this checkout take effect immediately."
+  printf '\n'
+
+  warn_if_linked_worktree "$SCRIPT_DIR"
+
+  switch_current "$SCRIPT_DIR" || {
+    log_error "Failed to switch current -> $SCRIPT_DIR"
+    return 1
+  }
+
+  printf '\n'
+  if [ "${DRY_RUN:-0}" -eq 1 ]; then
+    log_info "[DRY-RUN] Dev mode would be active. Generation GC would be skipped while active."
+  else
+    log_ok "Dev mode is active. Generation GC is skipped while current points outside generations/."
+  fi
+  log_info "To return to generation mode, run: $SCRIPT_DIR/deploy-all.sh"
+  return 0
 }
 
 # ── Parse arguments ───────────────────────────────────────────────────
@@ -79,6 +356,39 @@ while [ $# -gt 0 ]; do
       ONLY_TOOLS="$2"
       shift
       ;;
+    --status)
+      if [ "$MODE" != "deploy" ]; then
+        log_error "Cannot combine --status with --rollback/--dev."
+        exit 1
+      fi
+      MODE="status"
+      ;;
+    --rollback)
+      if [ "$MODE" != "deploy" ]; then
+        log_error "Cannot combine --rollback with --status/--dev."
+        exit 1
+      fi
+      MODE="rollback"
+      # Optional generation id: only consume $2 if it doesn't look like
+      # another option, so `--rollback --dry-run` still parses --dry-run
+      # as a flag rather than as a (bogus) generation id.
+      if [ $# -ge 2 ]; then
+        case "$2" in
+          --*) ;;
+          *)
+            ROLLBACK_TARGET="$2"
+            shift
+            ;;
+        esac
+      fi
+      ;;
+    --dev)
+      if [ "$MODE" != "deploy" ]; then
+        log_error "Cannot combine --dev with --status/--rollback."
+        exit 1
+      fi
+      MODE="dev"
+      ;;
     --help | -h)
       usage
       exit 0
@@ -91,6 +401,25 @@ while [ $# -gt 0 ]; do
   esac
   shift
 done
+
+# ── Dispatch current-symlink operations ─────────────────────────────────
+# These bypass the generation-build / per-tool-deploy / GC flow below
+# entirely (see the cmd_status/cmd_rollback/cmd_dev definitions above).
+
+case "$MODE" in
+  status)
+    cmd_status
+    exit $?
+    ;;
+  rollback)
+    cmd_rollback "$ROLLBACK_TARGET"
+    exit $?
+    ;;
+  dev)
+    cmd_dev
+    exit $?
+    ;;
+esac
 
 # ── Resolve tool list (with dedup) ────────────────────────────────────
 

--- a/shared/helpers.sh
+++ b/shared/helpers.sh
@@ -147,61 +147,95 @@ resolve_tools() {
 
 # ── Known $HOME-side link destinations per tool ─────────────────────────
 #
-# Single source of truth for "which paths under $HOME does this repo's
-# deploy create". uninstall.sh needs it to know what to remove;
-# deploy-all.sh --status needs it to check for broken symlinks. Keeping one
-# copy here (instead of duplicating the list in both scripts) is what
-# prevents the drift that let ocw-meter go unlisted from KNOWN_LINKS_bin in
-# the first place (see ADR DOC-2608040229 §2.6 / AGENTS.md 実装時の注意).
-# Use printf so the trailing-newline line-continuation works portably.
-KNOWN_LINKS_zsh=$(
-  printf '%s\n' \
-    "$HOME/.zshrc" \
-    "$HOME/.zsh_plugins.txt"
-)
-
-KNOWN_LINKS_nvim=$(
-  printf '%s\n' \
-    "${XDG_CONFIG_HOME:-$HOME/.config}/nvim/init.lua" \
-    "${XDG_CONFIG_HOME:-$HOME/.config}/nvim/lua" \
-    "${XDG_CONFIG_HOME:-$HOME/.config}/nvim/lazy-lock.json"
-)
-
-KNOWN_LINKS_tmux=$(
-  printf '%s\n' \
-    "$HOME/.tmux.conf"
-)
-
-KNOWN_LINKS_bin=$(
-  printf '%s\n' \
-    "$HOME/bin/ocw" \
-    "$HOME/bin/claude-ds" \
-    "$HOME/bin/ocw-meter"
-)
-
-KNOWN_LINKS_claude=$(
-  printf '%s\n' \
-    "$HOME/.claude/CLAUDE.md"
-)
-
 # links_for_tool <tool>
-# Print (one per line) the KNOWN_LINKS_<tool> destinations for <tool>
-# (empty if <tool> has none). Callers (uninstall.sh's per-tool loop and
-# distribution-artifact cleanup, deploy-all.sh's --status link-health scan)
-# all need the same tool -> KNOWN_LINKS_* mapping, and duplicating this case
-# statement is exactly the kind of drift the comment above warns about.
+# Print (one per line) the known $HOME symlink destinations for <tool>
+# (empty if <tool> has none). Single source of truth for "which paths under
+# $HOME does this repo's deploy create": uninstall.sh needs it to know what
+# to remove, deploy-all.sh --status needs it to check for broken symlinks.
+# Keeping one copy (instead of duplicating the list in both scripts) is
+# what prevents the drift that let ocw-meter go unlisted from
+# KNOWN_LINKS_bin in the first place (see ADR DOC-2608040229 §2.6 /
+# AGENTS.md 実装時の注意).
 #
-# A function (not eval-based indirection through a "KNOWN_LINKS_$tool" name)
-# keeps each KNOWN_LINKS_* variable directly referenced, so a static
-# analysis tool can still see the use.
+# A forgotten arm here surfaces as "No link list defined for '<tool>'.
+# Skipping." in uninstall.sh's per-tool loop ONLY when <tool> is in $TOOLS
+# AND has no KNOWN_GENERATED_* entry either (that loop only warns when both
+# _links and _generated come back empty). claude is the one tool where this
+# doesn't save you: it has a KNOWN_GENERATED_claude entry
+# (~/.claude/settings.json), so a forgotten claude arm here still leaves
+# _generated non-empty, the warning never fires, and ~/.claude/CLAUDE.md
+# quietly stops being touched while the generation it points into gets
+# deleted out from under it. deploy-all.sh --status's link-health scan
+# (a third consumer, added alongside this comment) has no warning path at
+# all for a forgotten arm: the tool's entries are just silently absent from
+# the report, so a broken symlink for that tool goes undetected too — the
+# same blind spot claude_skill_links() below exists to close for skills.
+#
+# Values are inlined into the case arms (not module-level KNOWN_LINKS_*
+# variables) on purpose: this file is sourced by every interactive zsh
+# startup (zsh/.zshrc), and module-level `VAR=$(printf ...)` assignments
+# both leak into that shell's namespace (zsh/.zshrc already has to unset
+# AVAILABLE_TOOLS for the same reason — see its "helpers.sh exports
+# AVAILABLE_TOOLS which we don't need in an interactive shell" comment) and
+# fork one subshell per tool at source time. Inlining also means $HOME /
+# $XDG_CONFIG_HOME are read at call time instead of source time, which is
+# what lets tests override them via `env HOME=...` after helpers.sh is
+# already sourced.
 links_for_tool() {
   case "$1" in
-    zsh) printf '%s\n' "$KNOWN_LINKS_zsh" ;;
-    nvim) printf '%s\n' "$KNOWN_LINKS_nvim" ;;
-    tmux) printf '%s\n' "$KNOWN_LINKS_tmux" ;;
-    bin) printf '%s\n' "$KNOWN_LINKS_bin" ;;
-    claude) printf '%s\n' "$KNOWN_LINKS_claude" ;;
+    zsh)
+      printf '%s\n' \
+        "$HOME/.zshrc" \
+        "$HOME/.zsh_plugins.txt"
+      ;;
+    nvim)
+      printf '%s\n' \
+        "${XDG_CONFIG_HOME:-$HOME/.config}/nvim/init.lua" \
+        "${XDG_CONFIG_HOME:-$HOME/.config}/nvim/lua" \
+        "${XDG_CONFIG_HOME:-$HOME/.config}/nvim/lazy-lock.json"
+      ;;
+    tmux)
+      printf '%s\n' \
+        "$HOME/.tmux.conf"
+      ;;
+    bin)
+      printf '%s\n' \
+        "$HOME/bin/ocw" \
+        "$HOME/bin/claude-ds" \
+        "$HOME/bin/ocw-meter"
+      ;;
+    claude)
+      printf '%s\n' \
+        "$HOME/.claude/CLAUDE.md"
+      ;;
   esac
+}
+
+# claude_skill_links [repo_root]
+# Print (one per line) the paths under $HOME/.claude/skills/ that are
+# symlinks owned by this repo's distribution (see
+# _dotfiles_symlink_is_repo_owned for the ownership test — the canonical
+# prefix always counts, and repo_root additionally recognizes the
+# pre-migration direct-to-worktree scheme, see ADR DOC-2608040229 §4.8/
+# §4.9). Skills aren't in links_for_tool()/KNOWN_LINKS_claude because
+# claude/deploy.sh symlinks them individually, one per skill directory
+# auto-detected under claude/skills/, rather than as a fixed list — but
+# they are still $HOME symlinks this repo creates, and in practice the
+# tool with the most of them (ADR §1.1). Shared by uninstall.sh (needs the
+# list to know what to restore) and deploy-all.sh --status (needs it so
+# its $HOME link-health scan doesn't blind-spot the tool with the most
+# symlinks of any of them). Prints nothing (not an error) if
+# ~/.claude/skills doesn't exist.
+claude_skill_links() {
+  _csl_repo_root="${1:-}"
+  _csl_dir="$HOME/.claude/skills"
+  [ -d "$_csl_dir" ] || return 0
+  for _csl_link in "$_csl_dir"/*; do
+    [ -L "$_csl_link" ] || continue
+    if _dotfiles_symlink_is_repo_owned "$_csl_link" "$_csl_repo_root"; then
+      printf '%s\n' "$_csl_link"
+    fi
+  done
 }
 
 # ── Logging (colourised when the output fd is a terminal) ─────────────
@@ -320,6 +354,16 @@ dotfiles_prefix() {
 # re-linking anything under $HOME.
 dotfiles_current_link() {
   printf '%s' "$(dotfiles_prefix)/current"
+}
+
+# dotfiles_keep_generations
+# Print the configured generation retention count
+# (${DOTFILES_KEEP_GENERATIONS:-3} — 3 is the default ADR §4.6 settled on:
+# enough to protect a running process's lazy-loaded files plus one
+# rollback target). Single source for this default so gc_generations and
+# deploy-all.sh --status can't drift apart and report different numbers.
+dotfiles_keep_generations() {
+  printf '%s' "${DOTFILES_KEEP_GENERATIONS:-3}"
 }
 
 # resolve_deploy_src
@@ -644,7 +688,7 @@ switch_current() {
 }
 
 # gc_generations
-# Removes generations beyond ${DOTFILES_KEEP_GENERATIONS:-3}, oldest first.
+# Removes generations beyond dotfiles_keep_generations(), oldest first.
 # Invariants: the generation `current` points at is never removed, and if
 # `current` points outside generations/ (dev mode — see ADR §4.5) nothing
 # is removed at all. Deletion goes through _dotfiles_safe_rmdir, which
@@ -671,7 +715,7 @@ gc_generations() {
   esac
   _gc_current_name=$(basename "$_gc_current_target")
 
-  _gc_keep="${DOTFILES_KEEP_GENERATIONS:-3}"
+  _gc_keep="$(dotfiles_keep_generations)"
 
   # Two passes over generations/, deliberately kept separate:
   #   1. Enumerate every entry (no -type filter) so a stray symlink or file

--- a/shared/helpers.sh
+++ b/shared/helpers.sh
@@ -213,11 +213,18 @@ links_for_tool() {
 
 # claude_skill_links [repo_root]
 # Print (one per line) the paths under $HOME/.claude/skills/ that are
-# symlinks owned by this repo's distribution (see
-# _dotfiles_symlink_is_repo_owned for the ownership test — the canonical
-# prefix always counts, and repo_root additionally recognizes the
-# pre-migration direct-to-worktree scheme, see ADR DOC-2608040229 §4.8/
-# §4.9). Skills aren't in links_for_tool()/KNOWN_LINKS_claude because
+# symlinks owned by this repo's distribution. Recognizes three schemes:
+# current-scheme (target under <prefix>/current/claude/skills/), a
+# generation directly (target under <prefix>/generations/*/claude/skills/,
+# e.g. when DOTFILES_DEPLOY_SRC was pointed at one directly), and the
+# pre-migration direct-to-worktree scheme (target under
+# repo_root/claude/skills/, if repo_root is given — see ADR
+# DOC-2608040229 §4.8/§4.9). Deliberately narrower than
+# _dotfiles_symlink_is_repo_owned's generic "anywhere under repo_root"
+# check: a user's own symlink into some other part of the working tree
+# (e.g. a scratch directory) is not a skill this repo distributed, and
+# treating it as one would make uninstall.sh delete a link it doesn't own.
+# Skills aren't in links_for_tool()/KNOWN_LINKS_claude because
 # claude/deploy.sh symlinks them individually, one per skill directory
 # auto-detected under claude/skills/, rather than as a fixed list — but
 # they are still $HOME symlinks this repo creates, and in practice the
@@ -230,11 +237,22 @@ claude_skill_links() {
   _csl_repo_root="${1:-}"
   _csl_dir="$HOME/.claude/skills"
   [ -d "$_csl_dir" ] || return 0
+  _csl_prefix="$(dotfiles_prefix)"
   for _csl_link in "$_csl_dir"/*; do
     [ -L "$_csl_link" ] || continue
-    if _dotfiles_symlink_is_repo_owned "$_csl_link" "$_csl_repo_root"; then
-      printf '%s\n' "$_csl_link"
-    fi
+    _csl_target=$(readlink "$_csl_link")
+    case "$_csl_target" in
+      "$_csl_prefix/current/claude/skills"/* | "$_csl_prefix/generations"/*/claude/skills/*)
+        printf '%s\n' "$_csl_link"
+        ;;
+      *)
+        if [ -n "$_csl_repo_root" ]; then
+          case "$_csl_target" in
+            "$_csl_repo_root/claude/skills"/*) printf '%s\n' "$_csl_link" ;;
+          esac
+        fi
+        ;;
+    esac
   done
 }
 

--- a/shared/helpers.sh
+++ b/shared/helpers.sh
@@ -614,7 +614,13 @@ create_generation() {
 
 # write_manifest <generation_dir> <src_tree> <mode>
 # Writes a plain-text .dotfiles-manifest into generation_dir recording
-# where this generation came from. <mode> is "generation" or "dev".
+# where this generation came from. <mode> is "generation" or "dev", but no
+# caller currently passes "dev": cmd_dev (deploy-all.sh) never calls this
+# function at all, since dev mode points current at a source tree rather
+# than a generation directory, and writing a manifest into the user's own
+# working tree would dirty it. deploy-all.sh --status instead reads dev
+# mode's provenance live via git rev-parse/status against the source tree
+# it points at, rather than through a written manifest.
 write_manifest() {
   _wm_gen_dir="$1"
   _wm_src_tree="$2"

--- a/shared/helpers.sh
+++ b/shared/helpers.sh
@@ -145,6 +145,65 @@ resolve_tools() {
   return 0
 }
 
+# ── Known $HOME-side link destinations per tool ─────────────────────────
+#
+# Single source of truth for "which paths under $HOME does this repo's
+# deploy create". uninstall.sh needs it to know what to remove;
+# deploy-all.sh --status needs it to check for broken symlinks. Keeping one
+# copy here (instead of duplicating the list in both scripts) is what
+# prevents the drift that let ocw-meter go unlisted from KNOWN_LINKS_bin in
+# the first place (see ADR DOC-2608040229 §2.6 / AGENTS.md 実装時の注意).
+# Use printf so the trailing-newline line-continuation works portably.
+KNOWN_LINKS_zsh=$(
+  printf '%s\n' \
+    "$HOME/.zshrc" \
+    "$HOME/.zsh_plugins.txt"
+)
+
+KNOWN_LINKS_nvim=$(
+  printf '%s\n' \
+    "${XDG_CONFIG_HOME:-$HOME/.config}/nvim/init.lua" \
+    "${XDG_CONFIG_HOME:-$HOME/.config}/nvim/lua" \
+    "${XDG_CONFIG_HOME:-$HOME/.config}/nvim/lazy-lock.json"
+)
+
+KNOWN_LINKS_tmux=$(
+  printf '%s\n' \
+    "$HOME/.tmux.conf"
+)
+
+KNOWN_LINKS_bin=$(
+  printf '%s\n' \
+    "$HOME/bin/ocw" \
+    "$HOME/bin/claude-ds" \
+    "$HOME/bin/ocw-meter"
+)
+
+KNOWN_LINKS_claude=$(
+  printf '%s\n' \
+    "$HOME/.claude/CLAUDE.md"
+)
+
+# links_for_tool <tool>
+# Print (one per line) the KNOWN_LINKS_<tool> destinations for <tool>
+# (empty if <tool> has none). Callers (uninstall.sh's per-tool loop and
+# distribution-artifact cleanup, deploy-all.sh's --status link-health scan)
+# all need the same tool -> KNOWN_LINKS_* mapping, and duplicating this case
+# statement is exactly the kind of drift the comment above warns about.
+#
+# A function (not eval-based indirection through a "KNOWN_LINKS_$tool" name)
+# keeps each KNOWN_LINKS_* variable directly referenced, so a static
+# analysis tool can still see the use.
+links_for_tool() {
+  case "$1" in
+    zsh) printf '%s\n' "$KNOWN_LINKS_zsh" ;;
+    nvim) printf '%s\n' "$KNOWN_LINKS_nvim" ;;
+    tmux) printf '%s\n' "$KNOWN_LINKS_tmux" ;;
+    bin) printf '%s\n' "$KNOWN_LINKS_bin" ;;
+    claude) printf '%s\n' "$KNOWN_LINKS_claude" ;;
+  esac
+}
+
 # ── Logging (colourised when the output fd is a terminal) ─────────────
 
 # _can_color <fd>

--- a/tests/deploy_smoke.sh
+++ b/tests/deploy_smoke.sh
@@ -1503,6 +1503,59 @@ scenario_status() {
   else
     fail "--status がリンク切れを検出する"
   fi
+
+  # --- devモードでは Mode: DEV と表示され、manifestの代わりにgit状態が出る ---
+  out="$(run_deploy "$sbx" --dev 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "--dev が失敗 (exit=$rc)"
+    log "$out"
+  fi
+  out="$(run_deploy "$sbx" --status 2>&1)"
+  if printf '%s' "$out" | grep -q "Mode: DEV"; then
+    pass "devモードの--statusはMode: DEVを表示する"
+  else
+    fail "devモードの--statusはMode: DEVを表示する"
+  fi
+  if printf '%s' "$out" | grep -q "Live source tree state"; then
+    pass "devモードの--statusはmanifestの代わりに実ソースツリーのgit状態を表示する"
+  else
+    fail "devモードの--statusはmanifestの代わりに実ソースツリーのgit状態を表示する"
+  fi
+
+  # --- currentが消えた世代を指しているとエラーとして報告される ---
+  new_sandbox
+  sbx="$SANDBOX_DIR"
+  prefix="$(dotfiles_prefix_for "$sbx")"
+  mkdir -p "$prefix"
+  ln -sfn "$prefix/generations/does-not-exist" "$prefix/current"
+
+  out="$(run_deploy "$sbx" --status 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    pass "currentが消えた世代を指すとき--statusが非0で終了する (exit=$rc)"
+  else
+    fail "currentが消えた世代を指すとき--statusが非0で終了する (exit=0のままだった)"
+  fi
+  if printf '%s' "$out" | grep -q "current points at a generation directory that no longer exists"; then
+    pass "currentが消えた世代を指すときの--statusエラーメッセージが表示される"
+  else
+    fail "currentが消えた世代を指すときの--statusエラーメッセージが表示される"
+  fi
+
+  # --- --status/--rollback/--devは互いに組み合わせられない ---
+  out="$(run_deploy "$sbx" --status --dev 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    pass "--status --dev はモード衝突としてエラーになる (exit=$rc)"
+  else
+    fail "--status --dev はモード衝突としてエラーになる (exit=0になってしまった)"
+  fi
+  if printf '%s' "$out" | grep -qi "cannot combine"; then
+    pass "モード衝突のエラーメッセージが表示される"
+  else
+    fail "モード衝突のエラーメッセージが表示される"
+  fi
 }
 
 # ── シナリオ24: --rollback ──────────────────────────────────────────────
@@ -1512,7 +1565,7 @@ scenario_rollback() {
     return
   fi
   log "=== シナリオ24: --rollback ==="
-  local sbx copy_dir prefix out rc gen1_content gen2_content gen2_target marker
+  local sbx copy_dir prefix out rc gen1_content gen2_content gen1_target gen2_target gen1_name gen2_name marker
 
   new_sandbox
   sbx="$SANDBOX_DIR"
@@ -1529,6 +1582,8 @@ scenario_rollback() {
     return
   fi
   gen1_content="$(cat "$sbx/bin/ocw" 2>/dev/null)"
+  gen1_target="$(current_target_for "$sbx")"
+  gen1_name="$(basename "$gen1_target")"
 
   marker="# smoke-test rollback marker $$"
   printf '%s\n' "$marker" >>"$copy_dir/bin/ocw"
@@ -1543,12 +1598,76 @@ scenario_rollback() {
   fi
   gen2_content="$(cat "$sbx/bin/ocw" 2>/dev/null)"
   gen2_target="$(current_target_for "$sbx")"
+  gen2_name="$(basename "$gen2_target")"
 
   if printf '%s' "$gen2_content" | grep -qF "$marker"; then
     pass "2回目のdeployでソースツリーの編集内容が反映されている（rollback検証の前提）"
   else
     fail "2回目のdeployでソースツリーの編集内容が反映されている（rollback検証の前提）"
     return
+  fi
+
+  # --- 明示的な世代ID指定: gen2 -> gen1 -> gen2 と往復して、
+  #     引数なし(直前の世代)とは別のコードパスを通ることを確認する ---
+  out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --rollback "$gen1_name" 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "--rollback <世代ID>(明示指定)が失敗 (exit=$rc)"
+    log "$out"
+  else
+    pass "--rollback <世代ID>(明示指定)が成功する"
+  fi
+  if [ "$(current_target_for "$sbx")" = "$gen1_target" ] && [ "$(cat "$sbx/bin/ocw" 2>/dev/null)" = "$gen1_content" ]; then
+    pass "--rollback <世代ID>で指定した世代へ切り替わる"
+  else
+    fail "--rollback <世代ID>で指定した世代へ切り替わる"
+  fi
+
+  out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --rollback "$gen2_name" 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "--rollback <世代ID>(gen2へ明示指定で戻す)が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+  if [ "$(current_target_for "$sbx")" = "$gen2_target" ]; then
+    pass "--rollback <世代ID>でgen2へ戻せる(以降のテストの前提を復元)"
+  else
+    fail "--rollback <世代ID>でgen2へ戻せる(以降のテストの前提を復元)"
+    return
+  fi
+
+  # --- パストラバーサルを狙った世代IDは拒否される ---
+  out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --rollback ../../etc 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    pass "--rollback ../../etc は拒否される (exit=$rc)"
+  else
+    fail "--rollback ../../etc は拒否される (exit=0になってしまった)"
+  fi
+  if printf '%s' "$out" | grep -q "Invalid generation id"; then
+    pass "パストラバーサルの拒否メッセージが表示される"
+  else
+    fail "パストラバーサルの拒否メッセージが表示される"
+  fi
+  if [ "$(current_target_for "$sbx")" = "$gen2_target" ]; then
+    pass "パストラバーサル入力を拒否してもcurrentは変更されない"
+  else
+    fail "パストラバーサル入力を拒否してもcurrentは変更されない"
+  fi
+
+  # --- -h は世代IDとして食われず、ヘルプ表示になる ---
+  out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --rollback -h 2>&1)"
+  rc=$?
+  if printf '%s' "$out" | grep -q "^Usage:"; then
+    pass "--rollback -h は世代IDとして消費されずヘルプが表示される"
+  else
+    fail "--rollback -h は世代IDとして消費されずヘルプが表示される"
+  fi
+  if printf '%s' "$out" | grep -q "Unknown generation: -h"; then
+    fail "--rollback -h が誤って世代IDとして扱われている"
+  else
+    pass "--rollback -h が世代IDとして誤消費されていない"
   fi
 
   # --- --dry-run は current を実際には変更しない ---
@@ -1601,6 +1720,22 @@ scenario_rollback() {
   else
     fail "戻せる世代が無い場合のエラーメッセージが表示される"
   fi
+
+  # --- currentが消えた世代を指しているとき、引数なしrollbackは
+  #     明示指定を促す明確なエラーになる ---
+  ln -sfn "$prefix/generations/does-not-exist" "$prefix/current"
+  out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --rollback 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    pass "currentが消えた世代を指すとき引数なしrollbackはエラー終了する (exit=$rc)"
+  else
+    fail "currentが消えた世代を指すとき引数なしrollbackはエラー終了する (exit=0になってしまった)"
+  fi
+  if printf '%s' "$out" | grep -q "current points at a generation that no longer exists"; then
+    pass "currentが消えた世代を指すときのエラーメッセージが表示される"
+  else
+    fail "currentが消えた世代を指すときのエラーメッセージが表示される"
+  fi
 }
 
 # ── シナリオ25: --dev ───────────────────────────────────────────────────
@@ -1610,7 +1745,7 @@ scenario_dev_mode() {
     return
   fi
   log "=== シナリオ25: --dev ==="
-  local sbx copy_dir prefix out rc marker gen_count_before gen_count_after
+  local sbx copy_dir prefix out rc marker gen_count_before gen_count_after latest_gen_target
 
   new_sandbox
   sbx="$SANDBOX_DIR"
@@ -1636,6 +1771,7 @@ scenario_dev_mode() {
     return
   fi
   gen_count_before="$(find "$prefix/generations" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
+  latest_gen_target="$(current_target_for "$sbx")"
 
   # --- --dry-run は current を実際には変更しない ---
   out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --dev --dry-run 2>&1)"
@@ -1690,6 +1826,100 @@ scenario_dev_mode() {
     pass "devモード中はDOTFILES_KEEP_GENERATIONSを絞ってもGCで世代が削除されない: $gen_count_after 件のまま"
   else
     fail "devモード中はDOTFILES_KEEP_GENERATIONSを絞ってもGCで世代が削除されない: 期待${gen_count_before}件、実際 $gen_count_after 件"
+  fi
+
+  # --- positive control: 同じgc_generationsが generation モードでは
+  #     実際に削除することを確認する（devモードで削除されないのがGCの
+  #     不変条件によるものであり、GC自体が何もしていないからではないことを
+  #     区別するため）。redeployでdevモードを抜けさせてから同条件で呼ぶ。 ---
+  wait_for_next_second
+  out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --force --only bin 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "positive control用の再deployが失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+  case "$(current_target_for "$sbx")" in
+    "$prefix/generations"/*)
+      pass "再deployでdevモードを抜けgenerationモードへ戻る（positive controlの前提）"
+      ;;
+    *)
+      fail "再deployでdevモードを抜けgenerationモードへ戻る（positive controlの前提）"
+      return
+      ;;
+  esac
+
+  sandbox_env "$sbx"
+  env "${SANDBOX_ENV[@]}" DOTFILES_KEEP_GENERATIONS=1 sh -c '. "'"$REPO_ROOT"'/shared/helpers.sh" && gc_generations' >/dev/null 2>&1
+  gen_count_after="$(find "$prefix/generations" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
+  if [ "$gen_count_after" -eq 1 ]; then
+    pass "positive control: generationモードでは同じgc_generationsが実際に1件まで削除する"
+  else
+    fail "positive control: generationモードでは同じgc_generationsが実際に1件まで削除する（実際: ${gen_count_after}件）"
+  fi
+}
+
+# ── シナリオ26: devモード中の --rollback は最新世代へ切り替える ─────────
+
+scenario_dev_mode_rollback() {
+  if ! has_tool bin; then
+    return
+  fi
+  log "=== シナリオ26: devモード中の--rollbackは最新世代へ切り替える ==="
+  local sbx copy_dir prefix out rc latest_gen_target
+
+  new_sandbox
+  sbx="$SANDBOX_DIR"
+  copy_dir="$(mktemp -d)"
+  CREATED_DIRS+=("$copy_dir")
+  copy_repo_snapshot "$copy_dir"
+  prefix="$(dotfiles_prefix_for "$sbx")"
+
+  out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --force --only bin 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "事前準備(1回目のdeploy-all.sh --only bin)が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+
+  wait_for_next_second
+  out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --force --only bin 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "事前準備(2回目のdeploy-all.sh --only bin)が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+  latest_gen_target="$(current_target_for "$sbx")"
+
+  out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --dev 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "--dev が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+
+  # --- devモード中に引数なし--rollbackすると、
+  #     「直前の世代」が定義できないため最新世代へ切り替わる ---
+  out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --rollback 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "devモード中の--rollbackが失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+  if printf '%s' "$out" | grep -qi "dev mode"; then
+    pass "devモード中の--rollbackはdevモードからの離脱であることを明示する"
+  else
+    fail "devモード中の--rollbackはdevモードからの離脱であることを明示する"
+  fi
+  if [ "$(current_target_for "$sbx")" = "$latest_gen_target" ]; then
+    pass "devモード中の引数なし--rollbackは最新世代へ切り替わる"
+  else
+    fail "devモード中の引数なし--rollbackは最新世代へ切り替わる (実際: $(current_target_for "$sbx"))"
   fi
 }
 
@@ -1746,6 +1976,8 @@ log
 scenario_rollback
 log
 scenario_dev_mode
+log
+scenario_dev_mode_rollback
 log
 
 if [ "$FAIL" -eq 0 ]; then

--- a/tests/deploy_smoke.sh
+++ b/tests/deploy_smoke.sh
@@ -1433,6 +1433,266 @@ scenario_cleanup_removes_orphaned_scratch_without_generation() {
   assert_not_exists "$prefix"
 }
 
+# ── シナリオ23: --status ────────────────────────────────────────────────
+
+scenario_status() {
+  if ! has_tool bin; then
+    return
+  fi
+  log "=== シナリオ23: --status ==="
+  local sbx prefix out rc
+
+  new_sandbox
+  sbx="$SANDBOX_DIR"
+  prefix="$(dotfiles_prefix_for "$sbx")"
+
+  out="$(run_deploy "$sbx" --force --only bin 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "deploy-all.sh --force --only bin が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+
+  out="$(run_deploy "$sbx" --status 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "--status が成功終了する (exit=$rc)"
+    log "$out"
+  else
+    pass "--status が成功終了する"
+  fi
+
+  if printf '%s' "$out" | grep -q "Mode: generation"; then
+    pass "--status がgenerationモードを表示する"
+  else
+    fail "--status がgenerationモードを表示する"
+  fi
+
+  if printf '%s' "$out" | grep -q "^  commit_sha: "; then
+    pass "--status がmanifestのcommit_shaを表示する"
+  else
+    fail "--status がmanifestのcommit_shaを表示する"
+  fi
+
+  if printf '%s' "$out" | grep -q "(current)"; then
+    pass "--status が世代一覧でcurrentを明示する"
+  else
+    fail "--status が世代一覧でcurrentを明示する"
+  fi
+
+  if printf '%s' "$out" | grep -qE "\[OK\][[:space:]]+$sbx/bin/ocw$"; then
+    pass "--status がリンク健全性をOKと報告する"
+  else
+    fail "--status がリンク健全性をOKと報告する"
+  fi
+
+  # --- リンク切れを作ると検出されること ---
+  rm -f "$sbx/bin/ocw-meter"
+  ln -s "$prefix/current/bin/does-not-exist" "$sbx/bin/ocw-meter"
+
+  out="$(run_deploy "$sbx" --status 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    pass "リンク切れがあると--statusが非0で終了する (exit=$rc)"
+  else
+    fail "リンク切れがあると--statusが非0で終了する (exit=0のままだった)"
+  fi
+  if printf '%s' "$out" | grep -qE "\[BROKEN\][[:space:]]+$sbx/bin/ocw-meter"; then
+    pass "--status がリンク切れを検出する"
+  else
+    fail "--status がリンク切れを検出する"
+  fi
+}
+
+# ── シナリオ24: --rollback ──────────────────────────────────────────────
+
+scenario_rollback() {
+  if ! has_tool bin; then
+    return
+  fi
+  log "=== シナリオ24: --rollback ==="
+  local sbx copy_dir prefix out rc gen1_content gen2_content gen2_target marker
+
+  new_sandbox
+  sbx="$SANDBOX_DIR"
+  copy_dir="$(mktemp -d)"
+  CREATED_DIRS+=("$copy_dir")
+  copy_repo_snapshot "$copy_dir"
+  prefix="$(dotfiles_prefix_for "$sbx")"
+
+  out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --force --only bin 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "1回目の deploy-all.sh --only bin が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+  gen1_content="$(cat "$sbx/bin/ocw" 2>/dev/null)"
+
+  marker="# smoke-test rollback marker $$"
+  printf '%s\n' "$marker" >>"$copy_dir/bin/ocw"
+
+  wait_for_next_second
+  out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --force --only bin 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "2回目の deploy-all.sh --only bin が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+  gen2_content="$(cat "$sbx/bin/ocw" 2>/dev/null)"
+  gen2_target="$(current_target_for "$sbx")"
+
+  if printf '%s' "$gen2_content" | grep -qF "$marker"; then
+    pass "2回目のdeployでソースツリーの編集内容が反映されている（rollback検証の前提）"
+  else
+    fail "2回目のdeployでソースツリーの編集内容が反映されている（rollback検証の前提）"
+    return
+  fi
+
+  # --- --dry-run は current を実際には変更しない ---
+  out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --rollback --dry-run 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "--rollback --dry-run が失敗 (exit=$rc)"
+    log "$out"
+  elif printf '%s' "$out" | grep -q '\[DRY-RUN\]'; then
+    pass "--rollback --dry-run はDRY-RUN出力になる"
+  else
+    fail "--rollback --dry-run はDRY-RUN出力になる"
+  fi
+  if [ "$(current_target_for "$sbx")" = "$gen2_target" ]; then
+    pass "--rollback --dry-run はcurrentを実際には変更しない"
+  else
+    fail "--rollback --dry-run はcurrentを実際には変更しない"
+  fi
+
+  # --- 実際にrollbackする ---
+  out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --rollback 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "--rollback が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+  pass "--rollback が成功する"
+
+  if [ "$(cat "$sbx/bin/ocw" 2>/dev/null)" = "$gen1_content" ]; then
+    pass "rollbackで\$HOME側から読める内容が前の世代のものに戻る（symlinkは張り直さない）"
+  else
+    fail "rollbackで\$HOME側から読める内容が前の世代のものに戻る（symlinkは張り直さない）"
+  fi
+
+  # $HOME 側の symlink 自体は current という固定パスを指したまま変わらない
+  # ことも確認する（current の付け替えだけで向き先が変わる、が世代方式の要）。
+  assert_symlink "$sbx/bin/ocw" "$prefix/current/bin/ocw"
+
+  # --- これ以上戻れない場合は明確なエラーになる ---
+  out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --rollback 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    pass "戻せる世代が無い場合はエラー終了する (exit=$rc)"
+  else
+    fail "戻せる世代が無い場合はエラー終了する (exit=0になってしまった)"
+  fi
+  if printf '%s' "$out" | grep -q "No older generation"; then
+    pass "戻せる世代が無い場合のエラーメッセージが表示される"
+  else
+    fail "戻せる世代が無い場合のエラーメッセージが表示される"
+  fi
+}
+
+# ── シナリオ25: --dev ───────────────────────────────────────────────────
+
+scenario_dev_mode() {
+  if ! has_tool bin; then
+    return
+  fi
+  log "=== シナリオ25: --dev ==="
+  local sbx copy_dir prefix out rc marker gen_count_before gen_count_after
+
+  new_sandbox
+  sbx="$SANDBOX_DIR"
+  copy_dir="$(mktemp -d)"
+  CREATED_DIRS+=("$copy_dir")
+  copy_repo_snapshot "$copy_dir"
+  prefix="$(dotfiles_prefix_for "$sbx")"
+
+  out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --force --only bin 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "事前準備(1回目のdeploy-all.sh --only bin)が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+
+  wait_for_next_second
+  out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --force --only bin 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "事前準備(2回目のdeploy-all.sh --only bin)が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+  gen_count_before="$(find "$prefix/generations" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
+
+  # --- --dry-run は current を実際には変更しない ---
+  out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --dev --dry-run 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "--dev --dry-run が失敗 (exit=$rc)"
+    log "$out"
+  fi
+  case "$(current_target_for "$sbx")" in
+    "$prefix/generations"/*)
+      pass "--dev --dry-run はcurrentを実際には変更しない"
+      ;;
+    *)
+      fail "--dev --dry-run はcurrentを実際には変更しない"
+      ;;
+  esac
+
+  # --- 実際に dev モードへ切り替える ---
+  out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --dev 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "--dev が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+  pass "--dev が成功する"
+
+  if [ "$(current_target_for "$sbx")" = "$copy_dir" ]; then
+    pass "--dev でcurrentがソースツリーを指す"
+  else
+    fail "--dev でcurrentがソースツリーを指す (実際: $(current_target_for "$sbx"))"
+  fi
+
+  marker="# smoke-test dev marker $$"
+  printf '%s\n' "$marker" >>"$copy_dir/bin/ocw"
+
+  if cat "$sbx/bin/ocw" 2>/dev/null | grep -qF "$marker"; then
+    pass "devモードではソースツリーの書き換えが\$HOME側へ即座に反映される"
+  else
+    fail "devモードではソースツリーの書き換えが\$HOME側へ即座に反映される"
+  fi
+
+  # --- devモード中はGCで世代が削除されないことを直接gc_generationsで検証する ---
+  # deploy-all.sh の通常フロー（--dev/--status/--rollback以外）は
+  # switch_current で必ずcurrentを新世代へ切り替えてからgc_generationsを
+  # 呼ぶため、この不変条件（shared/helpers.shのgc_generations、孫1実装）を
+  # 実際にdevモードのまま踏むには直接呼び出すしかない。
+  sandbox_env "$sbx"
+  env "${SANDBOX_ENV[@]}" DOTFILES_KEEP_GENERATIONS=1 sh -c '. "'"$REPO_ROOT"'/shared/helpers.sh" && gc_generations' >/dev/null 2>&1
+  gen_count_after="$(find "$prefix/generations" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
+  if [ "$gen_count_after" = "$gen_count_before" ]; then
+    pass "devモード中はDOTFILES_KEEP_GENERATIONSを絞ってもGCで世代が削除されない: $gen_count_after 件のまま"
+  else
+    fail "devモード中はDOTFILES_KEEP_GENERATIONSを絞ってもGCで世代が削除されない: 期待${gen_count_before}件、実際 $gen_count_after 件"
+  fi
+}
+
 log "REPO_ROOT: $REPO_ROOT"
 log "対象ツール: $TOOLS"
 log
@@ -1480,6 +1740,12 @@ log
 scenario_cleanup_dry_run_matches_reality
 log
 scenario_cleanup_removes_orphaned_scratch_without_generation
+log
+scenario_status
+log
+scenario_rollback
+log
+scenario_dev_mode
 log
 
 if [ "$FAIL" -eq 0 ]; then

--- a/tests/deploy_smoke.sh
+++ b/tests/deploy_smoke.sh
@@ -1231,6 +1231,50 @@ scenario_claude_old_scheme_skill_removed_by_uninstall() {
   assert_not_exists "$sbx/.claude/skills/$skill_name"
 }
 
+# ── シナリオ18b: リポジトリ内だがclaude/skills/配下ではない先を指す
+#     ユーザー自作skillリンクはuninstallの対象にならない ──────────────
+
+scenario_claude_user_skill_pointing_elsewhere_in_repo_not_swept() {
+  if ! has_tool claude; then
+    return
+  fi
+  log "=== シナリオ18b: repo_root配下だがclaude/skills/外を指すユーザー自作skillリンクは撤去されない ==="
+  local sbx out rc
+
+  new_sandbox
+  sbx="$SANDBOX_DIR"
+  mkdir -p "$sbx/.claude/skills"
+
+  # claude_skill_links() の repo_root チェックは「repo_root/claude/skills/配下」
+  # だけを配布物とみなす必要がある。REPO_ROOT配下の別ディレクトリ(例えば
+  # このテストファイル自身が置かれているtests/)を指すリンクまで拾ってしまうと、
+  # ユーザーがリポジトリ内の何かにリンクしているだけのskillをuninstallが
+  # 誤って削除してしまう(レビュー指摘: repo_root全体に対する前方一致は広すぎる)。
+  ln -s "$REPO_ROOT/tests" "$sbx/.claude/skills/my-own-skill"
+
+  out="$(run_uninstall "$sbx" --dry-run --only claude 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "uninstall.sh --dry-run --only claude が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+  if printf '%s' "$out" | grep -q "my-own-skill"; then
+    fail "claude/skills/外を指すユーザー自作skillリンクはuninstallの対象にならない（dry-runで言及されてしまった）"
+  else
+    pass "claude/skills/外を指すユーザー自作skillリンクはuninstallの対象にならない（dry-run）"
+  fi
+
+  out="$(run_uninstall "$sbx" --force --only claude 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "uninstall.sh --force --only claude が失敗 (exit=$rc)"
+    log "$out"
+    return
+  fi
+  assert_symlink "$sbx/.claude/skills/my-own-skill" "$REPO_ROOT/tests"
+}
+
 # ── シナリオ19: スコープ外ツールが参照している間は配布実体の後片付けをスキップする ──
 
 scenario_cleanup_skipped_while_other_tool_in_scope() {
@@ -1440,16 +1484,19 @@ scenario_status() {
     return
   fi
   log "=== シナリオ23: --status ==="
-  local sbx prefix out rc
+  local sbx prefix out rc skill_name skill_link
 
   new_sandbox
   sbx="$SANDBOX_DIR"
   prefix="$(dotfiles_prefix_for "$sbx")"
 
-  out="$(run_deploy "$sbx" --force --only bin 2>&1)"
+  # $TOOLS を deploy する（既定は bin,claude）。claude が対象に含まれるときだけ
+  # 下の「claude/skills/* のリンク切れ検出」を検証できるようにするため、
+  # bin 固定ではなく実行時の対象ツールに合わせる。
+  out="$(run_deploy "$sbx" --force --only "$TOOLS" 2>&1)"
   rc=$?
   if [ "$rc" -ne 0 ]; then
-    fail "deploy-all.sh --force --only bin が失敗 (exit=$rc)"
+    fail "deploy-all.sh --force --only $TOOLS が失敗 (exit=$rc)"
     log "$out"
     return
   fi
@@ -1502,6 +1549,34 @@ scenario_status() {
     pass "--status がリンク切れを検出する"
   else
     fail "--status がリンク切れを検出する"
+  fi
+
+  # --- claudeも対象のとき、claude/skills/* のリンク切れも検出されること ---
+  # 配布 symlink のうち本数が最も多い集合（ADR §1.1）が、KNOWN_LINKS_claude
+  # には載らずclaude_skill_links()経由でしか拾えないため、bin側の壊れた
+  # symlinkだけでは検証できない。実際にskillを1本壊して確認する。
+  if has_tool claude; then
+    skill_name="$(list_repo_skills | head -n1)"
+    if [ -n "$skill_name" ]; then
+      skill_link="$sbx/.claude/skills/$skill_name"
+      rm -f "$skill_link"
+      ln -s "$prefix/current/claude/skills/does-not-exist" "$skill_link"
+
+      out="$(run_deploy "$sbx" --status 2>&1)"
+      rc=$?
+      if [ "$rc" -ne 0 ]; then
+        pass "claude/skills/*のリンク切れがあると--statusが非0で終了する (exit=$rc)"
+      else
+        fail "claude/skills/*のリンク切れがあると--statusが非0で終了する (exit=0のままだった)"
+      fi
+      if printf '%s' "$out" | grep -qE "\[BROKEN\][[:space:]]+$skill_link"; then
+        pass "--status がclaude/skills/*のリンク切れを検出する"
+      else
+        fail "--status がclaude/skills/*のリンク切れを検出する"
+      fi
+    else
+      fail "claude/skills/*のリンク切れ検出テストの前提（skillが1つ以上存在すること）"
+    fi
   fi
 
   # --- devモードでは Mode: DEV と表示され、manifestの代わりにgit状態が出る ---
@@ -1962,6 +2037,8 @@ log
 scenario_claude_new_scheme_skill_removed_and_restored
 log
 scenario_claude_old_scheme_skill_removed_by_uninstall
+log
+scenario_claude_user_skill_pointing_elsewhere_in_repo_not_swept
 log
 scenario_cleanup_skipped_while_other_tool_in_scope
 log

--- a/tests/deploy_smoke.sh
+++ b/tests/deploy_smoke.sh
@@ -1640,7 +1640,7 @@ scenario_rollback() {
     return
   fi
   log "=== シナリオ24: --rollback ==="
-  local sbx copy_dir prefix out rc gen1_content gen2_content gen1_target gen2_target gen1_name gen2_name marker
+  local sbx copy_dir prefix out rc gen1_content gen2_content gen1_target gen2_target gen1_name gen2_name marker skill_name
 
   new_sandbox
   sbx="$SANDBOX_DIR"
@@ -1649,10 +1649,13 @@ scenario_rollback() {
   copy_repo_snapshot "$copy_dir"
   prefix="$(dotfiles_prefix_for "$sbx")"
 
-  out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --force --only bin 2>&1)"
+  # $TOOLS を deploy する（既定は bin,claude）。claude が対象に含まれるときは
+  # 2回目のdeployでskillを1つ追加し、rollbackで巻き戻ったあとにそのskillの
+  # symlinkがリンク切れとして扱われることも検証する。
+  out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --force --only "$TOOLS" 2>&1)"
   rc=$?
   if [ "$rc" -ne 0 ]; then
-    fail "1回目の deploy-all.sh --only bin が失敗 (exit=$rc)"
+    fail "1回目の deploy-all.sh --only $TOOLS が失敗 (exit=$rc)"
     log "$out"
     return
   fi
@@ -1663,17 +1666,27 @@ scenario_rollback() {
   marker="# smoke-test rollback marker $$"
   printf '%s\n' "$marker" >>"$copy_dir/bin/ocw"
 
+  if has_tool claude; then
+    skill_name="added-later"
+    mkdir -p "$copy_dir/claude/skills/$skill_name"
+    printf '# smoke-test skill added in gen2\n' >"$copy_dir/claude/skills/$skill_name/SKILL.md"
+  fi
+
   wait_for_next_second
-  out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --force --only bin 2>&1)"
+  out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --force --only "$TOOLS" 2>&1)"
   rc=$?
   if [ "$rc" -ne 0 ]; then
-    fail "2回目の deploy-all.sh --only bin が失敗 (exit=$rc)"
+    fail "2回目の deploy-all.sh --only $TOOLS が失敗 (exit=$rc)"
     log "$out"
     return
   fi
   gen2_content="$(cat "$sbx/bin/ocw" 2>/dev/null)"
   gen2_target="$(current_target_for "$sbx")"
   gen2_name="$(basename "$gen2_target")"
+
+  if has_tool claude; then
+    assert_symlink "$sbx/.claude/skills/$skill_name" "$prefix/current/claude/skills/$skill_name"
+  fi
 
   if printf '%s' "$gen2_content" | grep -qF "$marker"; then
     pass "2回目のdeployでソースツリーの編集内容が反映されている（rollback検証の前提）"
@@ -1781,6 +1794,25 @@ scenario_rollback() {
   # $HOME 側の symlink 自体は current という固定パスを指したまま変わらない
   # ことも確認する（current の付け替えだけで向き先が変わる、が世代方式の要）。
   assert_symlink "$sbx/bin/ocw" "$prefix/current/bin/ocw"
+
+  # --- gen1にはまだ無いskill(gen2で追加)のsymlinkは、rollback後に
+  #     current経由で解決できなくなりリンク切れとして残る。--rollback自身は
+  #     世代間差分を検出しない設計（指摘2への回答）なので、--statusがそれを
+  #     検出できることをここで固定する。 ---
+  if has_tool claude; then
+    out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --status 2>&1)"
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+      pass "rollbackでgen1に無いskillがリンク切れになると--statusが非0で終了する (exit=$rc)"
+    else
+      fail "rollbackでgen1に無いskillがリンク切れになると--statusが非0で終了する (exit=0のままだった)"
+    fi
+    if printf '%s' "$out" | grep -qE "\[BROKEN\][[:space:]]+$sbx/\.claude/skills/$skill_name"; then
+      pass "rollback後、gen2で追加されたskillのリンク切れを--statusが検出する"
+    else
+      fail "rollback後、gen2で追加されたskillのリンク切れを--statusが検出する"
+    fi
+  fi
 
   # --- これ以上戻れない場合は明確なエラーになる ---
   out="$(run_deploy_from "$copy_dir/deploy-all.sh" "$sbx" --rollback 2>&1)"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -180,41 +180,38 @@ for _tool in $TOOLS; do
     claude) _skills_src="$KNOWN_SKILLS_SRC_claude" ;;
   esac
 
-  if [ -n "$_skills_src" ] && [ -d "$HOME/.claude/skills" ]; then
-    for _skill_link in "$HOME/.claude/skills"/*; do
-      [ -L "$_skill_link" ] || continue
-      _target=$(readlink "$_skill_link")
-      # Recognize both schemes: current-scheme links go through
-      # DOTFILES_PREFIX/current/claude/skills/<name> (the normal case) or,
-      # if DOTFILES_DEPLOY_SRC was pointed at a generation directly, through
-      # DOTFILES_PREFIX/generations/<id>/claude/skills/<name>. $_skills_src
-      # (the working tree) covers pre-migration direct-to-worktree links.
-      case "$_target" in
-        "$DOTFILES_PREFIX/current/claude/skills"/* | "$DOTFILES_GENERATIONS_DIR"/*/claude/skills/* | "$_skills_src"/*)
-          _skill_name=$(basename "$_skill_link")
-          symlink_restore "$_skill_link" || OVERALL_OK=1
+  if [ -n "$_skills_src" ]; then
+    _OLDIFS="$IFS"
+    IFS='
+'
+    for _skill_link in $(claude_skill_links "$SCRIPT_DIR"); do
+      IFS="$_OLDIFS"
+      [ -z "$_skill_link" ] && continue
+      _skill_name=$(basename "$_skill_link")
+      symlink_restore "$_skill_link" || OVERALL_OK=1
 
-          # After removing the symlink, try to restore the original skill
-          # that deploy.sh backed up into ~/.claude/skills-backup/.
-          # Pick the oldest backup (first in glob order) — same policy as
-          # symlink_restore for .backup files.
-          for _cand in "$HOME/.claude/skills-backup/$_skill_name".*; do
-            [ -e "$_cand" ] || [ -L "$_cand" ] || continue
-            if [ "${DRY_RUN:-0}" -eq 1 ]; then
-              printf '[DRY-RUN] mv %s %s\n' "$_cand" "$_skill_link"
-            else
-              if mv "$_cand" "$_skill_link"; then
-                log_ok "Restored skill from backup: $_skill_link (from $(basename "$_cand"))"
-              else
-                log_error "Failed to restore skill backup: $_cand → $_skill_link"
-                OVERALL_OK=1
-              fi
-            fi
-            break
-          done
-          ;;
-      esac
+      # After removing the symlink, try to restore the original skill
+      # that deploy.sh backed up into ~/.claude/skills-backup/.
+      # Pick the oldest backup (first in glob order) — same policy as
+      # symlink_restore for .backup files.
+      for _cand in "$HOME/.claude/skills-backup/$_skill_name".*; do
+        [ -e "$_cand" ] || [ -L "$_cand" ] || continue
+        if [ "${DRY_RUN:-0}" -eq 1 ]; then
+          printf '[DRY-RUN] mv %s %s\n' "$_cand" "$_skill_link"
+        else
+          if mv "$_cand" "$_skill_link"; then
+            log_ok "Restored skill from backup: $_skill_link (from $(basename "$_cand"))"
+          else
+            log_error "Failed to restore skill backup: $_cand → $_skill_link"
+            OVERALL_OK=1
+          fi
+        fi
+        break
+      done
+      IFS='
+'
     done
+    IFS="$_OLDIFS"
   fi
 
   # skills-backup/ is where deploy.sh set aside pre-existing skills before

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -31,37 +31,10 @@ FORCE=0
 ONLY_TOOLS=""
 
 # ── Known symlinks per tool (dst only) ────────────────────────────────
-# Each tool entry lists one symlink destination per line.
-# Use printf so the trailing-newline line-continuation works portably.
-KNOWN_LINKS_zsh=$(
-  printf '%s\n' \
-    "$HOME/.zshrc" \
-    "$HOME/.zsh_plugins.txt"
-)
-
-KNOWN_LINKS_nvim=$(
-  printf '%s\n' \
-    "${XDG_CONFIG_HOME:-$HOME/.config}/nvim/init.lua" \
-    "${XDG_CONFIG_HOME:-$HOME/.config}/nvim/lua" \
-    "${XDG_CONFIG_HOME:-$HOME/.config}/nvim/lazy-lock.json"
-)
-
-KNOWN_LINKS_tmux=$(
-  printf '%s\n' \
-    "$HOME/.tmux.conf"
-)
-
-KNOWN_LINKS_bin=$(
-  printf '%s\n' \
-    "$HOME/bin/ocw" \
-    "$HOME/bin/claude-ds" \
-    "$HOME/bin/ocw-meter"
-)
-
-KNOWN_LINKS_claude=$(
-  printf '%s\n' \
-    "$HOME/.claude/CLAUDE.md"
-)
+# KNOWN_LINKS_<tool> and links_for_tool() now live in shared/helpers.sh —
+# deploy-all.sh --status needs the same list to check for broken symlinks,
+# and keeping one copy is what prevents the drift that let ocw-meter go
+# unlisted here in the first place (see ADR DOC-2608040229 §2.6).
 
 # Skills are symlinked individually by deploy.sh (auto-detected from
 # claude/skills/).  We walk ~/.claude/skills/ at uninstall time and
@@ -80,40 +53,6 @@ KNOWN_GENERATED_claude=$(
   printf '%s\n' \
     "$HOME/.claude/settings.json"
 )
-
-# links_for_tool <tool>
-# Print (one per line) the KNOWN_LINKS_<tool> destinations for <tool>
-# (empty if <tool> has none). Single source of truth for the tool ->
-# KNOWN_LINKS_* mapping: the main per-tool loop below and the distribution
-# artifact cleanup's cross-tool scan both need it, and duplicating this
-# case statement is exactly the kind of drift that let ocw-meter go
-# unlisted from KNOWN_LINKS_bin in the first place. A forgotten arm here
-# surfaces as "No link list defined for '<tool>'. Skipping." ONLY when
-# <tool> is in $TOOLS AND has no KNOWN_GENERATED_* entry either — the
-# main loop below only warns when both _links and _generated come back
-# empty (see its "No link list defined" check). claude is the one tool
-# where this doesn't save you: it has KNOWN_GENERATED_claude
-# (~/.claude/settings.json), so a forgotten claude arm here still leaves
-# _generated non-empty, the warning never fires, and ~/.claude/CLAUDE.md
-# quietly stops being touched while the generation it points into gets
-# deleted out from under it. A tool NOT in $TOOLS is missed silently
-# regardless of KNOWN_GENERATED_*: it's only ever passed to this function
-# by the cleanup's cross-tool scan, which has no warning path at all (the
-# tool is treated as having no links, so a live symlink into a
-# soon-to-be-deleted generation goes undetected).
-#
-# A function (not eval-based indirection through a "KNOWN_LINKS_$tool"
-# name) keeps each KNOWN_LINKS_* variable directly referenced, so a
-# static analysis tool can still see the use.
-links_for_tool() {
-  case "$1" in
-    zsh) printf '%s\n' "$KNOWN_LINKS_zsh" ;;
-    nvim) printf '%s\n' "$KNOWN_LINKS_nvim" ;;
-    tmux) printf '%s\n' "$KNOWN_LINKS_tmux" ;;
-    bin) printf '%s\n' "$KNOWN_LINKS_bin" ;;
-    claude) printf '%s\n' "$KNOWN_LINKS_claude" ;;
-  esac
-}
 
 # ── Usage ─────────────────────────────────────────────────────────────
 
@@ -205,9 +144,10 @@ for _tool in $TOOLS; do
   log_hr
   log_info "Uninstalling: $_tool"
 
-  # Get the list of known links for this tool via links_for_tool (see its
-  # definition above). KNOWN_GENERATED_* has only one case arm (claude), so
-  # it isn't worth routing through a helper the way KNOWN_LINKS_* is.
+  # Get the list of known links for this tool via links_for_tool (defined
+  # in shared/helpers.sh). KNOWN_GENERATED_* has only one case arm
+  # (claude), so it isn't worth routing through a helper the way
+  # KNOWN_LINKS_* is.
   _links="$(links_for_tool "$_tool")"
   _generated=""
   case "$_tool" in


### PR DESCRIPTION
## 背景

dotfilesは、macOS / Linux / WSL2 で共通の開発環境を再現するための設定リポジトリです。傘ブランチ `ai/deploy-stability` では、`$HOME` の設定がリポジトリの作業ツリーへ直接シンボリックリンクされていた従来方式から、世代ディレクトリと `current` シンボリックリンクを介した配布方式への移行を進めています。これまでの孫ブランチで、配布実体レイヤの導入・`claude` の追従・`uninstall.sh` の追従が完了し、配布と撤去の一連の流れが閉じました。

しかし、今 `$HOME` に効いている設定がどの世代・どのコミット由来なのかを確認する手段や、壊れた設定から前の状態へ戻す手段がまだありませんでした。

## このプルリクエストの目的

`deploy-all.sh` に、現在の配布状態を確認する `--status`、直前の世代へ戻す `--rollback`、作業ツリーへ即時反映するdevモード `--dev` を追加します。

## 実装内容

- `deploy-all.sh --status`: `current` が世代を指しているかdevモードかを表示し、世代であればmanifestの内容（デプロイ日時・コミットSHA・ブランチ・dirtyだったか等）を表示します。devモードの場合はmanifestが無いため、ソースツリーの現在のgit状態（コミットSHA・ブランチ・dirtyかどうか）をその場で読んで代わりに表示します。保持されている世代の一覧と、`$HOME` 側の各シンボリックリンク（`claude/skills/` 配下の個別シンボリックリンクを含む）の健全性（リンク切れの検出）も表示します。副作用はありません。
- `deploy-all.sh --rollback [世代ID]`: `current` を1つ前の世代（または指定した世代）へ付け替えます。`$HOME` 側のシンボリックリンクは張り直しません（`current` の付け替えだけで全リンクの向き先が変わる、という世代方式の要を利用しています）。切り替え先の世代に無いシンボリックリンクが残る可能性や、`~/.claude/settings.json`（生成された実ファイルのため付け替えの影響を受けない）については、完了メッセージで案内します。`--dry-run` に対応しています。
- `deploy-all.sh --dev`: `current` を作業ツリーそのものへ向けます。世代は作らず、リポジトリを編集すると即座に `$HOME` 側へ反映されます。リンクされたgit worktreeから実行した場合は、devモード向けの内容で警告を出します。`--dry-run` に対応しています。
- 配布先のパス一覧（`KNOWN_LINKS_*` と、それを引く `links_for_tool()`）を `uninstall.sh` から `shared/helpers.sh` へ移しました。対話zshの起動のたびにこのファイルが読まれることを踏まえ、モジュールレベルの変数として持たず `links_for_tool()` の各分岐へ直接埋め込む形にしています。`claude/skills/` 配下の個別シンボリックリンクを走査する `claude_skill_links()` も同様に共通化し、`--status` のリンク健全性チェックと `uninstall.sh` が同じロジックを参照するようにしました。片方だけ更新して食い違う事故（過去に `ocw-meter` が `uninstall.sh` 側から漏れていた）を防ぐためです。
- 世代保持数の既定値（3）を `shared/helpers.sh` の `dotfiles_keep_generations()` に一元化し、`gc_generations` と `--status` の両方がそこを参照するようにしました。

## レビューで見てほしいところ

- `--rollback` を引数なしで実行したときの「1つ前の世代」の決め方です。世代ディレクトリ名を日時順にソートし、現在の世代の直前を選ぶようにしました。`current` がdevモードを指している状態で `--rollback` を実行した場合は、「1つ前」が定義できないため、最新の世代へ切り替える扱いにしています。この挙動が直感的か確認をお願いします。
- `--dev` は `current` の付け替えのみを行い、`$HOME` 側のシンボリックリンク自体は作成しません。そのため、一度も deploy したことがない環境で `--dev` を最初に実行しても `$HOME` には何もリンクされません。最初に一度 `deploy-all.sh` を実行してから `--dev` を使う想定です。この制約で問題ないか確認をお願いします。
- devモード中はGCが動かないという不変条件（既存実装）を検証するテストを追加しましたが、`deploy-all.sh` の通常フローでは経路的に踏めないため、`shared/helpers.sh` の `gc_generations` を直接呼び出す形のテストにしました（generationモードに戻した状態で同じ呼び出しが実際に削除することを示すpositive controlも合わせて追加しています）。テストの妥当性を確認してください。

## テスト結果

`pre-commit run --all-files` と `tests/deploy_smoke.sh`（対象: 既定の `bin,claude`、および `bin` 単独、全26シナリオ）はすべて緑です。`./deploy-all.sh --dry-run` と `--status`（副作用なし）も実際の環境で実行し、想定通りの出力を確認しました。`bin/` 配下は変更していないため `python3 -m unittest discover -s bin/tests` は未実行です。

## 今後の予定

このプルリクエストで挙動が確定したので、次の孫ブランチで `AGENTS.md` / ルート `README.md` / テスト方針の文書を実装に合わせて更新する予定です。追加したオプション（`--status` / `--rollback` / `--dev`）とその出力形式は、その文書化の対象になります。

あわせて、`AGENTS.md`「実装時の注意」にある「`uninstall.sh` 内の `_links` / `_generated` / `_skills_src` を求める3つの `case` 文」という記述も、本PRで `_links` に相当する `case` 文が `shared/helpers.sh` の `links_for_tool()` へ移った結果、事実と合わなくなっています（`uninstall.sh` に残る `case "$_tool" in ... esac` は `_generated` / `_skills_src` の2つのみです）。この記述の更新も次の孫ブランチでの申し送り事項に含めてください。
