### PR TITLE
配布実体方式(世代 + current)に合わせて文書を更新する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,8 @@
 ## 概要
 
 クロスプラットフォーム（macOS / Linux / WSL2）対応の dotfiles。mise でランタイムを固定し、
-各ツールディレクトリ（`zsh/` `nvim/` `tmux/` `bin/` `claude/`）の `deploy.sh` が
+各ツールディレクトリ（`zsh/` `nvim/` `tmux/` `bin/` `claude/`）の `deploy.sh` が、配布実体
+（世代ディレクトリ + `current` シンボリックリンク。詳細は「デプロイの仕組み」節）を経由して
 ユーザーの `$HOME` に symlink を張ることで設定を配布する。
 
 ## 最重要ルール
@@ -12,15 +13,23 @@
   `git push --force` / `gh pr merge` を実行しない。例外はない。**
   すべての不可逆操作の前にこのルールを照合すること。
 - **deploy スクリプト（`deploy-all.sh` / `uninstall.sh` / `*/deploy.sh`）を実オペレーションで
-  実行しない。** symlink 先はユーザーの実 `$HOME` であり、`~/.zshrc` `~/.tmux.conf`
-  `~/.claude/settings.json` `~/bin/*` を実際に置き換える。動作確認は `deploy-all.sh --dry-run`
-  （全ツール対象）で行うのを基本とする。`HOME` を一時ディレクトリに差し替えるサンドボックス実行が
-  許されるツールの範囲は無条件ではない。副作用が `$HOME` の外（システムパッケージのインストール）や
-  外部ネットワークに及ぶツール（`tmux` `zsh` `nvim`）は対象外であり、詳細と対象ツールの分類は
-  `docs/design/` の「テスト方針（DOC-2608020715-b）」に従うこと。
+  実行しない。** `$HOME` 側のシンボリックリンクは配布実体
+  （`${XDG_DATA_HOME:-$HOME/.local/share}/dotfiles/` 配下の世代ディレクトリ + `current`）を
+  経由するが、リンクの向き先が指す実体は結局ユーザーの実 `$HOME` であり、`~/.zshrc`
+  `~/.tmux.conf` `~/.claude/settings.json` `~/bin/*` を実際に置き換える。世代の作成・`current`
+  の切り替え・古い世代の削除も同じ prefix 配下で実際に行われる。動作確認は
+  `deploy-all.sh --dry-run`（全ツール対象）で行うのを基本とする。**`deploy-all.sh --status` は
+  副作用が無いため実 `$HOME` に対して実行してよいが、`--rollback` と `--dev` は `current` を
+  実際に付け替えるため、`--dry-run` を付けずに実 `$HOME` に対して実行しない。**
+  `HOME` を一時ディレクトリに差し替えるサンドボックス実行が許されるツールの範囲は無条件ではない。
+  副作用が `$HOME` の外（システムパッケージのインストール）や外部ネットワークに及ぶツール
+  （`tmux` `zsh` `nvim`）は対象外であり、詳細と対象ツールの分類は `docs/design/` の
+  「テスト方針（DOC-2608020715-b）」に従うこと。
   **個別の `<tool>/deploy.sh` は `--dry-run` 引数を解釈しない**（環境変数 `DRY_RUN=1` のみ見る）。
   `sh zsh/deploy.sh --dry-run` のように直接引数を渡しても無視され実際に書き換えが起きるため、
   個別スクリプトを dry-run するときは `DRY_RUN=1 sh zsh/deploy.sh` のように環境変数で渡すこと。
+  単体実行時、配布元は環境変数 `DOTFILES_DEPLOY_SRC` が未設定なら `current` を自動的に使う
+  （`current` も無ければエラーで `./deploy-all.sh` を案内して終了する）。
 - 指示された範囲外の機能を先回りして実装しない。
 - **shellcheck / shfmt を含む linter の抑制ディレクティブ（`# shellcheck disable=...` 等）や、
   `.pre-commit-config.yaml` の `exclude` / `exclude_types` 追加・`shfmt` のオプション緩和などの
@@ -68,18 +77,90 @@
 
 ## デプロイの仕組み
 
-- `deploy-all.sh` が `shared/helpers.sh` を source し、`AVAILABLE_TOOLS` を解決した上で
-  各 `<tool>/deploy.sh` を呼び出す。
-- オプション: `--dry-run` / `--force` / `--only <tools>` / `--backup` / `--no-backup`。
-- symlink は `shared/helpers.sh` の `symlink_backup` 経由で張る。既存ファイルは `.backup`
-  （既に存在する場合はタイムスタンプ+PID 付きの別名）に退避される。`symlink_restore` が
-  uninstall 側の対応関数。ただし退避の前提は次の2点で崩れる:
-  - `--no-backup`（`BACKUP=0`）指定時は退避されず `rm -f` される
-  - `claude/skills/` は `symlink_backup` を通らない。`claude/deploy.sh` がスキルごとに
-    個別に symlink を張り、退避先も `~/.claude/skills-backup/<名前>.<日時>.<PID>` になる
-- `claude/settings.json` だけは symlink ではなく、ベース設定と `settings.machine.json`
-  （マシン固有・非追跡）をマージした**実ファイル**として生成される。マシンごとの上書き設定を
-  git 管理下に置かずに反映するため。
+`$HOME` はリポジトリの作業ツリーへ直接リンクしない。`deploy-all.sh` は作業ツリーを
+**配布実体**（世代ディレクトリ）へコピーし、`current` というシンボリックリンクをそこへ向け、
+各 `<tool>/deploy.sh` は `current` 経由で `$HOME` からリンクする（Capistrano の `releases/` +
+`current` と同じ構造）。採用理由と却下案は ADR
+[DOC-2608040229](docs/adr/DOC-2608040229_deploy-distribution-method.md) を参照。
+
+### 配布実体レイヤ
+
+- canonical prefix: `${XDG_DATA_HOME:-$HOME/.local/share}/dotfiles`
+- 世代ディレクトリ: `<prefix>/generations/<date +%Y%m%dT%H%M%S>-<short sha>`（作業ツリーから
+  `cp -a`。**`AVAILABLE_TOOLS` の各ディレクトリと `shared/` のみ**が対象で、`docs/` `tools/`
+  `templates/` `tests/` `.git` はコピーされない）
+- `current`: `<prefix>/current`。`ln -sfn` で切り替える（原子性は追わない。ADR §4.7）
+- 世代直下の `.dotfiles-manifest` にデプロイ日時・ソースツリーの絶対パス・コミット SHA・
+  ブランチ名・dirty だったか・リンクされた git ワークツリーからのデプロイか・モード（世代 or
+  dev）・ホスト名を平文で記録する
+- 保持世代数は既定3（`DOTFILES_KEEP_GENERATIONS` で上書き可）。GC は `current` が指す世代を
+  決して削除せず、dev モード中は何も削除しない
+- **`--only <tools>` は `$HOME` のどのリンクを張るかだけを制御し、世代の内容には影響しない。**
+  世代は常に全ツール分をコピーする（部分的な世代を作ると、他ツールのリンクが新世代に
+  存在しないパスを指してリンク切れになるため）
+
+### デプロイの流れ
+
+1. `deploy-all.sh` が `shared/helpers.sh` を source し、`AVAILABLE_TOOLS` を解決する
+2. 新しい世代ディレクトリを作り、`.dotfiles-manifest` を書く
+3. `current` を新世代へ切り替える
+4. 各 `<tool>/deploy.sh` を、配布元を環境変数 `DOTFILES_DEPLOY_SRC`（= `current` を指す
+   固定パス）として export した状態で呼び出す。symlink は `shared/helpers.sh` の
+   `symlink_backup` 経由で `$DOTFILES_DEPLOY_SRC/<tool>/...` へ張る
+5. 古い世代を GC する
+
+オプション: `--dry-run` / `--force` / `--only <tools>` / `--backup` / `--no-backup` /
+`--status` / `--rollback [世代ID]` / `--dev`。後者3つは `current` シンボリックリンク自体を
+操作するコマンドで、互いに組み合わせられず、`--only` / `--force` / `--backup` とも
+組み合わせられない（`--dry-run` のみ併用可）。
+
+- `--status`: 副作用なし。`current` の向き先（世代か dev モードか）・その manifest の内容
+  （dev モードでは manifest が無いためソースツリーの git 状態をその場で読んで代わりに表示する）・
+  保持世代一覧・`$HOME` 側リンクの健全性（リンク切れ検出）を表示する
+- `--rollback [世代ID]`: `current` を1つ前（または指定した）世代へ付け替える。`$HOME` 側の
+  symlink は張り直さない（`current` の付け替えだけで全リンクの向き先が変わるのが世代方式の要）
+- `--dev`: `current` を作業ツリーそのものへ向ける（世代は作らない。編集が即座に `$HOME` へ
+  反映される）。dev モード中は GC を行わない
+
+`$HOME` 側の配布先一覧は `shared/helpers.sh` の `links_for_tool()`（symlink 系のツール）と
+`claude_skill_links()`（`claude/skills/` の個別 symlink）に一元化されており、`uninstall.sh` と
+`deploy-all.sh --status` の両方がここを参照する。リストを二重管理すると片方だけ更新される
+事故が起きる（`uninstall.sh` 側から `ocw-meter` が漏れていた過去の不具合がまさにこれ）。
+
+### 単体 `<tool>/deploy.sh` 実行時の規約
+
+`DOTFILES_DEPLOY_SRC` が未設定なら `current` を自動的に使う（`shared/helpers.sh` の
+`resolve_deploy_src`）。`current` も無ければ、エラーメッセージで `./deploy-all.sh` を案内して
+終了する。単体実行が自分で世代を作ることはない（世代は常に全ツール分でなければならないため）。
+
+### symlink の退避
+
+symlink は `shared/helpers.sh` の `symlink_backup` 経由で張る。既存ファイルは `.backup`
+（既に存在する場合はタイムスタンプ+PID 付きの別名）に退避される。`symlink_restore` が
+uninstall 側の対応関数。ただし退避の前提は次の3点で崩れる:
+
+- `--no-backup`（`BACKUP=0`）指定時は退避されず `rm -f` される
+- dst が既にこのリポジトリ由来の symlink（リンク先が canonical prefix 配下、またはソースツリー
+  配下）であれば、退避せず張り替える。旧方式（作業ツリー直リンク）の symlink がそのまま
+  `.backup` として残り、後日 `uninstall.sh` がそれを「ユーザーの元設定」として誤って復元するのを
+  防ぐための判定
+- `claude/skills/` は `symlink_backup` を通らない。`claude/deploy.sh` がスキルごとに
+  個別に symlink を張り、退避先も `~/.claude/skills-backup/<名前>.<日時>.<PID>` になる
+
+### claude の例外
+
+`claude/settings.json` だけは symlink ではなく、`current` 経由の `claude/settings.json` と
+`claude/settings.machine.json`（マシン固有・非追跡だが `cp -a` で世代内にコピーされる）を
+マージした**実ファイル**として生成される。マシンごとの上書き設定を git 管理下に置かずに
+反映するため。
+
+### uninstall.sh の後片付け
+
+`uninstall.sh` は `$HOME` 側の symlink・生成ファイルを撤去したあと、配布実体
+（`<prefix>/generations/` と `current`）も片付ける。撤去対象に含まれないツールの symlink が
+まだ配布実体を参照している場合は片付けを行わず安全側に倒す。dev モード中（`current` が
+人間の作業ツリーを指している）は `current` というシンボリックリンク自体だけを取り除き、
+作業ツリーの実体には一切触れない。
 
 ## クロスプラットフォーム制約
 
