### PR TITLE
symlink 経由起動時に ocw-meter が価格表を見失う不具合を修正する

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -295,7 +295,7 @@ PR番号はリポジトリ**内**でしか一意でない。`--pr`とstandalone�
 | `OCW_METER_HOME` | `~/.local/state/ocw-meter` | 保存先ルート。**git worktree内を指すと拒否される**（誤commit防止）。`event`/`bind-pr`は書き込みをスキップして exit 0（設定ミスが誰にも気づかれないままにならないよう、既定の保存先へ `meter.error` を1件/日で記録し、fallbackした旨をstderrに警告する）、`validate`/`report`/`ingest`は非ゼロで停止する |
 | `OCW_METER_RAW` | `0` | `1`にすると `snapshot-quota` がredaction済みのstatusLine生JSONを `raw/YYYY-MM-DD/` へ保存する（既定オフ） |
 | `OCW_METER_CLAUDE_PROJECTS_DIR` | `~/.claude/projects` | `ingest` がtranscriptを探すディレクトリ |
-| `OCW_METER_PRICE_DIR` | `<このファイルのあるディレクトリ>/prices` | `ingest` が価格表(`*.json`)を探すディレクトリ |
+| `OCW_METER_PRICE_DIR` | `<symlink を解決した先にある ocw-meter の実体のディレクトリ>/prices` | `ingest` が価格表(`*.json`)を探すディレクトリ |
 | `OCW_METER_INGEST_USE_GH` | `0` | `1` にすると、PR番号未解決時に `gh pr list --head <branch>` へフォールバックする（既定オフ = ネットワークを一切叩かない） |
 | `OCW_METER_QUOTA_INTERVAL` | `60`（秒） | `snapshot-quota` が実際に `quota.sample` を書き込む最短間隔。数値でない値・負値は既定値にフォールバックする |
 

--- a/bin/ocw-meter
+++ b/bin/ocw-meter
@@ -241,9 +241,27 @@ export OCW_METER_HOME="${OCW_METER_HOME:-}"
 export OCW_METER_RAW="${OCW_METER_RAW:-0}"
 # Lets `ingest` find bin/prices/*.json relative to this file regardless
 # of the caller's cwd, without hardcoding a path (OCW_METER_PRICE_DIR
