### PR TITLE
bin/ocw・bin/ocw-meterのmacOS(BSD/bash 3.2)固有の非互換を解消

### DIFF
--- a/bin/ocw
+++ b/bin/ocw
@@ -99,6 +99,7 @@ realpath_m() {
   local target="$1"
   local dir=""
   local base=""
+  local parent=""
 
   if [ -d "$target" ]; then
     (cd -P -- "$target" && pwd -P)
@@ -111,7 +112,10 @@ realpath_m() {
   [ -d "$dir" ] ||
     die "cannot resolve path: $target"
 
-  printf '%s/%s\n' "$(cd -P -- "$dir" && pwd -P)" "$base"
+  parent="$(cd -P -- "$dir" && pwd -P)" ||
+    die "cannot resolve parent directory: $dir"
+
+  printf '%s/%s\n' "$parent" "$base"
 }
 
 json_nested_field() {
@@ -690,6 +694,8 @@ remove_worktree() {
   local slug=""
   local branch=""
   local worktree_dir=""
+  local invocation_real=""
+  local worktree_real=""
 
   slug="$(normalize_name "$task_name")"
 
@@ -704,7 +710,10 @@ remove_worktree() {
   echo "branch:    ${branch}"
   echo "force:     ${force}"
 
-  if [[ "$(realpath_m "$invocation_root")" == "$(realpath_m "$worktree_dir")" ]]; then
+  invocation_real="$(realpath_m "$invocation_root")"
+  worktree_real="$(realpath_m "$worktree_dir")"
+
+  if [[ "$invocation_real" == "$worktree_real" ]]; then
     echo "error: do not remove the current worktree" >&2
     echo "move to main first:" >&2
     echo "  cd ${repo_root}" >&2

--- a/bin/ocw
+++ b/bin/ocw
@@ -91,6 +91,29 @@ normalize_name() {
     sed -E 's/^-+|-+$//g'
 }
 
+# GNU realpath の `-m`（存在しないパスでも解決する）相当。BSD 版
+# realpath（macOS 標準の /bin/realpath）は `-m` 非対応のため自前実装する。
+# 対象パス自体が存在しない場合でも、親ディレクトリまでは存在する前提
+# （remove_worktree での「今いる worktree を消そうとしていないか」比較用途）。
+realpath_m() {
+  local target="$1"
+  local dir=""
+  local base=""
+
+  if [ -d "$target" ]; then
+    (cd -P -- "$target" && pwd -P)
+    return
+  fi
+
+  dir="$(dirname -- "$target")"
+  base="$(basename -- "$target")"
+
+  [ -d "$dir" ] ||
+    die "cannot resolve path: $target"
+
+  printf '%s/%s\n' "$(cd -P -- "$dir" && pwd -P)" "$base"
+}
+
 json_nested_field() {
   local json="$1"
   local container="$2"
@@ -681,7 +704,7 @@ remove_worktree() {
   echo "branch:    ${branch}"
   echo "force:     ${force}"
 
-  if [[ "$(realpath -m "$invocation_root")" == "$(realpath -m "$worktree_dir")" ]]; then
+  if [[ "$(realpath_m "$invocation_root")" == "$(realpath_m "$worktree_dir")" ]]; then
     echo "error: do not remove the current worktree" >&2
     echo "move to main first:" >&2
     echo "  cd ${repo_root}" >&2

--- a/bin/ocw-meter
+++ b/bin/ocw-meter
@@ -333,11 +333,22 @@ fi
 # so fd 0 stays untouched) — but bash 3.2 (macOS's shipped /bin/bash)
 # cannot parse a heredoc nested inside a process substitution and
 # fails with a parse-time syntax error (bash 5, e.g. CI, has no such
-# issue). Writing the program text to a temp file first sidesteps that
-# parser bug while keeping fd 0 untouched for the same reason.
+# issue). `python3 /dev/fd/3 ... 3<<'PY'` (heredoc attached to fd 3,
+# python reads its program from that fd's path) parses fine on both
+# bash versions, but was rejected after testing: whenever this script
+# is invoked via PATH lookup (`command -v ocw-meter && ocw-meter ...`
+# — the exact shape bin/ocw's ocw_meter_event() uses) rather than by
+# an absolute/relative path, fd 3's heredoc content came back empty on
+# this machine (bash silently ran an empty program, exit 0, no error).
+# Confirmed reproducible outside this file too, with a trivial script
+# in the same two shapes — so it isn't specific to this codebase, but
+# it's a real failure mode for exactly the callers that matter here.
+# Writing the program text to a temp file sidesteps that: the write
+# happens before python3 is invoked at all, so PATH lookup vs direct
+# path makes no difference to what python3 ends up reading.
 _ocw_meter_py="$(mktemp)" || die "mktemp failed"
 trap 'rm -f "$_ocw_meter_py"' EXIT
-cat >"$_ocw_meter_py" <<'PY'
+cat >"$_ocw_meter_py" <<'PY' || die "failed to write the embedded program to $_ocw_meter_py"
 # PERFORMANCE NOTE (why `ingest`, below, has its own write path instead
 # of calling `record`/`write_event` once per message): this CLI resolves
 # git metadata (repo slug, worktree root, branch, HEAD SHA, plus the

--- a/bin/ocw-meter
+++ b/bin/ocw-meter
@@ -335,17 +335,19 @@ fi
 # fails with a parse-time syntax error (bash 5, e.g. CI, has no such
 # issue). `python3 /dev/fd/3 ... 3<<'PY'` (heredoc attached to fd 3,
 # python reads its program from that fd's path) parses fine on both
-# bash versions, but was rejected after testing: whenever this script
-# is invoked via PATH lookup (`command -v ocw-meter && ocw-meter ...`
-# — the exact shape bin/ocw's ocw_meter_event() uses) rather than by
-# an absolute/relative path, fd 3's heredoc content came back empty on
-# this machine (bash silently ran an empty program, exit 0, no error).
-# Confirmed reproducible outside this file too, with a trivial script
-# in the same two shapes — so it isn't specific to this codebase, but
-# it's a real failure mode for exactly the callers that matter here.
-# Writing the program text to a temp file sidesteps that: the write
-# happens before python3 is invoked at all, so PATH lookup vs direct
-# path makes no difference to what python3 ends up reading.
+# bash versions, but was rejected after testing: with this embedded
+# program's real size (173KB), bash always backs fd 3 with a regular
+# temp file rather than a pipe (bash 3.2 always does; bash 5 does too
+# once the heredoc exceeds the pipe buffer, which 173KB does) — and
+# Apple's /usr/bin/python3 (3.9.6) cannot read a program from
+# /dev/fd/N when that fd is a regular file: it silently runs an empty
+# program and exits 0, no error. (PATH lookup vs an absolute/relative
+# path is NOT the deciding factor here — that's a red herring from an
+# earlier, confounded test that changed PATH and the python3 binary at
+# the same time; a pyenv/Homebrew python3 handles the same fd fine.)
+# Writing the program text to a temp file sidesteps that: python3
+# reads an ordinary file path instead of /dev/fd/N, so which python3
+# binary answers to `python3` makes no difference.
 _ocw_meter_py="$(mktemp)" || die "mktemp failed"
 trap 'rm -f "$_ocw_meter_py"' EXIT
 cat >"$_ocw_meter_py" <<'PY' || die "failed to write the embedded program to $_ocw_meter_py"

--- a/bin/ocw-meter
+++ b/bin/ocw-meter
@@ -328,12 +328,16 @@ fi
 # program, leaving sys.stdin at EOF, so snapshot-quota would ALWAYS see
 # empty input no matter what the caller piped in (caught by manual
 # testing while implementing 孫4 — every sample silently reported
-# rate_limits absent). Process substitution (`<(...)`) hands python a
-# FILE to read its program from instead of stdin, so fd 0 is never
-# touched here and passes through to the embedded script exactly as
-# the caller of `ocw-meter snapshot-quota` provided it.
-python3 <(
-  cat <<'PY'
+# rate_limits absent). This then became `python3 <(cat <<'PY' ... PY)`
+# (process substitution hands python a FILE to read its program from,
+# so fd 0 stays untouched) — but bash 3.2 (macOS's shipped /bin/bash)
+# cannot parse a heredoc nested inside a process substitution and
+# fails with a parse-time syntax error (bash 5, e.g. CI, has no such
+# issue). Writing the program text to a temp file first sidesteps that
+# parser bug while keeping fd 0 untouched for the same reason.
+_ocw_meter_py="$(mktemp)" || die "mktemp failed"
+trap 'rm -f "$_ocw_meter_py"' EXIT
+cat >"$_ocw_meter_py" <<'PY'
 # PERFORMANCE NOTE (why `ingest`, below, has its own write path instead
 # of calling `record`/`write_event` once per message): this CLI resolves
 # git metadata (repo slug, worktree root, branch, HEAD SHA, plus the
@@ -4236,7 +4240,7 @@ def main():
 
 sys.exit(main())
 PY
-) "$cmd" "$@"
+python3 "$_ocw_meter_py" "$cmd" "$@"
 py_status=$?
 
 case "$cmd" in

--- a/bin/tests/lint.sh
+++ b/bin/tests/lint.sh
@@ -9,15 +9,23 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 status=0
 
+# Single source of truth for "every shell script in the repo" — used by
+# both the bash -n block below and the /bin/bash -n compatibility block.
+# Duplicating this find in two places is exactly the failure shape
+# AGENTS.md warns about for links_for_tool(): a future standalone CLI
+# added to bin/ only gets appended to one of the two copies, and the
+# other silently checks one file fewer with no error or warning.
+list_shell_scripts() {
+  find "$repo_root" \
+    \( -path "$repo_root/.git" -o -path "$repo_root/*/.git" \) -prune -o \
+    -type f \( -name '*.sh' -o -name 'ocw' -o -name 'claude-ds' -o -name 'ocw-meter' \) -print0
+}
+
 echo "== bash -n =="
 while IFS= read -r -d '' file; do
   echo "  bash -n $file"
   bash -n "$file" || status=1
-done < <(
-  find "$repo_root" \
-    \( -path "$repo_root/.git" -o -path "$repo_root/*/.git" \) -prune -o \
-    -type f \( -name '*.sh' -o -name 'ocw' -o -name 'claude-ds' -o -name 'ocw-meter' \) -print0
-)
+done < <(list_shell_scripts)
 
 echo "== /bin/bash -n (macOS bash 3.2 compatibility) =="
 # `bash -n` above resolves via PATH, which on a dev machine with
@@ -29,11 +37,7 @@ if [ -x /bin/bash ] && /bin/bash --version | head -1 | grep -q 'version 3\.'; th
   while IFS= read -r -d '' file; do
     echo "  /bin/bash -n $file"
     /bin/bash -n "$file" || status=1
-  done < <(
-    find "$repo_root" \
-      \( -path "$repo_root/.git" -o -path "$repo_root/*/.git" \) -prune -o \
-      -type f \( -name '*.sh' -o -name 'ocw' -o -name 'claude-ds' -o -name 'ocw-meter' \) -print0
-  )
+  done < <(list_shell_scripts)
 else
   echo "  skipped (no bash 3.x at /bin/bash)"
 fi

--- a/bin/tests/lint.sh
+++ b/bin/tests/lint.sh
@@ -43,12 +43,13 @@ if [ -f "$meter_script" ]; then
   tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/ocw-meter-heredoc-XXXXXX")"
   trap 'rm -rf "$tmp_dir"' EXIT
   tmp_py="$tmp_dir/heredoc.py"
-  # Match only the actual heredoc opener line (`cat <<'PY'`, possibly
-  # indented), not prose that merely mentions `<<'PY'` in a comment — a
-  # loose `/<<'PY'/` pattern would start extraction at the first such
-  # mention (e.g. a comment explaining the heredoc) and pull in
-  # non-Python lines ahead of the real opener.
-  awk "/^[[:space:]]*cat <<'PY'\$/{flag=1; next} /^PY\$/{flag=0} flag" "$meter_script" >"$tmp_py"
+  # Match only the actual heredoc opener line (`cat >"$_ocw_meter_py"
+  # <<'PY'`, possibly indented), not prose that merely mentions
+  # `<<'PY'` in a comment — a loose `/<<'PY'/` pattern would start
+  # extraction at the first such mention (e.g. a comment explaining
+  # the heredoc) and pull in non-Python lines ahead of the real
+  # opener.
+  awk "/^[[:space:]]*cat >\"\\\$_ocw_meter_py\" <<'PY'\$/{flag=1; next} /^PY\$/{flag=0} flag" "$meter_script" >"$tmp_py"
   if [ -s "$tmp_py" ]; then
     echo "  py_compile (extracted heredoc)"
     python3 -m py_compile "$tmp_py" || status=1

--- a/bin/tests/lint.sh
+++ b/bin/tests/lint.sh
@@ -19,6 +19,25 @@ done < <(
     -type f \( -name '*.sh' -o -name 'ocw' -o -name 'claude-ds' -o -name 'ocw-meter' \) -print0
 )
 
+echo "== /bin/bash -n (macOS bash 3.2 compatibility) =="
+# `bash -n` above resolves via PATH, which on a dev machine with
+# Homebrew bash installed is bash 5 — so a syntax construct bash 3.2
+# alone rejects (e.g. a heredoc nested inside a process substitution)
+# passes silently. macOS still ships bash 3.2 at /bin/bash, so re-run
+# the same check there whenever that's a 3.x build.
+if [ -x /bin/bash ] && /bin/bash --version | head -1 | grep -q 'version 3\.'; then
+  while IFS= read -r -d '' file; do
+    echo "  /bin/bash -n $file"
+    /bin/bash -n "$file" || status=1
+  done < <(
+    find "$repo_root" \
+      \( -path "$repo_root/.git" -o -path "$repo_root/*/.git" \) -prune -o \
+      -type f \( -name '*.sh' -o -name 'ocw' -o -name 'claude-ds' -o -name 'ocw-meter' \) -print0
+  )
+else
+  echo "  skipped (no bash 3.x at /bin/bash)"
+fi
+
 echo "== python3 -m py_compile =="
 while IFS= read -r -d '' file; do
   echo "  py_compile $file"
@@ -44,12 +63,13 @@ if [ -f "$meter_script" ]; then
   trap 'rm -rf "$tmp_dir"' EXIT
   tmp_py="$tmp_dir/heredoc.py"
   # Match only the actual heredoc opener line (`cat >"$_ocw_meter_py"
-  # <<'PY'`, possibly indented), not prose that merely mentions
-  # `<<'PY'` in a comment — a loose `/<<'PY'/` pattern would start
-  # extraction at the first such mention (e.g. a comment explaining
-  # the heredoc) and pull in non-Python lines ahead of the real
-  # opener.
-  awk "/^[[:space:]]*cat >\"\\\$_ocw_meter_py\" <<'PY'\$/{flag=1; next} /^PY\$/{flag=0} flag" "$meter_script" >"$tmp_py"
+  # <<'PY' || die ...`, possibly indented), not prose that merely
+  # mentions `<<'PY'` in a comment — a loose `/<<'PY'/` pattern would
+  # start extraction at the first such mention (e.g. a comment
+  # explaining the heredoc) and pull in non-Python lines ahead of the
+  # real opener. No trailing `$` on the opener pattern: the line ends
+  # with `|| die "..."`, not right after `<<'PY'`.
+  awk "/^[[:space:]]*cat >\"\\\$_ocw_meter_py\" <<'PY'/{flag=1; next} /^PY\$/{flag=0} flag" "$meter_script" >"$tmp_py"
   if [ -s "$tmp_py" ]; then
     echo "  py_compile (extracted heredoc)"
     python3 -m py_compile "$tmp_py" || status=1

--- a/bin/tests/test_ocw.py
+++ b/bin/tests/test_ocw.py
@@ -514,6 +514,28 @@ class ExistingBehaviorRegressionTests(OcwTestCase):
         force_remove = run_ocw(["rm", "-f", "widget-maker"], self.repo_root)
         self.assertEqual(force_remove.returncode, 0, force_remove.stderr)
 
+    def test_remove_current_worktree_is_guarded(self):
+        create = run_ocw(["widget-maker"], self.repo_root)
+        self.assertEqual(create.returncode, 0, create.stderr)
+
+        worktree_dir = self.repo_root.parent / "widget-maker"
+        result = run_ocw(["rm", "widget-maker"], worktree_dir)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("do not remove the current worktree", result.stderr)
+
+        # The worktree is still there (removal was refused) — force-remove
+        # from main so this test doesn't leak a dangling worktree.
+        force_remove = run_ocw(["rm", "-f", "widget-maker"], self.repo_root)
+        self.assertEqual(force_remove.returncode, 0, force_remove.stderr)
+
+    def test_remove_other_worktree_from_main_is_not_guarded(self):
+        create = run_ocw(["widget-maker"], self.repo_root)
+        self.assertEqual(create.returncode, 0, create.stderr)
+
+        result = run_ocw(["rm", "widget-maker"], self.repo_root)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("do not remove the current worktree", result.stderr)
+
 
 class VscodeAutoLaunchRegressionTests(OcwTestCase):
     """Regression coverage for the incident where bin/ocw's open_vscode()

--- a/bin/tests/test_ocw_meter.py
+++ b/bin/tests/test_ocw_meter.py
@@ -1842,7 +1842,15 @@ class SymlinkInvocationTests(OcwMeterTestCase):
         hop1_dir.mkdir()
         hop2_dir.mkdir()
         hop1_link = hop1_dir / "ocw-meter"
-        hop1_link.symlink_to(os.path.relpath(OCW_METER, hop1_dir))
+        # `os.path.relpath` must be computed against hop1_dir's
+        # symlink-resolved physical location, not its as-given path:
+        # on macOS `$TMPDIR` sits under `/var/...`, itself a symlink to
+        # `/private/var/...`, so the two differ by one path component.
+        # The kernel resolves a relative symlink target against the
+        # physical directory it lives in, so an unresolved hop1_dir
+        # yields a target one `../` short and this link ends up
+        # pointing nowhere.
+        hop1_link.symlink_to(os.path.relpath(OCW_METER, hop1_dir.resolve()))
         hop2_link = hop2_dir / "ocw-meter"
         hop2_link.symlink_to(hop1_link)
 


### PR DESCRIPTION
## 背景

dotfilesは、macOS / Linux / WSL2 で共通の開発環境を再現するための設定リポジトリです。8b944bb（#48）のプルリクエストの説明で、`python3 -m unittest discover -s bin/tests -v` を実行すると9件の既知の失敗があると報告されていました（実測では10件でした。内訳は後述します）。これらはいずれもCI環境（Linux・GNU coreutils・bash 5系）では発生せず、ローカルのmacOS環境（BSD系コマンド・bash 3.2）でのみ発生する非互換の問題でした。

## このプルリクエストの目的

放置されていたこの10件の既知の失敗を解消します。

## 実装内容

- `bin/ocw` の684行目にある `realpath -m` を修正しました。`-m`（存在しないパスでも解決する）はGNU coreutilsの拡張オプションで、macOS標準の `/bin/realpath`（BSD版）には存在せず、実行時にエラーになっていました。同じ挙動を `cd -P` と `pwd -P` を組み合わせた自前の関数 `realpath_m()` として実装し、置き換えました。呼び出し側では、比較結果を一度変数に代入してから `if` で比較する形にしています（`if [[ "$(realpath_m ...)" == "$(realpath_m ...)" ]]` のようにコマンド置換をそのまま条件式に書くと、内部で失敗しても `set -e` が効かず、両方失敗すると空文字列同士の比較が真になって「今いるworktreeを消そうとしている」と誤判定してしまうため）。`realpath_m()` 自身も、親ディレクトリの解決に失敗した場合に嘘の絶対パスを返さないよう、失敗を明示的に検査しています。
- `bin/ocw-meter` に埋め込まれているPythonコードの呼び出し方法を修正しました。従来は「プロセス置換の中にヒアドキュメントを埋め込む」という構文（`python3 <(cat <<'PY' ... PY)`）を使っていましたが、macOS標準のbash（3.2系）はこの構文の組み合わせを正しく解析できず、構文エラーになっていました。Pythonコードを一時ファイル（`mktemp`）に書き出してから実行する方式に変更し、元の設計意図（標準入力を汚さないこと）は保ったまま解消しました。一時ファイルへの書き込み失敗も検査するようにしています。
- 上記の修正に合わせて、`bin/tests/lint.sh` の埋め込みPythonコード抽出パターンを新しい呼び出し方法に追従させました。また、`bash -n` によるチェックは実行時のPATH解決先（Homebrewのbash 5系など）に依存し、macOS標準の `/bin/bash`（3.2系）固有の構文エラーを検出できないため、`/bin/bash` が3.2系のときは同じチェックをそちらでも実行するブロックを追加しました。対象ファイルを列挙する処理は、2箇所での重複を避けるため関数に一元化しています。
- `bin/tests/test_ocw_meter.py` の `SymlinkInvocationTests` にあった、相対シンボリックリンクの構築ミスを修正しました。macOSでは一時ディレクトリ（`$TMPDIR`）が `/var/...` 配下にありますが、これは実体である `/private/var/...` へのシンボリックリンクです。テストコードがこの違いを考慮せずに相対パスを計算していたため、実際にシンボリックリンクを解決する際に1階層分ずれて壊れたリンクになっていました。
- `bin/tests/test_ocw.py` に、`ocw rm` の「今いるworktreeを消そうとしていないか」ガードを直接検証するテストを2件追加しました。この修正前は、ガード自体を直接見るテストが存在せず、10件のうち5件を占めていた `realpath -m` の障害（ガードが常時誤発火する状態）を検出できていませんでした。

### 10件の内訳

masterに各修正を1つずつ適用して切り分けました。

| 解消に必要な修正 | 件数 |
|---|---|
| `bin/ocw`（`realpath_m`）のみ | 5件 |
| `bin/ocw-meter`（呼び出し方法）のみ | 1件 |
| `bin/tests/test_ocw_meter.py`（相対symlinkの構築ミス）のみ | 1件 |
| `bin/ocw` と `bin/ocw-meter` の両方が必要 | 3件 |
| **合計** | **10件** |

## テスト結果

- `python3 -m unittest discover -s bin/tests -v`: 200件全て成功（既知の失敗10件はすべて解消し、新規テスト2件を含め新規の失敗なし）
- `pre-commit run --all-files`: 全項目Passed
- `bin/tests/lint.sh`: OK

## 自己レビュー

- 正当性: 依頼にあった既知の失敗（実測10件、内訳は上表）を全て特定し解消済み
- エッジケース: `realpath_m()` は対象パスが存在する場合・存在しない場合（親は存在）・親も存在しない場合（die）を確認済み。`bin/ocw-meter` の一時ファイルはtrapでEXIT時に確実に削除されることを確認済み
- テスト: 既存テストスイート200件（新規2件を含む）が全て成功することを確認。新規テストは `bin/tests/test_ocw.py` に、`ocw rm` の現在worktreeガードの発火・誤発火を検証する2件を追加
- 無関係変更: なし（変更は `bin/ocw` `bin/ocw-meter` `bin/tests/lint.sh` `bin/tests/test_ocw.py` `bin/tests/test_ocw_meter.py` の5ファイルのみ）