@@ -126,7 +207,9 @@ tests/deploy_smoke.sh
 
 `HOME` を一時ディレクトリへ差し替えたサンドボックス上で実際に deploy /
 uninstall を行い、symlink・既存ファイルの退避・冪等性・
-`claude/settings.json` の実ファイル生成を検証する（既定の対象は
+`claude/settings.json` の実ファイル生成に加えて、世代の作成と GC・
+ソースツリー消失耐性・編集分離・`--rollback`・`--dev`・
+配布実体（世代 + `current`）の後片付けを検証する（既定の対象は
 `bin,claude`。デプロイの検証は必ずこのサンドボックス経由で行い、
 人間の実 `$HOME` に対して直接実行しない。詳細は
 [docs/design/DOC-2608020715-b_テスト方針.md](docs/design/DOC-2608020715-b_テスト方針.md)
@@ -179,13 +262,22 @@ PR を作る前に
 ## 実装時の注意
 
 - 新しいツールディレクトリを足すときは `shared/helpers.sh` の `AVAILABLE_TOOLS` に加えて、
-  `uninstall.sh` の `KNOWN_LINKS_<tool>`（生成ファイルがあれば `KNOWN_GENERATED_<tool>` も）にも
-  追加する。**さらに、`uninstall.sh` 内の `_links` / `_generated` / `_skills_src` を求める
-  3つの `case "$_tool" in ... esac` にも、新しいツール名の arm を追加する。** `KNOWN_LINKS_<tool>`
-  変数を定義しただけで case 文に arm を足し忘れると、`_links` が空のまま扱われ「No link list
-  defined」で静かにスキップされる（変数の存在だけでは case 文の arm は自動生成されない）。
-  これを忘れると `uninstall.sh` は該当ツールを静かにスキップし、張った symlink が
-  ユーザーの `$HOME` に残り続ける。
+  同じく `shared/helpers.sh` の `links_for_tool()` に `$HOME` 側リンク先を返す `case` の arm を
+  追加する。**`uninstall.sh` と `deploy-all.sh --status` の両方がここを一次情報源として参照する**
+  ため、二重管理を避けるためにここへ一元化されている（過去に `uninstall.sh` 側だけ
+  `KNOWN_LINKS_bin` に `ocw-meter` が無く撤去漏れが起きた不具合の再発防止）。
+  生成ファイル（symlink ではなく実ファイルを生成するツール。例: `claude/settings.json`）が
+  あれば `uninstall.sh` の `KNOWN_GENERATED_<tool>` を定義し、`_generated` を求める
+  `case "$_tool" in ... esac` にも arm を追加する。スキルの個別 symlink のように
+  「リポジトリ由来判定」が別途必要な場合は `_skills_src` を求める `case` にも arm を追加する。
+  **`uninstall.sh` に残る `case` 文はこの2つ（`_generated` / `_skills_src`）のみで、
+  `_links` に相当する分岐は `shared/helpers.sh` の `links_for_tool()` へ移っている。**
+  `links_for_tool()` に arm を足し忘れると、`uninstall.sh` 側の `_links` が空のまま扱われ
+  「No link list defined」で静かにスキップされる。**ただし `KNOWN_GENERATED_<tool>` を
+  定義済みのツール（`claude` 等）はこのスキップ自体が発生しない**（`_generated` が非空の
+  ままループが継続するため）。この場合、警告なしに `_links` 側の symlink だけが撤去されずに
+  残る。`deploy-all.sh --status` のリンク健全性スキャンには arm 忘れに対する警告経路が無く、
+  その分の `$HOME` リンクが静かにレポートから抜け落ちる点にも注意する。
 - README は「ルート `README.md`（全体）」と「各ツールの `README.md`（詳細）」の二層構造。
   片方だけ更新しない。
 - `docs/` の文書に地の文で言及するときは、説明的ファイル名だけで呼ばず、その文書の DOC-ID を明示する

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,8 +111,8 @@
 
 オプション: `--dry-run` / `--force` / `--only <tools>` / `--backup` / `--no-backup` /
 `--status` / `--rollback [世代ID]` / `--dev`。後者3つは `current` シンボリックリンク自体を
-操作するコマンドで、互いに組み合わせられず、`--only` / `--force` / `--backup` とも
-組み合わせられない（`--dry-run` のみ併用可）。
+操作するコマンドで、互いに組み合わせられず、`--only` / `--force` / `--backup` / `--no-backup`
+とも組み合わせられない（`--dry-run` のみ併用可）。
 
 - `--status`: 副作用なし。`current` の向き先（世代か dev モードか）・その manifest の内容
   （dev モードでは manifest が無いためソースツリーの git 状態をその場で読んで代わりに表示する）・
@@ -157,10 +157,11 @@ uninstall 側の対応関数。ただし退避の前提は次の3点で崩れる
 ### uninstall.sh の後片付け
 
 `uninstall.sh` は `$HOME` 側の symlink・生成ファイルを撤去したあと、配布実体
-（`<prefix>/generations/` と `current`）も片付ける。撤去対象に含まれないツールの symlink が
-まだ配布実体を参照している場合は片付けを行わず安全側に倒す。dev モード中（`current` が
-人間の作業ツリーを指している）は `current` というシンボリックリンク自体だけを取り除き、
-作業ツリーの実体には一切触れない。
+（`<prefix>/generations/` `<prefix>/.tmp/` と `current`、空になった `<prefix>` 自体）も
+片付ける。撤去対象に含まれないツールの symlink がまだ配布実体を参照している場合は片付けを
+行わず安全側に倒す。dev モード中（`current` が人間の作業ツリーを指している）でも
+`generations/` `.tmp/` と `current` 自体は通常どおり片付けられる。保護されるのは
+**`current` が指す作業ツリーの実体だけ**であり、そちらには一切触れない。
 
 ## クロスプラットフォーム制約
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ sudo apt update && sudo apt install $(cat apt-packages.txt)
 ./deploy-all.sh --only zsh,nvim          # Deploy specific tools (comma-separated)
 ./deploy-all.sh --backup                 # Back up existing config files (default)
 ./deploy-all.sh --no-backup              # Overwrite without backing up
+./deploy-all.sh --status                 # Show what's currently deployed (read-only)
+./deploy-all.sh --rollback [id]          # Switch current back to the previous (or given) generation
+./deploy-all.sh --dev                    # Point current at this working tree (live-edit mode)
 ```
 
 Options can be combined:
@@ -64,6 +67,13 @@ Options can be combined:
 ./deploy-all.sh --dry-run --only tmux
 ./deploy-all.sh --force --only zsh,nvim --no-backup
 ```
+
+`--status` / `--rollback` / `--dev` operate on the `current` symlink itself (see
+[docs/adr/DOC-2608040229_deploy-distribution-method.md](docs/adr/DOC-2608040229_deploy-distribution-method.md))
+and cannot be combined with each other or with `--only` / `--force` / `--backup` —
+`--dry-run` is the only modifier they accept. `--status` has no side effects and is
+safe to run against your real `$HOME`; `--rollback` and `--dev` actually repoint
+`current`, so preview them with `--dry-run` first.
 
 ## Development Setup
 