-# still overrides this for tests/customization).
-OCW_METER_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# still overrides this for tests/customization). Resolves the
+# BASH_SOURCE[0] symlink chain by hand first: deploy.sh installs this
+# script as a symlink (e.g. ~/bin/ocw-meter), and `dirname` on an
+# unresolved symlink path yields the symlink's OWN directory rather than
+# the real script's — `ingest` would then look for a nonexistent
+# ~/bin/prices and silently find zero price tables (ADR
+# DOC-2608040229 §2.6). `readlink -f` is GNU-only and unavailable on
+# macOS, so this walks the chain one hop at a time instead, resolving a
+# relative link target against the directory of the link being read.
+_ocw_meter_src="${BASH_SOURCE[0]}"
+while [ -L "$_ocw_meter_src" ]; do
+  _ocw_meter_link_dir="$(cd "$(dirname "$_ocw_meter_src")" && pwd)"
+  _ocw_meter_src="$(readlink "$_ocw_meter_src")"
+  case "$_ocw_meter_src" in
+    /*) ;;
+    *) _ocw_meter_src="$_ocw_meter_link_dir/$_ocw_meter_src" ;;
+  esac
+done
+OCW_METER_SCRIPT_DIR="$(cd "$(dirname "$_ocw_meter_src")" && pwd)"
 export OCW_METER_SCRIPT_DIR
+unset _ocw_meter_src _ocw_meter_link_dir
 
 cmd="${1:-}"
 if [ -z "$cmd" ]; then

--- a/bin/ocw-meter
+++ b/bin/ocw-meter
@@ -252,14 +252,14 @@ export OCW_METER_RAW="${OCW_METER_RAW:-0}"
 # relative link target against the directory of the link being read.
 _ocw_meter_src="${BASH_SOURCE[0]}"
 while [ -L "$_ocw_meter_src" ]; do
-  _ocw_meter_link_dir="$(cd "$(dirname "$_ocw_meter_src")" && pwd)"
+  _ocw_meter_link_dir="$(CDPATH='' cd -- "$(dirname "$_ocw_meter_src")" && pwd)"
   _ocw_meter_src="$(readlink "$_ocw_meter_src")"
   case "$_ocw_meter_src" in
     /*) ;;
     *) _ocw_meter_src="$_ocw_meter_link_dir/$_ocw_meter_src" ;;
   esac
 done
-OCW_METER_SCRIPT_DIR="$(cd "$(dirname "$_ocw_meter_src")" && pwd)"
+OCW_METER_SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname "$_ocw_meter_src")" && pwd)"
 export OCW_METER_SCRIPT_DIR
 unset _ocw_meter_src _ocw_meter_link_dir
 

--- a/bin/tests/test_ocw_meter.py
+++ b/bin/tests/test_ocw_meter.py
@@ -1779,6 +1779,85 @@ class IngestTests(OcwMeterTestCase):
         self.assertFalse(events_file.read_text(encoding="utf-8").endswith("\n"))
 
 
+class SymlinkInvocationTests(OcwMeterTestCase):
+    """ADR DOC-2608040229 §2.6: deploy.sh installs this script as a
+    symlink (e.g. ~/bin/ocw-meter). `dirname` on an unresolved
+    BASH_SOURCE[0] would then point at the SYMLINK's own directory, not
+    where bin/prices/*.json actually lives, so `ingest` would silently
+    find zero price tables (empty price_table_dir -> completeness
+    "unknown" and cost_estimate_usd null, even for a model that IS
+    priced in the real bin/prices/*.json). These tests invoke the
+    script only through a symlink and deliberately do NOT set
+    OCW_METER_PRICE_DIR, so a regression of the BASH_SOURCE[0]
+    resolution shows up as a completeness/cost_estimate_usd mismatch
+    rather than a hard failure."""
+
+    def setUp(self):
+        super().setUp()
+        self.projects_dir = pathlib.Path(self.tmpdir.name) / "claude-projects"
+        self.projects_dir.mkdir(parents=True, exist_ok=True)
+
+    def _run_ingest_via(self, exe_path):
+        env = dict(os.environ)
+        env["OCW_METER_HOME"] = str(self.home)
+        env["OCW_METER_CLAUDE_PROJECTS_DIR"] = str(self.projects_dir)
+        env["OCW_METER_INGEST_USE_GH"] = "0"
+        env.pop("OCW_METER_PRICE_DIR", None)
+        for key in ("OCW_RUN_ID", "OCW_ROLE", "HERDR_WORKSPACE_ID", "HERDR_PANE_ID"):
+            env.pop(key, None)
+        return subprocess.run(
+            [str(exe_path), "ingest"],
+            cwd=str(REPO_ROOT),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+    def test_ingest_resolves_price_dir_through_absolute_symlink(self):
+        link_dir = pathlib.Path(self.tmpdir.name) / "bin-abs"
+        link_dir.mkdir()
+        link_path = link_dir / "ocw-meter"
+        link_path.symlink_to(OCW_METER)
+
+        write_transcript(self.projects_dir, "proj", "sess-symlink-abs", [
+            assistant_line("sess-symlink-abs", "m1", model="deepseek-v4-pro",
+                            input_tokens=1000, cache_read_input_tokens=2000, output_tokens=300),
+        ])
+        result = self._run_ingest_via(link_path)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = read_events(self.home)[0]
+        self.assertEqual(event["price_table_version"], "deepseek-2026-08-01")
+        self.assertEqual(event["cost_basis"], "estimated")
+        self.assertEqual(event["completeness"], "complete")
+        self.assertIsNotNone(event["cost_estimate_usd"])
+
+    def test_ingest_resolves_price_dir_through_chained_relative_symlink(self):
+        # Two hops, the first a RELATIVE target, to exercise the
+        # resolution loop walking more than once and resolving a
+        # relative link target against the directory of the link being
+        # read, not the final destination's directory.
+        hop1_dir = pathlib.Path(self.tmpdir.name) / "hop1"
+        hop2_dir = pathlib.Path(self.tmpdir.name) / "hop2"
+        hop1_dir.mkdir()
+        hop2_dir.mkdir()
+        hop1_link = hop1_dir / "ocw-meter"
+        hop1_link.symlink_to(os.path.relpath(OCW_METER, hop1_dir))
+        hop2_link = hop2_dir / "ocw-meter"
+        hop2_link.symlink_to(hop1_link)
+
+        write_transcript(self.projects_dir, "proj", "sess-symlink-chain", [
+            assistant_line("sess-symlink-chain", "m1", model="deepseek-v4-pro",
+                            input_tokens=1000, cache_read_input_tokens=2000, output_tokens=300),
+        ])
+        result = self._run_ingest_via(hop2_link)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = read_events(self.home)[0]
+        self.assertEqual(event["price_table_version"], "deepseek-2026-08-01")
+        self.assertEqual(event["completeness"], "complete")
+        self.assertIsNotNone(event["cost_estimate_usd"])
+
+
 class ReportReconcileTests(OcwMeterTestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
## 背景

dotfilesは、macOS / Linux / WSL2 で共通の開発環境を再現するための設定リポジトリです。`bin/ocw-meter` は Claude Code の利用状況を記録・集計するツールで、費用計算には `bin/prices/*.json` の価格表を使います。

`deploy-all.sh` はこのスクリプトを `~/bin/ocw-meter` へシンボリックリンクとして配布しますが、価格表の位置を求める処理が `BASH_SOURCE[0]` のシンボリックリンクを解決していませんでした。そのため symlink 経由で起動すると、実在しない `~/bin/prices` を探しにいき、価格表が見つからず費用計算が完全性 `unknown`（未確定）のまま記録されてしまう不具合がありました（配布方式の見直し作業の途中で見つかった不具合で、詳細は ADR DOC-2608040229 §2.6 に記録されています）。

## このプルリクエストの目的

`bin/ocw-meter` が symlink 経由で起動されても、正しく価格表の位置を解決できるようにします。

## 実装内容

- `bin/ocw-meter` の `OCW_METER_SCRIPT_DIR` 解決処理を、`BASH_SOURCE[0]` から始めてシンボリックリンクを1段ずつ手動で辿る方式に変更しました。相対パスのリンク先は、リンクファイル自身のディレクトリを基準に解決します。`readlink -f` は macOS に存在しないため使っていません。
- `OCW_METER_PRICE_DIR` による上書きの挙動は変えていません。
- `bin/tests/test_ocw_meter.py` に回帰テストを追加しました。実行ファイルへの絶対パスのシンボリックリンク1本、および相対パスのリンクを含む2段階のシンボリックリンクの、両方の経路から起動した場合に価格表が正しく解決されることを確認します。

## レビューで見てほしいところ

- シンボリックリンクの解決ループを `while [ -L "$_ocw_meter_src" ]` で書きました。circular symlink（自己参照するリンク）を作った場合は無限ループになりますが、これは deploy.sh 自身が作るリンクでは起こり得ない状況のため、特別なガードは入れていません。この判断で問題ないか確認をお願いします。

## テスト結果

- `bin/tests/lint.sh`: 成功
- `python3 -m unittest discover -s bin/tests -v`（195件、新規2件を含む）: 成功
- `pre-commit run --all-files`: 成功