@@ -148,37 +158,60 @@ for details. `bin/` changes should additionally be verified with
     └── README.md
 ```
 
-## Deploying from a git worktree
+## How deployment works
 
-Deploy scripts symlink files **from this checkout** into `$HOME`. If you deploy
-from a linked git worktree (created by `git worktree add`, or by `ocw`), those
-symlinks point into that worktree — and they break silently the moment the
-worktree is removed (`ocw rm`, `git worktree remove`). `~/.zshrc`,
-`~/.claude/skills/*` and `~/bin/*` all stop working, long after the deploy
-reported success.
+`$HOME` never links directly into this checkout. `./deploy-all.sh` copies the tool
+directories into a dated **generation** directory under
+`${XDG_DATA_HOME:-$HOME/.local/share}/dotfiles/generations/`, points a `current`
+symlink at it, and every tool's `deploy.sh` links `$HOME` through `current` — never
+through the generation directory directly. Re-running deploy creates a new
+generation and swaps `current` over; the last few generations are kept (default 3,
+override with `DOTFILES_KEEP_GENERATIONS`) so a broken deploy can be undone with
+`--rollback` instead of git surgery. Editing this checkout after a deploy has no
+effect on `$HOME` unless you're in dev mode (see below) — `$HOME` reads from the
+generation snapshot, not the live working tree.
 
-The deploy scripts warn when this happens:
+See
+[docs/adr/DOC-2608040229_deploy-distribution-method.md](docs/adr/DOC-2608040229_deploy-distribution-method.md)
+for the full rationale, and
+[docs/reference/DOC-2608040805_配布実体運用ガイド.md](docs/reference/DOC-2608040805_配布実体運用ガイド.md)
+for day-to-day operations (inspecting what's deployed, rolling back, entering/leaving
+dev mode, recovering a broken symlink, migrating an older machine).
 
-```
-[WARN] Deploying from a linked git worktree:
-[WARN]   /path/to/dotfiles/my-feature
-[WARN] Symlinks will point INTO this worktree and will break when it is
-[WARN] removed (e.g. by 'ocw rm').
-[WARN] After merging, re-run the deploy from the main worktree:
-[WARN]   cd /path/to/dotfiles/master && ./deploy-all.sh
-```
+## Working on this checkout: dev mode and worktrees
 
-Deploying from a worktree is fine while testing a change. Just **re-run the
-deploy from the main worktree once the change is merged**, before removing the
-worktree. Set `DOTFILES_QUIET_WORKTREE_WARNING=1` to silence the warning.
-
-If symlinks are already broken, list the dangling ones with:
+Because `$HOME` normally reads from a copied generation, edits to this checkout
+(including in a linked `git worktree` created by `git worktree add` or `ocw`) do
+**not** reach `$HOME` until you re-deploy. If you want live-edit behavior instead —
+useful while iterating on a config change — use dev mode:
 
 ```bash
-find ~ ~/.config ~/.claude ~/.claude/skills ~/bin -maxdepth 1 -type l ! -exec test -e {} \; -print
+./deploy-all.sh --dev
 ```
 
-then re-run `./deploy-all.sh` from the main worktree.
+This points `current` directly at this working tree (no generation is created), so
+edits take effect immediately, matching how earlier versions of this repo always
+behaved. The tradeoff dev mode brings back: if `current` points at a **linked**
+worktree and that worktree is removed (`ocw rm`, `git worktree remove`), every
+`$HOME` symlink breaks the moment it disappears. `--dev` warns when this applies:
+
+```
+[WARN] This working tree is a linked git worktree:
+[WARN]   /path/to/dotfiles/my-feature
+[WARN] Dev mode makes $HOME resolve directly into it via current. Removing this
+[WARN] worktree (e.g. 'ocw rm') will break every $HOME symlink until you switch
+[WARN] back to generation mode.
+```
+
+Re-run `./deploy-all.sh` (without `--dev`) to leave dev mode and go back to the
+default, safer generation mode — this also fixes any symlinks a removed dev-mode
+worktree left broken. Set `DOTFILES_QUIET_WORKTREE_WARNING=1` to silence the
+warning. To check what's currently deployed (generation vs. dev mode, and whether
+any `$HOME` symlink is broken) without side effects:
+
+```bash
+./deploy-all.sh --status
+```
 
 ## Uninstalling
 
@@ -189,7 +222,12 @@ then re-run `./deploy-all.sh` from the main worktree.
 ./uninstall.sh --only tmux   # Uninstall a specific tool
 ```
 
-The uninstall script removes **known symlinks** and restores backed-up config files (`*.backup`).
+The uninstall script removes **known symlinks**, restores backed-up config files
+(`*.backup`), and — once no remaining tool still references it — cleans up the
+distribution artifacts themselves (the `generations/` directory and the `current`
+symlink under the canonical prefix). If `current` is in dev mode (pointing at a
+working tree), only the `current` symlink is removed; the working tree itself is
+never touched.
 Note: `--only nvim` currently removes legacy dein.vim symlinks; lazy.nvim symlinks (`init.lua`, `lua/`, `lazy-lock.json`) are not yet tracked.
 See each tool's deploy script for the full list of files it creates.
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Options can be combined:
 
 `--status` / `--rollback` / `--dev` operate on the `current` symlink itself (see
 [docs/adr/DOC-2608040229_deploy-distribution-method.md](docs/adr/DOC-2608040229_deploy-distribution-method.md))
-and cannot be combined with each other or with `--only` / `--force` / `--backup` —
+and cannot be combined with each other or with `--only` / `--force` / `--backup` / `--no-backup` —
 `--dry-run` is the only modifier they accept. `--status` has no side effects and is
 safe to run against your real `$HOME`; `--rollback` and `--dev` actually repoint
 `current`, so preview them with `--dry-run` first.
@@ -203,6 +203,22 @@ worktree and that worktree is removed (`ocw rm`, `git worktree remove`), every
 [WARN] back to generation mode.
 ```
 
+A related but separate warning can show up during an ordinary (non-`--dev`) deploy
+too: running `./deploy-all.sh` itself from a linked worktree still prints the
+"Deploying from a linked git worktree" warning below, left over from the pre-generation
+direct-link scheme. In generation mode this warning is misleading — the
+generation this deploy creates is a `cp -a` snapshot, so `$HOME` symlinks resolve
+through it rather than through the worktree, and removing the worktree afterward
+does **not** break them. Only dev mode actually makes the worktree's removal
+break `$HOME` symlinks, as described above.
+
+```
+[WARN] Deploying from a linked git worktree:
+[WARN]   /path/to/dotfiles/my-feature
+[WARN] Symlinks will point INTO this worktree and will break when it is
+[WARN] removed (e.g. by 'ocw rm').
+```
+
 Re-run `./deploy-all.sh` (without `--dev`) to leave dev mode and go back to the
 default, safer generation mode — this also fixes any symlinks a removed dev-mode
 worktree left broken. Set `DOTFILES_QUIET_WORKTREE_WARNING=1` to silence the
@@ -224,10 +240,11 @@ any `$HOME` symlink is broken) without side effects:
 
 The uninstall script removes **known symlinks**, restores backed-up config files
 (`*.backup`), and — once no remaining tool still references it — cleans up the
-distribution artifacts themselves (the `generations/` directory and the `current`
-symlink under the canonical prefix). If `current` is in dev mode (pointing at a
-working tree), only the `current` symlink is removed; the working tree itself is
-never touched.
+distribution artifacts themselves (the `generations/` directory, the scratch `.tmp/`
+directory, the `current` symlink, and the canonical prefix itself once empty). If
+`current` is in dev mode (pointing at a working tree), `generations/` / `.tmp/` /
+`current` are still cleaned up as usual; only the working tree `current` points at
+is protected and never touched.
 Note: `--only nvim` currently removes legacy dein.vim symlinks; lazy.nvim symlinks (`init.lua`, `lua/`, `lazy-lock.json`) are not yet tracked.
 See each tool's deploy script for the full list of files it creates.
 

--- a/bin/README.md
+++ b/bin/README.md
@@ -23,10 +23,15 @@
 
 ## 2. Quick Start
 
+新規マシンでは単体の `bin/deploy.sh` ではなく、リポジトリルートの `deploy-all.sh` を実行してください。
+`$HOME` 側のリンクは `${XDG_DATA_HOME:-$HOME/.local/share}/dotfiles/` 配下の配布実体を経由しており、
+これを作るのは `deploy-all.sh` だけです。`current` がまだ無い状態で `bin/deploy.sh` を単体実行すると、
+エラーで終了し `./deploy-all.sh` の実行を案内されます。
+
 ```bash
-# 1. Run deploy script
-cd ~/.dotfiles/bin
-./deploy.sh
+# 1. リポジトリルートから実行
+cd ~/.dotfiles
+./deploy-all.sh --only bin
 
 # 2. Restart your shell (or source ~/.zshrc) so ~/bin is on PATH
 exec $SHELL -l
@@ -35,6 +40,9 @@ exec $SHELL -l
 which ocw
 which claude-ds
 ```
+
+すでに一度 `deploy-all.sh` を実行済みで配布実体（`current`）が存在するなら、
+`bin/` ディレクトリから単体の `./deploy.sh` を実行しても構いません。
 
 > **Note**: `~/bin` の PATH 追加は `zsh/.zshrc` が担っています。bash 等他のシェルを使う場合は、各自で `~/bin` を PATH に通してください。
 
@@ -276,8 +284,9 @@ PR番号はリポジトリ**内**でしか一意でない。`--pr`とstandalone�
 - `OCW_METER_RAW=1`のときのみ、redaction済みのstatusLine生JSONを`raw/YYYY-MM-DD/`へ保存し、
   イベントの`raw_ref`にそのパスを記録する（既定では一切保存しない）
 - **事前準備（必須）**: `ocw-meter` が PATH に無い環境では statusLine コマンド自体が
-  `command not found` になり表示が壊れる。必ず先に `bin/deploy.sh` を実行して
-  `~/bin/ocw-meter` を配置し、`~/bin` が PATH に入っていることを確認すること（本ドキュメント §5 参照）
+  `command not found` になり表示が壊れる。必ず先に `./deploy-all.sh --only bin`
+  （リポジトリルートから）を実行して `~/bin/ocw-meter` を配置し、`~/bin` が PATH に
+  入っていることを確認すること（本ドキュメント §5 参照）
 
 **保存先と環境変数:**
 

--- a/claude/README.md
+++ b/claude/README.md
@@ -52,7 +52,11 @@ Claude Code がセッション開始時に読み込むグローバルな個人�
 現在の設定:
 - 脳筋後輩キャラクターでの応答スタイル指定（語尾・一人称・二人称）
 
-CLAUDE.md は個人設定のため、このファイルを直接編集することで即座に反映される。
+`~/.claude/CLAUDE.md` を直接編集すればその場ですぐに反映されるが、これは配布実体（世代
+ディレクトリ）内のコピーを直接編集しているだけで、リポジトリの作業ツリー側
+（`claude/CLAUDE.md`）には反映されない。恒久的に変更したい場合はリポジトリ側を編集して
+再デプロイするか、編集のたびに即時反映させたいなら dev モード（`./deploy-all.sh --dev`）を
+使うこと。詳細は §4.8 を参照。
 
 ### 3.2 settings.json
 
@@ -312,16 +316,29 @@ cd ~/.dotfiles/claude
 
 Claude Code は起動時に設定を読み込むため、設定変更後は Claude Code を再起動してください。
 
-### 4.8 CLAUDE.md の直接編集
+### 4.8 CLAUDE.md の編集
 
-CLAUDE.md は個人設定のため、symlink 先を直接編集して問題ありません。リポジトリ側のファイルに即反映されます。
+既定（世代モード）では、`~/.claude/CLAUDE.md` は配布実体（世代ディレクトリ）内のコピーへの
+symlink であり、**リポジトリの作業ツリーを直接指してはいない**（旧方式（作業ツリー直リンク）
+とは異なる点に注意）。
+
+- `~/.claude/CLAUDE.md` を直接編集すると即座に反映されるが、リポジトリ側には反映されず、
+  次回 `./deploy.sh`（または `./deploy-all.sh`）実行時に上書きされる
+- リポジトリ側の `claude/CLAUDE.md` を編集しても、再デプロイするまで `~/.claude/CLAUDE.md`
+  には反映されない
+- 編集のたびに即時反映させたい場合は dev モード（`./deploy-all.sh --dev`）を使う。この場合
+  `current` が作業ツリーそのものを指すため、リポジトリ側の編集がそのまま
+  `~/.claude/CLAUDE.md` に反映される（世代方式の詳細はルート `AGENTS.md`
+  「デプロイの仕組み」・ADR DOC-2608040229 を参照）
 
 ```bash
-# 直接編集
-vim ~/.claude/CLAUDE.md
-
-# またはリポジトリ側を編集（同じファイル）
+# 恒久的に変更する場合（世代モード）
 vim ~/.dotfiles/claude/CLAUDE.md
+./deploy.sh   # または ./deploy-all.sh
+
+# 試行錯誤したい場合（dev モード）
+./deploy-all.sh --dev
+vim ~/.dotfiles/claude/CLAUDE.md   # 即座に ~/.claude/CLAUDE.md に反映される
 ```
 
 ## 5. Troubleshooting

--- a/claude/README.md
+++ b/claude/README.md
@@ -23,7 +23,7 @@ Claude Code の設定ファイル群。`~/.claude/` にデプロイして使う�
 初回（新規マシン、まだ何もデプロイしていない状態）は、単体の `claude/deploy.sh` ではなく
 必ずリポジトリルートの `deploy-all.sh` を実行してください。単体実行は配布実体
 （`current`）経由でしか読まないため、`current` がまだ無い新規マシンではエラーで終了します
-（詳細は「デプロイの仕組み」節。ルート `AGENTS.md` にも同じ規約があります）。
+（詳細はルート `AGENTS.md`「デプロイの仕組み」節を参照）。
 
 ```bash
 # 1. リポジトリルートから実行（初回は必ずこちら）
@@ -233,7 +233,7 @@ vim settings.machine.json
 # デプロイ実行(ベース + machine をマージして ~/.claude/settings.json を生成)
 # 単体の ./deploy.sh ではなく、リポジトリルートから ./deploy-all.sh を実行すること。
 # 単体実行は配布実体(current)経由でしか settings.machine.json を読まないため、
-# 作業ツリー側で今編集した内容を拾わない(「デプロイの仕組み」節参照)。
+# 作業ツリー側で今編集した内容を拾わない(ルート AGENTS.md「デプロイの仕組み」節参照)。
 cd ~/.dotfiles
 ./deploy-all.sh --only claude
 ```

--- a/claude/README.md
+++ b/claude/README.md
@@ -20,16 +20,25 @@ Claude Code の設定ファイル群。`~/.claude/` にデプロイして使う�
 
 ## 2. Quick Start
 
+初回（新規マシン、まだ何もデプロイしていない状態）は、単体の `claude/deploy.sh` ではなく
+必ずリポジトリルートの `deploy-all.sh` を実行してください。単体実行は配布実体
+（`current`）経由でしか読まないため、`current` がまだ無い新規マシンではエラーで終了します
+（詳細は「デプロイの仕組み」節。ルート `AGENTS.md` にも同じ規約があります）。
+
 ```bash
-# 1. Run deploy script
-cd ~/.dotfiles/claude
-./deploy.sh
+# 1. リポジトリルートから実行（初回は必ずこちら）
+cd ~/.dotfiles
+./deploy-all.sh --only claude
 
 # 2. Verify
-ls -la ~/.claude/CLAUDE.md         # symlink
+ls -la ~/.claude/CLAUDE.md         # symlink（current 経由）
 ls -la ~/.claude/settings.json     # 実ファイル（deploy.sh が生成）
 ls -la ~/.claude/skills/           # 各スキルが symlink（herdr など独自スキルは残る）
 ```
+
+すでに一度 `deploy-all.sh` を実行済みで `current` が存在する状態であれば、
+`claude/` ディレクトリから単体の `./deploy.sh` を実行しても構いません（配布実体を
+作り直さず、既存の `current` を読み直すだけです）。
 
 The deploy script:
 - Creates `~/.claude/` directory with mode `700`（認証情報を置く可能性があるため）
@@ -130,7 +139,7 @@ EOF
 # リポジトリ側に新しいスキルを追加
 mkdir -p claude/skills/new-skill
 # ... SKILL.md を作成 ...
-./deploy.sh  # 自動検出されて symlink が作られる
+cd ~/.dotfiles && ./deploy-all.sh --only claude  # 自動検出されて symlink が作られる
 ```
 
 ### 3.4 statusLine — Claude 利用枠スナップショット
@@ -152,9 +161,9 @@ Claude Code のステータスバーに 5時間枠 / 週間枠 / コンテキス
 （推定値からのフォールバック計算は記録用イベントにのみ使い、表示には使わない）。
 
 **事前準備（必須）**: `ocw-meter` が PATH に無い環境では statusLine コマンド自体が
-`command not found` になり、表示が壊れる。必ず先に `bin/deploy.sh` を実行して
-`~/bin/ocw-meter` を配置し、`~/bin` が PATH に入っていることを確認すること
-（`~/bin` の PATH 追加は `zsh/.zshrc` 依存。`bin/README.md` §5 参照）。
+`command not found` になり、表示が壊れる。必ず先に `./deploy-all.sh --only bin`
+（リポジトリルートから）を実行して `~/bin/ocw-meter` を配置し、`~/bin` が PATH に
+入っていることを確認すること（`~/bin` の PATH 追加は `zsh/.zshrc` 依存。`bin/README.md` §5 参照）。
 
 **観測は既存フローに一切割り込まない。** `snapshot-quota` は例外が起きても必ず表示文字列を
 stdout に返し exit 0 する（statusLine が壊れて画面が崩れる事態を避けるための最優先事項）。
@@ -187,7 +196,9 @@ statusLine が描画のたびに呼ばれても書き込みが肥大しない。
    ```
 2. `claude/settings.machine.json`（無ければ `settings.machine.json.example` からコピー）に、
    確認した `hooks`（通常は Herdr の `herdr-agent-state.sh`）を明記する（§4.3参照）
-3. `./deploy.sh` を実行する
+3. `./deploy-all.sh --only claude`（リポジトリルートから）を実行する。**単体の
+   `claude/deploy.sh` では不可**（配布実体経由でしか読まないため、今編集した
+   `settings.machine.json` の内容を拾わない）
 4. deploy 後、再度 手順1 のコマンドを実行し、`hooks.SessionStart` が健在であることを確認する
 
 **statusLine の無効化方法:**
@@ -195,7 +206,7 @@ statusLine が描画のたびに呼ばれても書き込みが肥大しない。
 `claude/settings.machine.json` に `"statusLine": null` は効かない（machine側の shallow merge は
 `null` も値として上書きしてしまうだけで、キー自体を消せない）。無効化したい場合は
 `~/.claude/settings.json` の `statusLine` キーを deploy 後に手動で削除する
-（**次回 `./deploy.sh` 実行時に `claude/settings.json` の内容で再度上書きされる**ので、
+（**次回 `./deploy-all.sh` 実行時に `claude/settings.json` の内容で再度上書きされる**ので、
 恒久的に無効化したい場合はリポジトリ側の `claude/settings.json` から `statusLine` を削除すること）。
 
 ## 4. Customization — マシン固有設定の追加
@@ -219,8 +230,12 @@ cp settings.machine.json.example settings.machine.json
 # 自分の環境に合わせて編集
 vim settings.machine.json
 
-# デプロイ実行（ベース + machine をマージして ~/.claude/settings.json を生成）
-./deploy.sh
+# デプロイ実行(ベース + machine をマージして ~/.claude/settings.json を生成)
+# 単体の ./deploy.sh ではなく、リポジトリルートから ./deploy-all.sh を実行すること。
+# 単体実行は配布実体(current)経由でしか settings.machine.json を読まないため、
+# 作業ツリー側で今編集した内容を拾わない(「デプロイの仕組み」節参照)。
+cd ~/.dotfiles
+./deploy-all.sh --only claude
 ```
 
 `settings.machine.json` は `.gitignore` で除外されているため、commit されません。
@@ -307,11 +322,13 @@ vim settings.machine.json
 
 ### 4.7 設定の反映確認
 
-`settings.machine.json` を編集した後は、再デプロイで反映されます:
+`settings.machine.json` を編集した後は、再デプロイで反映されます。**単体の `claude/deploy.sh`
+ではなく `./deploy-all.sh` を使うこと**（単体実行は配布実体経由でしか読まないため、
+作業ツリー側の編集を拾わない）:
 
 ```bash
-cd ~/.dotfiles/claude
-./deploy.sh
+cd ~/.dotfiles
+./deploy-all.sh --only claude
 ```
 
 Claude Code は起動時に設定を読み込むため、設定変更後は Claude Code を再起動してください。
@@ -323,9 +340,10 @@ symlink であり、**リポジトリの作業ツリーを直接指してはい�
 とは異なる点に注意）。
 
 - `~/.claude/CLAUDE.md` を直接編集すると即座に反映されるが、リポジトリ側には反映されず、
-  次回 `./deploy.sh`（または `./deploy-all.sh`）実行時に上書きされる
-- リポジトリ側の `claude/CLAUDE.md` を編集しても、再デプロイするまで `~/.claude/CLAUDE.md`
-  には反映されない
+  次回 `./deploy-all.sh` 実行時に上書きされる
+- リポジトリ側の `claude/CLAUDE.md` を編集しても、`./deploy-all.sh` を再実行するまで
+  `~/.claude/CLAUDE.md` には反映されない。**単体の `claude/deploy.sh` を実行しても
+  反映されない**（配布実体経由でしか読まないため。新しい世代を作るのは `deploy-all.sh` だけ）
 - 編集のたびに即時反映させたい場合は dev モード（`./deploy-all.sh --dev`）を使う。この場合
   `current` が作業ツリーそのものを指すため、リポジトリ側の編集がそのまま
   `~/.claude/CLAUDE.md` に反映される（世代方式の詳細はルート `AGENTS.md`
@@ -334,7 +352,7 @@ symlink であり、**リポジトリの作業ツリーを直接指してはい�
 ```bash
 # 恒久的に変更する場合（世代モード）
 vim ~/.dotfiles/claude/CLAUDE.md
-./deploy.sh   # または ./deploy-all.sh
+cd ~/.dotfiles && ./deploy-all.sh --only claude
 
 # 試行錯誤したい場合（dev モード）
 ./deploy-all.sh --dev
@@ -347,20 +365,23 @@ vim ~/.dotfiles/claude/CLAUDE.md   # 即座に ~/.claude/CLAUDE.md に反映さ�
 
 Claude Code は起動時に設定を読み込みます。
 
-- **マシン固有の設定を追加・変更する** → `claude/settings.machine.json` を編集して再デプロイ:
+- **マシン固有の設定を追加・変更する** → `claude/settings.machine.json` を編集して再デプロイ
+  （単体の `claude/deploy.sh` ではなく `./deploy-all.sh` を使うこと。単体実行は配布実体
+  経由でしか読まないため、今編集した内容を拾わない）:
   ```bash
-  cd ~/.dotfiles/claude && ./deploy.sh
+  cd ~/.dotfiles && ./deploy-all.sh --only claude
   ```
 - **`~/.claude/settings.json` を何らかの理由で直接編集した** → Claude Code を再起動。
-  ただし次回 `deploy.sh` 実行時に上書きされるため、恒久的な変更は `settings.machine.json` に転記してください。
+  ただし次回 `./deploy-all.sh` 実行時に上書きされるため、恒久的な変更は `settings.machine.json` に転記してください。
 
 ### `settings.machine.json` の変更が反映されない
 
-`settings.machine.json` を編集した後は、**必ず再デプロイ**してください。
-deploy.sh がその時点の `settings.machine.json` を読み取って `~/.claude/settings.json` を再生成します。
+`settings.machine.json` を編集した後は、**必ず `./deploy-all.sh` で再デプロイ**してください。
+単体の `claude/deploy.sh` では配布実体（`current`）経由でしか読まないため、
+今編集した `settings.machine.json` の内容を拾いません。
 
 ```bash
-cd ~/.dotfiles/claude && ./deploy.sh
+cd ~/.dotfiles && ./deploy-all.sh --only claude
 ```
 
 ### デプロイで既存設定が消えた
@@ -398,10 +419,12 @@ python3 -m json.tool claude/settings.machine.json
 ### symlink が壊れている
 
 ```bash
+cd ~/.dotfiles
+
 # 確認
 ls -la ~/.claude/CLAUDE.md
+./deploy-all.sh --status   # current の向き先・リンク切れの有無も確認できる
 
 # 修復
-cd ~/.dotfiles/claude
-./deploy.sh
+./deploy-all.sh --only claude
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@
 | シェルを書く前に読む | [design/DOC-2608020715-a_シェルスクリプトコーディング方針.md](design/DOC-2608020715-a_シェルスクリプトコーディング方針.md) | POSIX sh / bash の使い分け、bashism の回避 |
 | デプロイを検証する | [design/DOC-2608020715-b_テスト方針.md](design/DOC-2608020715-b_テスト方針.md) | 実 HOME を汚さずに検証する4層の方法 |
 | なぜ配布方式を今の形にしたかを知る | [adr/DOC-2608040229_deploy-distribution-method.md](adr/DOC-2608040229_deploy-distribution-method.md) | 世代ディレクトリ + `current` を採用した理由と、却下した案 |
+| デプロイの運用手順（世代確認・ロールバック・dev モード等）を調べる | [reference/DOC-2608040805_配布実体運用ガイド.md](reference/DOC-2608040805_配布実体運用ガイド.md) | canonical prefix の構造・manifest 全フィールド・移行手順 |
 | なぜ `ocw-meter` をこの設計にしたかを知る | [adr/DOC-2608021229_llm-cost-observability-collection-method.md](adr/DOC-2608021229_llm-cost-observability-collection-method.md) | feasibility probe の実測結果に基づく収集方式の決定記録 |
 | `ocw-meter` のイベントスキーマを調べる | [reference/DOC-2608021229-c_ocw-meterイベントスキーマ.md](reference/DOC-2608021229-c_ocw-meterイベントスキーマ.md) | 全 event_type・全フィールド・費用計算式の一次情報源 |
 | LLM費用のベースラインを測る手順を知る | [reference/DOC-2608021229-b_LLM費用観測ベースライン計測手順.md](reference/DOC-2608021229-b_LLM費用観測ベースライン計測手順.md) | 実PR 5〜10本での計測手順 |
@@ -74,6 +75,7 @@
 |---|---|---|
 | DOC-2608021229-b | [LLM費用観測ベースライン計測手順.md](reference/DOC-2608021229-b_LLM費用観測ベースライン計測手順.md) | `ocw-meter` 導入後、実PR 5〜10本でLLM費用・Claude利用枠のベースラインを計測する手順書（旧ID: `DOC-004`） |
 | DOC-2608021229-c | [ocw-meterイベントスキーマ.md](reference/DOC-2608021229-c_ocw-meterイベントスキーマ.md) | `ocw-meter` が書く全イベント型の恒久リファレンス。共通エンベロープの全フィールド、全 `event_type`、`idempotency_key` の生成規則、費用計算式、`completeness` の判定基準を実データで検証した上でまとめたもの（旧ID: `DOC-005`） |
+| DOC-2608040805 | [配布実体運用ガイド.md](reference/DOC-2608040805_配布実体運用ガイド.md) | 世代ディレクトリ + `current` 配布方式の日常運用手順。canonical prefix のディレクトリ構造・manifest の全フィールド・世代確認・ロールバック・dev モードの出入り・リンク切れ対処・旧方式からの移行手順 |
 
 ## 新規ファイル追加時のルール
 

--- a/docs/design/DOC-2608020715-b_テスト方針.md
+++ b/docs/design/DOC-2608020715-b_テスト方針.md
@@ -4,20 +4,35 @@
 
 ## 前提となる事実
 
+- `$HOME` はリポジトリの作業ツリーへ直接リンクしない。`deploy-all.sh` は作業ツリーを
+  `${XDG_DATA_HOME:-$HOME/.local/share}/dotfiles/generations/<世代ID>` へコピーし、
+  `current` シンボリックリンクをそこへ向け、各 `<tool>/deploy.sh` は `current` 経由で
+  `$HOME` からリンクする（世代ディレクトリ + `current` 方式。ADR DOC-2608040229 参照）。
+  この配布実体（`generations/` と `current`）は canonical prefix 配下、すなわち
+  **`XDG_DATA_HOME` に依存する**ため、以前は nvim 固有の関心事だった `XDG_DATA_HOME` の
+  サンドボックス差し替えが、**今はサンドボックス対象の全ツール（`bin` `claude` を含む）に
+  共通の前提**になっている。差し替えを怠ると、サンドボックス実行のつもりが実 `$HOME` の
+  `~/.local/share/dotfiles/` を書き換えてしまう
 - すべての deploy スクリプト（`deploy-all.sh` `uninstall.sh` `*/deploy.sh`）は `$HOME` 環境変数を
   参照しており、`~` のハードコードは無い。**ただし `HOME` の差し替えだけでは実 `$HOME` を汚さない
   保証にはならない。** 以下のツールは `$HOME` 以外の環境変数を優先参照するため、これらも一時ディレクトリ
   配下へ差し替えるか unset した状態でサンドボックスを構築する必要がある。
-  - `nvim/deploy.sh`: `XDG_CONFIG_HOME`（既定 `$HOME/.config`）/ `XDG_DATA_HOME`（既定 `$HOME/.local/share`）
-    / `XDG_CACHE_HOME`（既定 `$HOME/.cache`）
+  - 全ツール共通: `XDG_DATA_HOME`（既定 `$HOME/.local/share`）。配布実体（`generations/` /
+    `current`）の置き場所を決める canonical prefix の算出に使われる（`shared/helpers.sh` の
+    `dotfiles_prefix`）
+  - `nvim/deploy.sh`: 上記に加えて `XDG_CONFIG_HOME`（既定 `$HOME/.config`）/
+    `XDG_CACHE_HOME`（既定 `$HOME/.cache`）
   - `zsh/deploy.sh`: `ANTIDOTE_HOME`（既定 `$HOME/.antidote`）。既存インストールがある場合
     `rm -rf "$ANTIDOTE_HOME"` を実行することがあるため、実環境で `ANTIDOTE_HOME` が export
     されていると読み取りだけでは済まない実害が起きる
 - 副作用の性質はツールごとに異なる。サンドボックス実行の対象を決める際は、**ネットワークの要否**と
-  **副作用が `$HOME` 配下に閉じるか**の2軸で分類する。
-  - `bin/deploy.sh`: 純粋な symlink のみ。ネットワーク不要、副作用は `$HOME` 配下に閉じる
+  **副作用が `$HOME` 配下に閉じるか**の2軸で分類する。この分類は配布方式が世代ディレクトリ +
+  `current` 方式になった後も変わらない（配布実体の置き場所も `XDG_DATA_HOME` 経由で
+  `$HOME` 配下に閉じており、新たにネットワークやシステムパッケージへの依存を持ち込んでいないため）。
+  - `bin/deploy.sh`: 純粋な symlink のみ（`current` 経由）。ネットワーク不要、副作用は `$HOME`
+    配下に閉じる
   - `claude/deploy.sh`: symlink ではなく設定ファイルをマージして実ファイルとして生成する。
-    `claude/skills/` は個別に symlink を張り、バックアップ先も他ツールと異なる
+    `claude/skills/` は個別に symlink（`current` 経由）を張り、バックアップ先も他ツールと異なる
     （`~/.claude/skills-backup/<名前>.<日時>.<PID>`）。ネットワーク不要、副作用は `$HOME` 配下に閉じる
   - `tmux/deploy.sh`: symlink を張るだけでなく、**tmux が未インストールの場合は
     `sudo apt-get install`（Linux）や `brew install`（macOS）を実行してシステムにパッケージを
@@ -32,7 +47,7 @@
 |---|---|---|---|
 | 構文検査 | `sh -n` / `bash -n` | 全シェルスクリプト | 毎コミット |
 | ドライラン | `./deploy-all.sh --dry-run` | 全ツール | 毎コミット |
-| サンドボックス実行 | `HOME`（および該当する場合は `XDG_CONFIG_HOME` / `XDG_DATA_HOME` / `XDG_CACHE_HOME` / `ANTIDOTE_HOME`）を一時ディレクトリに差し替えて実際に deploy | 副作用が `$HOME` 配下に閉じるツール（`bin` `claude`） | ローカル（CI導入後は CI でも実行） |
+| サンドボックス実行 | `HOME` と `XDG_DATA_HOME`（配布実体の置き場所。全ツール共通）に加えて、該当する場合は `XDG_CONFIG_HOME` / `XDG_CACHE_HOME` / `ANTIDOTE_HOME` を一時ディレクトリに差し替えて実際に deploy | 副作用が `$HOME` 配下に閉じるツール（`bin` `claude`） | ローカル（CI導入後は CI でも実行） |
 | 実マシン検証 | 実 `$HOME` に対する `--dry-run` → 人間の確認 → 人間による実行 | 全ツール（特に `tmux` のパッケージインストール、`zsh` `nvim` のネットワーク処理） | リリース前に人間が行う |
 
 構文検査とドライランはコストが低く副作用も無いため毎コミットで行う。`shellcheck` / `shfmt` および CI
@@ -61,6 +76,32 @@
 - [ ] 同じ内容で2回実行しても壊れないか（冪等性。2回目は「既にリンク済み」として扱われるか）
 - [ ] `./uninstall.sh --force` を実行すると symlink が削除され、`.backup` があれば元のファイルに戻るか
 - [ ] `claude/settings.json` が symlink ではなく実ファイルとして生成されているか
+- [ ] **ソースツリー消失耐性**: サンドボックス内に作業ツリーのコピーを作りそこから deploy した後、
+      そのコピーを削除しても `$HOME` 側の配布物が読めるか（世代ディレクトリへの `cp -a` コピーが
+      作業ツリーから独立していることの回帰テスト）
+- [ ] **編集分離**: deploy 後に作業ツリー側のファイルを書き換えても、`$HOME` 側から読める内容が
+      変わらないか（世代モードでは `$HOME` は世代ディレクトリのスナップショットを読んでおり、
+      作業ツリーの編集途中の状態が即座に本番へ反映されないことの回帰テスト）
+- [ ] **世代と GC**: 再デプロイで世代ディレクトリが増え、`current` が新世代を指すか。保持数
+      （既定3、`DOTFILES_KEEP_GENERATIONS` で上書き可）を超えた古い世代が削除され、`current` が
+      指す世代は削除されないか
+- [ ] **`--only` は世代の内容に影響しない**: `--only <tool>` で deploy しても、世代ディレクトリには
+      全ツール分がコピーされているか
+- [ ] **ロールバック**（`--rollback`）: 内容の異なる世代を複数作ったあと、`current` が前の世代へ
+      戻り、`$HOME` 側のリンクを張り直さずに読める内容が前の世代のものへ戻るか
+- [ ] **dev モード**（`--dev`）: `current` が作業ツリーを直接指すか。作業ツリー側のファイルを
+      書き換えると `$HOME` 側から読める内容が即座に変わるか。dev モード中は世代の GC が
+      走らないか
+- [ ] **`--status`**: `current` の向き先・manifest の内容（コミット SHA・ブランチ等）・保持世代
+      一覧が出力に含まれるか。リンク切れを意図的に作った状態で検出されるか
+- [ ] **旧方式（作業ツリー直リンク）からの移行**: 旧方式の symlink が張られた状態で deploy すると、
+      新方式（`current` 経由）へ張り替わり、旧方式のリンクが `.backup` として残らないか
+- [ ] **uninstall による配布実体の後片付け**: `uninstall.sh` 実行後に、canonical prefix の
+      `generations/` と `current` が片付くか（撤去対象に含まれないツールがまだ配布実体を
+      参照している場合は片付けが行われないか）
+- [ ] **uninstall の dev モード保護**: `current` が作業ツリーを指している状態（dev モード）で
+      `uninstall.sh` を実行しても、作業ツリー自体が削除されず、`current` というシンボリック
+      リンクだけが取り除かれるか
 
 この文書は「何をどう検証するか」を定義するところまでとし、検証を自動化するスクリプトの実装は別のタスクの
 担当とします。

--- a/docs/reference/DOC-2608021229-b_LLM費用観測ベースライン計測手順.md
+++ b/docs/reference/DOC-2608021229-b_LLM費用観測ベースライン計測手順.md
@@ -18,8 +18,8 @@
 
 - 孫1〜5（`bin/ocw-meter`本体・工程イベント埋め込み・DeepSeek ingest・Claude quota・本レポート機能）が
   すべて`master`にマージ済みであること
-- `bin/deploy.sh`を実行し、`~/bin/ocw-meter`が配置され、`~/bin`がPATHに入っていること
-  （確認: `which ocw-meter`）
+- `./deploy-all.sh --only bin`（リポジトリルートから）を実行し、`~/bin/ocw-meter`が配置され、
+  `~/bin`がPATHに入っていること（確認: `which ocw-meter`）
 - `claude/settings.json`の`statusLine`が`ocw-meter snapshot-quota`を指していること
   （確認: `claude/README.md` §3.4、または`cat ~/.claude/settings.json | grep statusLine`）
 - **計測期間中、フロー・規約・モデル構成を一切変更しない。** 具体的には:

--- a/docs/reference/DOC-2608040805_配布実体運用ガイド.md
+++ b/docs/reference/DOC-2608040805_配布実体運用ガイド.md
@@ -21,8 +21,11 @@ ${XDG_DATA_HOME:-$HOME/.local/share}/dotfiles/
     (dev モード中は作業ツリーそのものへのシンボリックリンクになる)
 ```
 
-- `current` は `$HOME` 側の全 symlink が経由する唯一の間接参照点です。世代ディレクトリを
-  直接指す `$HOME` 側 symlink はありません
+- `current` は `$HOME` 側の全 symlink が経由する唯一の間接参照点です。`deploy-all.sh` および
+  単体 `<tool>/deploy.sh` の通常経路では、世代ディレクトリを直接指す `$HOME` 側 symlink は
+  作られません（`DOTFILES_DEPLOY_SRC` を世代へ直接向けて単体実行した場合を除く。この場合に
+  備えて `claude_skill_links()` 等は世代ディレクトリを直接指すリンクも認識対象にしています。
+  後述の「旧方式からの移行手順」も参照）
 - 世代ディレクトリ名は `<date +%Y%m%dT%H%M%S>-<short sha>`。同一秒・同一コミットで
   再デプロイすると ID が衝突し、上書きせずエラーになります（`shared/helpers.sh` の
   `create_generation`）
@@ -107,8 +110,9 @@ dev モード中に `--rollback` を実行すると、「1つ前」が定義で�
 
 - dev モードでリンクされた git worktree（`ocw` などで作った worktree）を指していると、
   その worktree を消した瞬間に全 `$HOME` リンクが壊れます。`--dev` 実行時に警告が出ます
-- `uninstall.sh` は dev モード中、作業ツリーの実体には一切触れず、`current` という
-  シンボリックリンク自体だけを取り除きます
+- `uninstall.sh` は dev モード中でも `generations/` `.tmp/` と `current` 自体は通常どおり
+  片付けます。保護されるのは **`current` が指す作業ツリーの実体だけ**で、そちらには一切
+  触れません
 
 **抜ける（世代モードに戻る）:**
 
@@ -142,22 +146,31 @@ dev モード中に `--rollback` を実行すると、「1つ前」が定義で�
 
 **移行時に何が起きるか:**
 
-- `symlink_backup` が、既存の symlink が旧方式（作業ツリー直リンク）由来かどうかを
-  判定します（リンク先がソースツリー配下、または canonical prefix 配下であるか）。
-  旧方式のリンクは**`.backup` として退避されず**、そのまま新方式（`current` 経由）の
-  リンクへ張り替えられます
-- `claude/skills/` 配下の個別 symlink も同様です。旧方式で張られたスキルの symlink は
-  `~/.claude/skills-backup/` へ退避されず、張り替えられます
+- `symlink_backup` が、既存の symlink が「リポジトリ由来」かどうかを判定します。判定基準は
+  リンク先が canonical prefix 配下、または**今回 `deploy-all.sh` を実行しているチェックアウト**
+  配下であることです（`shared/helpers.sh` の `_dotfiles_symlink_is_repo_owned`。判定対象は
+  「ソースツリー一般」ではなく、あくまで今実行しているチェックアウトそのものです）。
+  リポジトリ由来と判定された symlink は**`.backup` として退避されず**、そのまま新方式
+  （`current` 経由）のリンクへ張り替えられます
+- **旧方式のリンクが、今回 deploy を実行しているチェックアウトとは別のパス
+  （例: 以前 `ocw` などで作った別の worktree）を指している場合は、リポジトリ由来と
+  判定されず `.backup` へ退避されます。** 複数のチェックアウト（worktree）を使い分けて
+  deploy してきた場合はこのケースに当たりうるため注意してください
+- `claude/skills/` 配下の個別 symlink も同様の判定です。旧方式で張られたスキルの symlink は、
+  今回 deploy を実行しているチェックアウトを指している場合に限り
+  `~/.claude/skills-backup/` へ退避されず張り替えられます
 
 **`.backup` として残るもの:**
 
 - deploy 対象のリポジトリとは無関係にユーザー自身が用意していたファイル・symlink
   （例: 元々存在した `~/.zshrc` が本リポジトリの deploy とは無関係なものだった場合）
+- 旧方式の symlink であっても、今回 deploy を実行しているチェックアウトとは**別のパス**
+  （別の worktree 等）を指しているもの
 
 **`.backup` として残らないもの:**
 
-- 旧方式（このリポジトリの過去の deploy が作った）の symlink。上記のとおり退避されず
-  張り替えられます
+- 旧方式（今回 deploy を実行しているのと同じチェックアウトの過去の deploy が作った）の
+  symlink。上記のとおり退避されず張り替えられます
 
 移行後、`uninstall.sh` は新方式（`current` 経由・世代ディレクトリを直接指す場合の両方）と
 旧方式（作業ツリー直リンク）の両方のスキームを認識して撤去できます。マシンによって

--- a/docs/reference/DOC-2608040805_配布実体運用ガイド.md
+++ b/docs/reference/DOC-2608040805_配布実体運用ガイド.md
@@ -1,0 +1,164 @@
+# 配布実体運用ガイド
+
+この文書は、世代ディレクトリ + `current` シンボリックリンクによる配布方式
+（ADR DOC-2608040229）の日常運用で繰り返し引く事実をまとめたものです。設計判断の経緯を
+知りたい場合は ADR DOC-2608040229 を、実装の全体像を知りたい場合はルート `AGENTS.md`
+「デプロイの仕組み」を参照してください。
+
+## canonical prefix のディレクトリ構造
+
+```
+${XDG_DATA_HOME:-$HOME/.local/share}/dotfiles/
+├── .tmp/                              # create_generation のスクラッチ領域(通常は空。クラッシュ時のみ残骸が残りうる)
+├── generations/
+│   ├── 20260804T091500-fab7694/       # 世代ディレクトリ(作業ツリーの cp -a コピー)
+│   │   ├── .dotfiles-manifest
+│   │   ├── shared/
+│   │   └── zsh/ nvim/ tmux/ bin/ claude/
+│   ├── 20260804T101200-25e1430/
+│   └── 20260804T113000-fab7694/
+└── current -> generations/20260804T113000-fab7694
+    (dev モード中は作業ツリーそのものへのシンボリックリンクになる)
+```
+
+- `current` は `$HOME` 側の全 symlink が経由する唯一の間接参照点です。世代ディレクトリを
+  直接指す `$HOME` 側 symlink はありません
+- 世代ディレクトリ名は `<date +%Y%m%dT%H%M%S>-<short sha>`。同一秒・同一コミットで
+  再デプロイすると ID が衝突し、上書きせずエラーになります（`shared/helpers.sh` の
+  `create_generation`）
+- 世代の中身は常に `AVAILABLE_TOOLS`（`zsh nvim tmux bin claude`）全部 + `shared/`。
+  `--only` はこの中身に影響しません（`$HOME` のどのリンクを張るかだけを制御します）
+
+## `.dotfiles-manifest` の全フィールド
+
+世代ディレクトリ直下に平文で置かれます（`write_manifest`、`shared/helpers.sh`）。
+
+| フィールド | 内容 |
+|---|---|
+| `deployed_at` | デプロイ日時（`date +%Y-%m-%dT%H:%M:%S%z`） |
+| `source_tree` | デプロイ元の作業ツリーの絶対パス |
+| `commit_sha` | デプロイ元のコミット SHA（取得できなければ `unknown`） |
+| `branch` | デプロイ元のブランチ名（同上） |
+| `dirty` | デプロイ元が `git status --porcelain` で汚れていたか（`0`/`1`。git が使えなければ `unknown`） |
+| `linked_worktree` | リンクされた git worktree からのデプロイだったか（`0`/`1`） |
+| `mode` | 常に `generation`。dev モードは manifest を書かない（後述） |
+| `hostname` | デプロイしたホスト名（`uname -n`） |
+
+dev モードは `current` が作業ツリーそのものを指すため、manifest を持ちません。
+`./deploy-all.sh --status` は dev モード中、上記の `commit_sha` / `branch` / `dirty` 相当の
+情報をその場で作業ツリーの git 状態から読んで代わりに表示します。
+
+## 世代の一覧を見る／今効いている世代を調べる
+
+```bash
+./deploy-all.sh --status
+```
+
+副作用なし。実 `$HOME` に対してそのまま実行してよいコマンドです。以下を表示します。
+
+- `current` の向き先（世代、または dev モードのソースツリー）
+- 世代であればその `.dotfiles-manifest` の内容、dev モードであればソースツリーの
+  生の git 状態
+- 保持されている世代の一覧（`*` が付いているものが `current`）
+- `$HOME` 側の全 symlink（`claude/skills/` 配下の個別 symlink を含む）の健全性。
+  リンク切れ（`[BROKEN]`）を検出すると終了コードが 1 になります
+
+保持世代数は既定 3（`DOTFILES_KEEP_GENERATIONS` 環境変数で上書き可）。`current` が指す
+世代と dev モード中は GC の対象から除外されます。
+
+## ロールバックの手順
+
+```bash
+./deploy-all.sh --rollback           # current の1つ前の世代へ
+./deploy-all.sh --rollback <世代ID>  # 指定した世代へ(世代IDは --status の一覧に出る文字列)
+./deploy-all.sh --rollback --dry-run # 何が起きるかを事前確認
+```
+
+`$HOME` 側の symlink は張り直されません。全リンクが `current` という1本のシンボリック
+リンク経由で解決される設計のため、`current` の付け替え1回だけで全リンクの向き先が
+一斉に切り替わります（ADR DOC-2608040229 §4.1）。
+
+**ロールバックが戻さないもの**: `~/.claude/settings.json` は生成された実ファイルであり
+symlink ではないため、`current` の付け替えの影響を受けません。ロールバック後にその内容も
+戻したい場合は、ロールバック先の世代から `claude/deploy.sh` を明示的に再実行してください。
+
+**ロールバック先に無いリンクが残る可能性**: ロールバック先の世代に、現在の世代にはある
+symlink（例: 後から追加された claude スキル）が存在しない場合、そのリンクはダングリングの
+まま残ります。ロールバック後は `--status` を実行してリンク切れが無いか確認してください。
+
+dev モード中に `--rollback` を実行すると、「1つ前」が定義できないため最新の世代へ
+切り替わります。
+
+## dev モードの入り方・抜け方・注意点
+
+**入る:**
+
+```bash
+./deploy-all.sh --dev
+```
+
+`current` を作業ツリーそのものへ向けます。世代は作られず、`$HOME` 側の symlink も
+新規作成されません（一度も `deploy-all.sh` を実行していない環境で `--dev` を最初に
+実行しても、`$HOME` には何もリンクされません。先に一度通常の deploy を行ってから
+使う想定です）。dev モード中はリポジトリの編集がそのまま即座に `$HOME` へ反映され、
+世代の GC も行われません。
+
+**注意点:**
+
+- dev モードでリンクされた git worktree（`ocw` などで作った worktree）を指していると、
+  その worktree を消した瞬間に全 `$HOME` リンクが壊れます。`--dev` 実行時に警告が出ます
+- `uninstall.sh` は dev モード中、作業ツリーの実体には一切触れず、`current` という
+  シンボリックリンク自体だけを取り除きます
+
+**抜ける（世代モードに戻る）:**
+
+```bash
+./deploy-all.sh
+```
+
+通常の deploy を実行するだけで新しい世代が作られ、`current` がそちらへ切り替わります。
+
+## リンク切れを見つけたときの対処
+
+```bash
+./deploy-all.sh --status
+```
+
+の「Link health」セクションに `[BROKEN]` として表示されます。典型的な原因:
+
+- `current` が指す世代が何らかの理由で削除された（GC の不変条件が壊れていない限り
+  起きないはずですが、手動で世代ディレクトリを消した場合など）
+- dev モードでソースツリー自体（リンクされた worktree）が削除された
+
+対処は `./deploy-all.sh` を再実行して新しい世代を作り直すことです。`current` が壊れた
+シンボリックリンクになっている場合、単体の `<tool>/deploy.sh` を直接実行しようとすると
+`resolve_deploy_src` がそれを検出し、「current is a broken symlink」という専用の
+エラーメッセージで `./deploy-all.sh` の実行を案内して終了します。
+
+## 旧方式（作業ツリー直リンク）からの移行手順
+
+既存マシンで行うことは、新方式の `./deploy-all.sh` を実行するだけです。追加の手順は
+必要ありません。
+
+**移行時に何が起きるか:**
+
+- `symlink_backup` が、既存の symlink が旧方式（作業ツリー直リンク）由来かどうかを
+  判定します（リンク先がソースツリー配下、または canonical prefix 配下であるか）。
+  旧方式のリンクは**`.backup` として退避されず**、そのまま新方式（`current` 経由）の
+  リンクへ張り替えられます
+- `claude/skills/` 配下の個別 symlink も同様です。旧方式で張られたスキルの symlink は
+  `~/.claude/skills-backup/` へ退避されず、張り替えられます
+
+**`.backup` として残るもの:**
+
+- deploy 対象のリポジトリとは無関係にユーザー自身が用意していたファイル・symlink
+  （例: 元々存在した `~/.zshrc` が本リポジトリの deploy とは無関係なものだった場合）
+
+**`.backup` として残らないもの:**
+
+- 旧方式（このリポジトリの過去の deploy が作った）の symlink。上記のとおり退避されず
+  張り替えられます
+
+移行後、`uninstall.sh` は新方式（`current` 経由・世代ディレクトリを直接指す場合の両方）と
+旧方式（作業ツリー直リンク）の両方のスキームを認識して撤去できます。マシンによって
+移行の進み具合が異なっていても、`uninstall.sh` はどちらのリンクも正しく撤去します。

--- a/nvim/README.md
+++ b/nvim/README.md
@@ -47,14 +47,23 @@ mise use ripgrep fd node@lts python@latest
 
 ## 2. Quick Start
 
+On a fresh machine, run the top-level `deploy-all.sh` (not `nvim/deploy.sh` directly) —
+`$HOME` links through a distribution artifact under `${XDG_DATA_HOME:-$HOME/.local/share}/dotfiles/`
+that only `deploy-all.sh` creates. Running `nvim/deploy.sh` standalone before that
+exists fails with an error pointing you back here.
+
 ```bash
-# 1. Run deploy script
-cd ~/.dotfiles/nvim
-./deploy.sh
+# 1. Run the top-level deploy script
+cd ~/.dotfiles
+./deploy-all.sh --only nvim
 
 # 2. Open NeoVim — plugins auto-install via lazy.nvim on first launch
 nvim
 ```
+
+Once `deploy-all.sh` has run at least once, you can re-run `nvim/deploy.sh` directly
+to re-link `nvim` alone (it reuses the existing distribution artifact rather than
+creating a new one).
 
 The deploy script:
 - Creates `~/.config/nvim/` directory

--- a/nvim/README.md
+++ b/nvim/README.md
@@ -255,5 +255,7 @@ Delete or move them manually if found.
 This means lazy.nvim can't find a plugin file. Ensure `nvim/lua/plugins/` is symlinked correctly:
 ```bash
 readlink ~/.config/nvim/lua
-# Should point to ~/.dotfiles/nvim/lua
+# Should point through the distribution's `current` symlink, e.g.
+# ~/.local/share/dotfiles/current/nvim/lua (not directly into ~/.dotfiles).
+# Run ./deploy-all.sh --status from the repo root to see what `current` resolves to.
 ```

--- a/tmux/README.md
+++ b/tmux/README.md
@@ -42,10 +42,19 @@ WSLg / Windows Terminal users get automatic clipboard passthrough to Windows. Fo
 
 ## 2. Quick Start
 
+On a fresh machine, run the top-level `deploy-all.sh` (not `tmux/deploy.sh` directly) —
+`$HOME` links through a distribution artifact under `${XDG_DATA_HOME:-$HOME/.local/share}/dotfiles/`
+that only `deploy-all.sh` creates. Running `tmux/deploy.sh` standalone before that
+exists fails with an error pointing you back here.
+
 ```bash
-cd ~/.dotfiles/tmux
-./deploy.sh
+cd ~/.dotfiles
+./deploy-all.sh --only tmux
 ```
+
+Once `deploy-all.sh` has run at least once, you can re-run `tmux/deploy.sh` directly
+to re-link `tmux` alone (it reuses the existing distribution artifact rather than
+creating a new one).
 
 The deploy script:
 - Symlinks `tmux.conf` → `~/.tmux.conf`

--- a/zsh/README.md
+++ b/zsh/README.md
@@ -174,11 +174,13 @@ antidote update
 
 ### Custom Antidote Install Location
 
-Set `ANTIDOTE_HOME` **before** running `deploy.sh`:
+Set `ANTIDOTE_HOME` **before the first deploy** (this is usually done on a fresh
+machine, before `current` exists — use the top-level `deploy-all.sh`, not
+`zsh/deploy.sh` directly; see Quick Start above):
 
 ```bash
 export ANTIDOTE_HOME="$HOME/.local/share/antidote"
-./deploy.sh
+cd ~/.dotfiles && ./deploy-all.sh --only zsh
 ```
 
 To make it permanent, add to `~/.zshenv` (sourced before `.zshrc`):

--- a/zsh/README.md
+++ b/zsh/README.md
@@ -38,11 +38,20 @@ chsh -s "$(which zsh)"
 
 ## 2. Quick Start
 
+On a fresh machine, run the top-level `deploy-all.sh` (not `zsh/deploy.sh` directly) —
+`$HOME` links through a distribution artifact under `${XDG_DATA_HOME:-$HOME/.local/share}/dotfiles/`
+that only `deploy-all.sh` creates. Running `zsh/deploy.sh` standalone before that
+exists fails with an error pointing you back here.
+
 ```bash
-cd ~/.dotfiles/zsh
-./deploy.sh
+cd ~/.dotfiles
+./deploy-all.sh --only zsh
 exec zsh
 ```
+
+Once `deploy-all.sh` has run at least once, you can re-run `zsh/deploy.sh` directly
+to re-link `zsh` alone (it reuses the existing distribution artifact rather than
+creating a new one).
 
 The deploy script:
 - Symlinks `.zshrc` → `~/.zshrc`


### PR DESCRIPTION
## 背景

dotfilesは、macOS / Linux / WSL2 で共通の開発環境を再現するための設定リポジトリです。傘ブランチ `ai/deploy-stability` では、`$HOME` の設定ファイルをリポジトリの作業ツリーへ直接シンボリックリンクする方式から、世代ディレクトリと `current` シンボリックリンクを介した配布実体方式への移行を進めてきました。これまでの孫ブランチで、配布実体レイヤの導入・`claude` の追従・`uninstall.sh` の追従・運用コマンド(`--status` / `--rollback` / `--dev`)の追加が完了し、実装は確定しています。

しかし `AGENTS.md` やルート `README.md`、テスト方針、各ツールの `README.md` は、旧方式(作業ツリー直リンク)を前提にした説明のままでした。

## このプルリクエストの目的

実装を一切変更せず、文書だけを現在の実装に合わせて更新します。あわせて、日常運用で繰り返し引く事実をまとめた新規リファレンス文書を追加します。

## 実装内容

- `AGENTS.md` を更新しました。
  - 「最重要ルール」の deploy スクリプトに関する記述に、配布実体を経由すること・`--status` は実 `$HOME` に対して実行してよいが `--rollback` / `--dev` は避けることを追記しました。
  - 「デプロイの仕組み」節を全面的に書き直し、配布実体レイヤの構造・デプロイの流れ・`--status` / `--rollback` / `--dev` の挙動・単体実行時の規約・symlink の退避ルール・`claude` の例外・`uninstall.sh` の後片付けをまとめました。
  - 「実装時の注意」を、`$HOME` 側リンク先の一覧が `uninstall.sh` から `shared/helpers.sh` の `links_for_tool()` へ移った現状に合わせて書き直しました。
- ルート `README.md` を更新しました。
  - `deploy-all.sh` のオプション一覧に `--status` / `--rollback` / `--dev` を追加しました。
  - 「Deploying from a git worktree」節を、世代モードが既定になったことで前提が変わった点を踏まえ、「dev モードを使う場合の注意」として書き直しました。
  - 「Uninstalling」節に、配布実体(世代ディレクトリ + `current`)も後片付けされることを追記しました。
- 各ツールの `README.md` を確認し、実態と食い違っていた箇所を修正しました。
  - `claude/README.md`: 「CLAUDE.md を直接編集するとリポジトリ側にも即反映される」という説明が、配布実体経由になったことで誤りになっていたため、世代モードとdevモードでの挙動の違いに書き直しました。
  - `nvim/README.md`: `readlink ~/.config/nvim/lua` の期待値が作業ツリー直リンクのままだったため、`current` 経由のパスに修正しました。
  - `zsh/README.md` / `tmux/README.md` / `bin/README.md` は実態と食い違う記述が無かったため変更していません。
- `docs/design/DOC-2608020715-b_テスト方針.md` を更新しました。
  - 「前提となる事実」に、配布実体の置き場所が `XDG_DATA_HOME` に依存するようになった結果、以前は nvim 固有だった `XDG_DATA_HOME` のサンドボックス差し替えが、サンドボックス対象の全ツール(`bin` `claude`)に共通の前提になったことを追記しました。
  - 「サンドボックス実行の検証項目」チェックリストに、ソースツリー消失耐性・編集分離・世代とGC・ロールバック・devモード・`--status`・旧方式からの移行・uninstallによる後片付けの項目を追加しました。
  - サンドボックス対象ツールの分類(`bin` `claude` のみ)自体は変更していません。
- `docs/reference/DOC-2608040805_配布実体運用ガイド.md` を新規作成しました。canonical prefix のディレクトリ構造・`.dotfiles-manifest` の全フィールド・世代確認とロールバックの手順・dev モードの出入り・リンク切れの対処・旧方式からの移行手順をまとめています。`docs/README.md` の索引にも追記しました。

## レビューで見てほしいところ

- 文書に書いたコマンドや出力例は、実際に手元で `./deploy-all.sh --help` や `./deploy-all.sh --status`(副作用が無いため実環境で実行し、出力を確認済みです)を動かして裏取りしています。書きぶりが実装と食い違っていないか確認をお願いします。
- `claude/README.md` の「CLAUDE.md の編集」節は、世代モードとdevモードで挙動が異なる点を新たに説明に加えました。分かりやすさに問題がないか確認してもらえると助かります。
- テスト方針の「サンドボックス実行の検証項目」に追加した項目は、`tests/deploy_smoke.sh` に既に実装されているシナリオをドキュメント側に反映したものです。抜けている観点が無いか確認をお願いします。

## テスト結果

`pre-commit run --all-files`、`./tools/doc-id/doc-id check`、`./tools/doc-id/doc-id verify` はすべて緑です。シェルスクリプトは変更していないため `tests/deploy_smoke.sh` の実行は不要と判断しました。

## 今後の予定

孫6(`bin/ocw-meter` が symlink 経由の起動で価格表を見失うバグの修正)は本プルリクエストとは独立しており、別ブランチで進行中です。傘ブランチ `ai/deploy-stability` への全孫のマージが完了したら、最後に `master` への統合プルリクエストを作成する予定です。
