### PR TITLE
bin/ocw: 設定リーダとリポジトリコンテキスト解決をbare/雛形対応に再構築

### DIFF
--- a/bin/ocw
+++ b/bin/ocw
@@ -190,8 +190,14 @@ worktree_cleanup_boundary=""
 #
 # `git config --get <key>` exits 1 for an unset key, which `set -e` would
 # otherwise treat as a script-ending failure — the `|| value="$default"`
-# catches exactly that case (and only that case; a genuinely broken
-# `.git/config` still surfaces as a fatal error to the caller).
+# is what stops that from killing the script. It is intentionally broader
+# than "unset key" alone: ANY non-zero exit (a malformed `.git/config`, a
+# key with multiple values) falls back to the default the same way, and
+# `2>/dev/null` suppresses git's own diagnostic either way. This keeps an
+# optional-config lookup from ever being fatal on its own — a broken
+# `.git/config` still surfaces to the caller, just via whichever *other*,
+# unsuppressed git invocation (e.g. `rev-parse --is-bare-repository` in
+# init_repo_context) hits it first, not via this function.
 ocw_config_get() {
   local key="$1"
   local default="${2:-}"
@@ -337,6 +343,16 @@ resolve_worktree_layout() {
   [ "$boundary_tmpl" != "$prefix" ] ||
     die "ocw.worktreeDir has no '/' before {name}, cannot determine a cleanup boundary: ${tmpl}"
 
+  # A leading '/' right before {name} (e.g. "/{name}") strips down to an
+  # empty boundary here, not a relative one -- that's the filesystem root,
+  # which the "must expand to an absolute path" check below wouldn't
+  # catch (an empty boundary that expands to "" still isn't a path at
+  # all, absolute or otherwise) and shouldn't be treated as interchangeable
+  # with it: the real problem is the cleanup boundary itself is undefined,
+  # not that the template is relative.
+  [ -n "$boundary_tmpl" ] ||
+    die "ocw.worktreeDir's cleanup boundary would be the filesystem root, which is not allowed: ${tmpl}"
+
   worktree_dir_template="$tmpl"
   worktree_cleanup_boundary="$(expand_worktree_dir_template "$boundary_tmpl" "")"
 
@@ -356,8 +372,13 @@ init_repo_context() {
   # itself when there's no worktree to be standing in.
   invocation_root="$(git rev-parse --show-toplevel 2>/dev/null)" || invocation_root=""
 
+  # Unlike invocation_root above, this failure is NOT expected in normal
+  # use (it means "not in a git repo" or something worse, like a broken
+  # `.git/config`) and always ends in die() below -- so stderr is left
+  # unsuppressed here, on purpose, so git's own diagnostic reaches the
+  # user instead of being replaced by our more generic message alone.
   repo_root="$(
-    git worktree list --porcelain 2>/dev/null |
+    git worktree list --porcelain |
       awk '
         /^worktree / {
           sub(/^worktree /, "")
@@ -892,15 +913,21 @@ remove_worktree() {
   echo "branch:    ${branch}"
   echo "force:     ${force}"
 
-  invocation_real="$(realpath_m "$invocation_root")"
-  worktree_real="$(realpath_m "$worktree_dir")"
+  # invocation_root is empty when ocw was invoked from inside a bare
+  # repository (ADR DOC-2608062258 §2.1/§3.10) -- there's no worktree to
+  # be "standing in", so the guard below has nothing to compare against
+  # and must be skipped rather than compared against an empty path.
+  if [ -n "$invocation_root" ]; then
+    invocation_real="$(realpath_m "$invocation_root")"
+    worktree_real="$(realpath_m "$worktree_dir")"
 
-  if [[ "$invocation_real" == "$worktree_real" ]]; then
-    echo "error: do not remove the current worktree" >&2
-    echo "move to main first:" >&2
-    echo "  cd ${repo_root}" >&2
-    echo "  ocw rm ${slug}" >&2
-    exit 1
+    if [[ "$invocation_real" == "$worktree_real" ]]; then
+      echo "error: do not remove the current worktree" >&2
+      echo "move to main first:" >&2
+      echo "  cd ${repo_root}" >&2
+      echo "  ocw rm ${slug}" >&2
+      exit 1
+    fi
   fi
 
   [ -d "$worktree_dir" ] ||

--- a/bin/ocw
+++ b/bin/ocw
@@ -191,13 +191,17 @@ worktree_cleanup_boundary=""
 # `git config --get <key>` exits 1 for an unset key, which `set -e` would
 # otherwise treat as a script-ending failure — the `|| value="$default"`
 # is what stops that from killing the script. It is intentionally broader
-# than "unset key" alone: ANY non-zero exit (a malformed `.git/config`, a
-# key with multiple values) falls back to the default the same way, and
-# `2>/dev/null` suppresses git's own diagnostic either way. This keeps an
+# than "unset key" alone: ANY non-zero exit (e.g. a malformed
+# `.git/config` — NOT a key with multiple values, which `git config --get`
+# resolves to its own last value at exit 0, bypassing this fallback
+# entirely) falls back to the default the same way, and `2>/dev/null`
+# suppresses git's own diagnostic either way. This keeps an
 # optional-config lookup from ever being fatal on its own — a broken
 # `.git/config` still surfaces to the caller, just via whichever *other*,
-# unsuppressed git invocation (e.g. `rev-parse --is-bare-repository` in
-# init_repo_context) hits it first, not via this function.
+# unsuppressed git invocation (e.g. `git worktree list --porcelain` in
+# init_repo_context, which runs — and would die on this — before
+# resolve_repo_name/resolve_worktree_layout ever call this function)
+# hits it first, not via this function.
 ocw_config_get() {
   local key="$1"
   local default="${2:-}"
@@ -344,12 +348,12 @@ resolve_worktree_layout() {
     die "ocw.worktreeDir has no '/' before {name}, cannot determine a cleanup boundary: ${tmpl}"
 
   # A leading '/' right before {name} (e.g. "/{name}") strips down to an
-  # empty boundary here, not a relative one -- that's the filesystem root,
-  # which the "must expand to an absolute path" check below wouldn't
-  # catch (an empty boundary that expands to "" still isn't a path at
-  # all, absolute or otherwise) and shouldn't be treated as interchangeable
-  # with it: the real problem is the cleanup boundary itself is undefined,
-  # not that the template is relative.
+  # empty boundary here, not a relative one -- that's the filesystem root.
+  # Left alone, an empty boundary would still get caught below by the
+  # "must expand to an absolute path" check (an empty string doesn't match
+  # the /* pattern either), but with the wrong label: it isn't relative,
+  # it's undefined. This dedicated check exists to die with the accurate
+  # reason before that mislabeled one would otherwise fire.
   [ -n "$boundary_tmpl" ] ||
     die "ocw.worktreeDir's cleanup boundary would be the filesystem root, which is not allowed: ${tmpl}"
 

--- a/bin/ocw
+++ b/bin/ocw
@@ -178,16 +178,186 @@ require_herdr_ready() {
 
 invocation_root=""
 repo_root=""
-project_dir=""
+repo_parent=""
 repo_name=""
+is_bare="false"
+worktree_dir_template=""
+worktree_cleanup_boundary=""
+
+# git config `ocw.*` reader. `.git/config` is shared by every worktree of a
+# repo (including bare), so whichever worktree ocw is invoked from sees the
+# same values. Must be called after repo_root is known.
+#
+# `git config --get <key>` exits 1 for an unset key, which `set -e` would
+# otherwise treat as a script-ending failure — the `|| value="$default"`
+# catches exactly that case (and only that case; a genuinely broken
+# `.git/config` still surfaces as a fatal error to the caller).
+ocw_config_get() {
+  local key="$1"
+  local default="${2:-}"
+  local value=""
+
+  value="$(git -C "$repo_root" config --get "$key" 2>/dev/null)" || value="$default"
+
+  printf '%s\n' "$value"
+}
+
+# Bool variant: `--type=bool --default=...` always exits 0, even for an
+# unset key (it prints the default instead), so no `|| true` is needed here
+# the way it is in ocw_config_get above.
+ocw_config_get_bool() {
+  local key="$1"
+  local default="$2"
+
+  git -C "$repo_root" config --get --type=bool --default="$default" "$key"
+}
+
+# repo_name resolution order (ADR DOC-2608062258 §3.6):
+#   1. ocw.repoName (explicit override)
+#   2. basename of remote.origin.url with a trailing .git stripped
+#   3. path-based guess: bare -> basename(repo_root) with .git stripped;
+#      basename(repo_root) in {main,master,trunk} -> basename(repo_parent)
+#      (current behavior, preserved); otherwise basename(repo_root)
+resolve_repo_name() {
+  local configured=""
+  local origin_url=""
+  local origin_base=""
+  local root_base=""
+
+  configured="$(ocw_config_get ocw.repoName "")"
+
+  if [ -n "$configured" ]; then
+    repo_name="$configured"
+    return
+  fi
+
+  origin_url="$(git -C "$repo_root" config --get remote.origin.url 2>/dev/null)" || origin_url=""
+
+  if [ -n "$origin_url" ]; then
+    origin_base="$(basename -- "$origin_url")"
+    origin_base="${origin_base%.git}"
+
+    if [ -n "$origin_base" ]; then
+      repo_name="$origin_base"
+      return
+    fi
+  fi
+
+  root_base="$(basename -- "$repo_root")"
+
+  if [ "$is_bare" = "true" ]; then
+    repo_name="${root_base%.git}"
+    return
+  fi
+
+  case "$root_base" in
+    main | master | trunk)
+      repo_name="$(basename -- "$repo_parent")"
+      ;;
+    *)
+      repo_name="$root_base"
+      ;;
+  esac
+}
+
+# Substitutes the known ocw.worktreeDir placeholders. `name` is passed
+# separately (rather than always pulled from a global) so the cleanup
+# boundary can be expanded with it left blank (ADR §2.9/§3.5).
+expand_worktree_dir_template() {
+  local tmpl="$1"
+  local name="${2:-}"
+  local result="$tmpl"
+
+  result="${result//\{repo_root\}/$repo_root}"
+  result="${result//\{repo_parent\}/$repo_parent}"
+  result="${result//\{repo\}/$repo_name}"
+  result="${result//\{name\}/$name}"
+
+  printf '%s\n' "$result"
+}
+
+# Reads, validates, and expands ocw.worktreeDir (ADR DOC-2608062258 §3.4 /
+# §3.5 / §2.9). Populates worktree_dir_template (raw, still containing
+# {name}) and worktree_cleanup_boundary (fully expanded, the path
+# `ocw rm`'s empty-directory cleanup must never delete past).
+resolve_worktree_layout() {
+  local tmpl=""
+  local rest=""
+  local placeholder=""
+  local token=""
+  local prefix=""
+  local boundary_tmpl=""
+
+  tmpl="$(ocw_config_get ocw.worktreeDir '{repo_parent}/{name}')"
+
+  # Leading `~` expands to $HOME. Matched via parameter expansion (not a
+  # case pattern) so the literal, unexpanded tilde in $tmpl is what's
+  # being compared -- shellcheck's SC2088 flags a quoted '~/'* case
+  # pattern as if it were a failed expansion attempt, which isn't what
+  # this is: the tilde here is user-supplied config text being tested,
+  # never a path bash itself should expand.
+  if [ "$tmpl" = '~' ]; then
+    tmpl="$HOME"
+  elif [ "${tmpl#\~/}" != "$tmpl" ]; then
+    tmpl="${HOME}/${tmpl#\~/}"
+  fi
+
+  # Reject unknown {placeholders} instead of leaving them as literal
+  # directory-name text — a typo like {rep_root} would otherwise silently
+  # create a directory literally named "{rep_root}".
+  rest="$tmpl"
+
+  while [[ "$rest" == *"{"*"}"* ]]; do
+    placeholder="${rest#*\{}"
+    placeholder="${placeholder%%\}*}"
+
+    case "$placeholder" in
+      repo_root | repo_parent | repo | name) ;;
+      *)
+        die "unknown placeholder {${placeholder}} in ocw.worktreeDir: ${tmpl}"
+        ;;
+    esac
+
+    token="{${placeholder}}"
+    rest="${rest#*"$token"}"
+  done
+
+  case "$tmpl" in
+    *'{name}'*) ;;
+    *)
+      die "ocw.worktreeDir must contain {name}: ${tmpl}"
+      ;;
+  esac
+
+  # The cleanup boundary is everything up to the last '/' before {name} —
+  # the longest prefix of the expanded path that doesn't depend on {name}.
+  prefix="${tmpl%%\{name\}*}"
+  boundary_tmpl="${prefix%/*}"
+
+  [ "$boundary_tmpl" != "$prefix" ] ||
+    die "ocw.worktreeDir has no '/' before {name}, cannot determine a cleanup boundary: ${tmpl}"
+
+  worktree_dir_template="$tmpl"
+  worktree_cleanup_boundary="$(expand_worktree_dir_template "$boundary_tmpl" "")"
+
+  case "$worktree_cleanup_boundary" in
+    /*) ;;
+    *)
+      die "ocw.worktreeDir must expand to an absolute path: ${tmpl}"
+      ;;
+  esac
+}
 
 init_repo_context() {
-  invocation_root="$(
-    git rev-parse --show-toplevel 2>/dev/null
-  )" || die "run ocw from inside a Git worktree"
+  # Unlike repo_root below, invocation_root is allowed to come back empty:
+  # `git rev-parse --show-toplevel` always fails inside a bare repository
+  # (ADR DOC-2608062258 §2.1), and its only consumer (remove_worktree's
+  # "don't remove the worktree you're standing in" guard) can simply skip
+  # itself when there's no worktree to be standing in.
+  invocation_root="$(git rev-parse --show-toplevel 2>/dev/null)" || invocation_root=""
 
   repo_root="$(
-    git -C "$invocation_root" worktree list --porcelain |
+    git worktree list --porcelain 2>/dev/null |
       awk '
         /^worktree / {
           sub(/^worktree /, "")
@@ -195,13 +365,17 @@ init_repo_context() {
           exit
         }
       '
-  )"
+  )" || repo_root=""
 
   [ -n "$repo_root" ] ||
-    die "could not determine the main worktree"
+    die "run ocw from inside a Git repository"
 
-  project_dir="$(dirname "$repo_root")"
-  repo_name="$(basename "$project_dir")"
+  is_bare="$(git -C "$repo_root" rev-parse --is-bare-repository)"
+
+  repo_parent="$(dirname -- "$repo_root")"
+
+  resolve_repo_name
+  resolve_worktree_layout
 }
 
 open_vscode() {
@@ -421,7 +595,15 @@ create_worktree() {
     base_ref="$(
       git -C "$repo_root" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null |
         sed 's|.*/||'
-    )"
+    )" || base_ref=""
+
+    # origin/HEAD is unset/unresolvable (no remote, or a remote without a
+    # HEAD symref) -> fall back to repo_root's own HEAD, which resolves in
+    # bare repos too (ADR DOC-2608062258 §3.10 / §2.3).
+    if [ -z "$base_ref" ]; then
+      base_ref="$(git -C "$repo_root" symbolic-ref --short HEAD 2>/dev/null)" || base_ref=""
+    fi
+
     [ -n "$base_ref" ] || base_ref="main"
   fi
 
@@ -444,7 +626,7 @@ create_worktree() {
     die "worktree name became empty"
 
   branch="ai/${slug}"
-  worktree_dir="${project_dir}/${slug}"
+  worktree_dir="$(expand_worktree_dir_template "$worktree_dir_template" "$slug")"
   workspace_label="${repo_name} / ${slug}"
 
   echo "repo:        ${repo_name}"
@@ -703,7 +885,7 @@ remove_worktree() {
     die "worktree name became empty"
 
   branch="ai/${slug}"
-  worktree_dir="${project_dir}/${slug}"
+  worktree_dir="$(expand_worktree_dir_template "$worktree_dir_template" "$slug")"
 
   echo "repo:      ${repo_name}"
   echo "remove:    ${worktree_dir}"

--- a/bin/tests/test_ocw.py
+++ b/bin/tests/test_ocw.py
@@ -162,6 +162,23 @@ def set_config(repo_dir, key, value):
     _git(["config", key, value], repo_dir)
 
 
+def make_repo_without_origin(root, dir_name="main"):
+    """A minimal git repo at <root>/<dir_name> with one commit and no
+    `origin` remote at all -- exercises repo_name's third resolution step
+    (ADR DOC-2608062258 §3.6, the path-based guess), which make_repo()
+    can never reach since it always configures an origin remote.
+    """
+    repo_dir = pathlib.Path(root) / dir_name
+    repo_dir.mkdir(parents=True)
+    _git(["init", "-q", "-b", "main"], repo_dir)
+    _git(["config", "user.email", "test@example.invalid"], repo_dir)
+    _git(["config", "user.name", "Test"], repo_dir)
+    (repo_dir / "README.md").write_text("test\n", encoding="utf-8")
+    _git(["add", "README.md"], repo_dir)
+    _git(["commit", "-q", "-m", "initial"], repo_dir)
+    return repo_dir
+
+
 def run_ocw(args, cwd, meter_on_path=False, meter_home=None, extra_env=None, path_prepend=None, timeout=30):
     # _CODE_SHIM_DIR goes ahead of BASE_PATH_DIRS (see its module-level
     # comment) so the no-op `code` always wins over a real one that might
@@ -188,6 +205,20 @@ def run_ocw(args, cwd, meter_on_path=False, meter_home=None, extra_env=None, pat
     # `code`, and ocw refusing to invoke it at all) mean a regression in
     # either one alone still can't launch a real VS Code window.
     env["OCW_NO_VSCODE"] = "1"
+    # Also unconditional and after extra_env: bin/ocw now reads git config
+    # `ocw.*` (ocw_config_get()), which resolves through the normal
+    # system/global/local layering. Without this, a developer's own
+    # `~/.gitconfig` (a real, plausible place to put `ocw.worktreeDir` per
+    # ADR DOC-2608062258 §3.4's own "put a personal default in --global"
+    # rationale) would leak into every test in this file and change where
+    # worktrees get created — verified by reproducing a `[ocw]
+    # worktreeDir = ...` block in a throwaway $HOME and watching
+    # test_default_template_matches_current_layout fail. This is
+    # independent of HOME: the tilde-expansion test overrides HOME via
+    # extra_env, and GIT_CONFIG_GLOBAL/SYSTEM are what git actually reads
+    # for global/system config regardless of $HOME.
+    env["GIT_CONFIG_GLOBAL"] = "/dev/null"
+    env["GIT_CONFIG_SYSTEM"] = "/dev/null"
     return subprocess.run(
         [str(OCW), *args],
         cwd=str(cwd),
@@ -717,6 +748,21 @@ class BareRepoTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(extract_repo_name(result.stdout), "proj")
 
+    def test_rm_works_from_bare_repo(self):
+        # A bare repo is the only place invocation_root comes back empty
+        # (ADR §2.1/§3.10) -- this is the one black-box path that actually
+        # exercises remove_worktree()'s guard-skip for that case, not just
+        # create_worktree()'s bare handling covered above.
+        create = run_ocw(["widget-maker"], self.bare_dir)
+        self.assertEqual(create.returncode, 0, create.stderr)
+
+        worktree_dir = self.bare_dir.parent / "widget-maker"
+        self.assertTrue(worktree_dir.is_dir())
+
+        remove = run_ocw(["rm", "widget-maker"], self.bare_dir)
+        self.assertEqual(remove.returncode, 0, remove.stderr)
+        self.assertFalse(worktree_dir.exists())
+
 
 class RepoNameResolutionTests(OcwTestCase):
     """repo_name 解決順 (ADR DOC-2608062258 §3.6): ocw.repoName > origin URL
@@ -735,6 +781,28 @@ class RepoNameResolutionTests(OcwTestCase):
         result = run_ocw(["widget-maker"], self.repo_root)
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(extract_repo_name(result.stdout), "origin")
+
+
+class RepoNamePathGuessTests(unittest.TestCase):
+    """repo_name 解決順の第3段（パスからの推測、ADR DOC-2608062258 §3.6）の
+    非 bare 側2分岐。make_repo() は常に origin remote を張るためどちらの
+    分岐にも到達できず、専用に origin 無しリポジトリを使う。"""
+
+    def test_main_named_dir_uses_parent_dir_name(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_dir = make_repo_without_origin(tmp, dir_name="main")
+
+            result = run_ocw(["widget-maker"], repo_dir)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(extract_repo_name(result.stdout), pathlib.Path(tmp).name)
+
+    def test_non_special_dir_name_is_used_as_is(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_dir = make_repo_without_origin(tmp, dir_name="myrepo")
+
+            result = run_ocw(["widget-maker"], repo_dir)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(extract_repo_name(result.stdout), "myrepo")
 
 
 class WorktreeDirTemplateTests(OcwTestCase):
@@ -761,6 +829,37 @@ class WorktreeDirTemplateTests(OcwTestCase):
         worktree_dir = self.repo_root / ".worktrees" / "widget-maker"
         self.assertTrue(worktree_dir.is_dir())
         self.assertFalse((self.repo_root.parent / "widget-maker").exists())
+
+    def test_nested_template_round_trips_through_remove(self):
+        # remove_worktree() computes worktree_dir through the same template
+        # expansion as create_worktree() (孫1 プロンプト項目5) -- this is
+        # the one black-box test that would fail if that wiring were
+        # reverted back to a hardcoded {repo_parent}/{name} path while
+        # create_worktree() kept using the template.
+        set_config(self.repo_root, "ocw.worktreeDir", "{repo_root}/.worktrees/{name}")
+
+        create = run_ocw(["widget-maker"], self.repo_root)
+        self.assertEqual(create.returncode, 0, create.stderr)
+
+        worktree_dir = self.repo_root / ".worktrees" / "widget-maker"
+        self.assertTrue(worktree_dir.is_dir())
+
+        remove = run_ocw(["rm", "widget-maker"], self.repo_root)
+        self.assertEqual(remove.returncode, 0, remove.stderr)
+        self.assertFalse(worktree_dir.exists())
+
+    def test_prefixed_name_template_places_worktree_correctly(self):
+        # {name} isn't its own path component here -- exercises the
+        # non-trivial cleanup-boundary recompute for this exact ADR §2.9
+        # table row ({repo_parent}/{repo}-{name} -> boundary {repo_parent}).
+        set_config(self.repo_root, "ocw.worktreeDir", "{repo_parent}/{repo}-{name}")
+
+        result = run_ocw(["widget-maker"], self.repo_root)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        # repo_name derives from make_repo()'s origin remote (origin.git).
+        worktree_dir = self.repo_root.parent / "origin-widget-maker"
+        self.assertTrue(worktree_dir.is_dir())
 
     def test_tilde_expansion(self):
         # HOME is swapped to a tempdir for this one process invocation
@@ -797,6 +896,27 @@ class WorktreeDirTemplateTests(OcwTestCase):
         result = run_ocw(["widget-maker"], self.repo_root)
         self.assertNotEqual(result.returncode, 0)
         self.assertFalse((self.repo_root.parent / "relative").exists())
+
+    def test_name_alone_dies_with_no_boundary_message(self):
+        # Distinct die branch from test_relative_template_dies above: with
+        # no '/' anywhere before {name}, the cleanup boundary can't be
+        # computed at all (ADR §2.9's "{name}" row) -- a different failure
+        # than "expands to a relative path".
+        set_config(self.repo_root, "ocw.worktreeDir", "{name}")
+
+        result = run_ocw(["widget-maker"], self.repo_root)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("no '/' before {name}", result.stderr)
+
+    def test_root_boundary_template_dies_with_specific_message(self):
+        # "/{name}" is itself an absolute path, but its cleanup boundary
+        # collapses to the filesystem root -- a different failure than
+        # "not absolute", and must say so.
+        set_config(self.repo_root, "ocw.worktreeDir", "/{name}")
+
+        result = run_ocw(["widget-maker"], self.repo_root)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("filesystem root", result.stderr)
 
 
 if __name__ == "__main__":

--- a/bin/tests/test_ocw.py
+++ b/bin/tests/test_ocw.py
@@ -77,6 +77,7 @@ _code_shim_path.write_text(
 _code_shim_path.chmod(0o755)
 
 RUN_LINE_RE = re.compile(r"^run:\s+(\S+)$", re.MULTILINE)
+REPO_LINE_RE = re.compile(r"^repo:\s+(\S+)$", re.MULTILINE)
 
 
 def _git(args, cwd):
@@ -124,6 +125,41 @@ def make_repo(root):
     _git(["push", "-q", "-u", "origin", "main"], main_dir)
     _git(["remote", "set-head", "origin", "main"], main_dir)
     return main_dir
+
+
+def make_bare_repo(root, name="proj.git"):
+    """A bare repo at <root>/<name> with one commit on branch `main`, and
+    (deliberately) no `origin` remote of its own — this mirrors what a
+    real bare repo used as *someone else's* origin looks like from the
+    inside (ADR DOC-2608062258 §2.2/§2.3): `git worktree list --porcelain`
+    has exactly one entry (the bare dir itself, with a `bare` line instead
+    of `branch`), and `git symbolic-ref HEAD` resolves to the default
+    branch. With no `ocw.worktreeDir` override, ocw's default template
+    (`{repo_parent}/{name}`) puts worktrees at dirname(repo_root)/<name> —
+    i.e. right next to the bare directory, exercising the same "no
+    `origin/HEAD` to fall back to" base_ref path bin/ocw's create_worktree
+    has to survive (ADR §3.10).
+    """
+    bare_dir = pathlib.Path(root) / name
+    _git(["init", "-q", "--bare", "-b", "main", str(bare_dir)], root)
+
+    with tempfile.TemporaryDirectory() as scratch_root:
+        scratch_dir = pathlib.Path(scratch_root) / "scratch"
+        scratch_dir.mkdir()
+        _git(["init", "-q", "-b", "main"], scratch_dir)
+        _git(["config", "user.email", "test@example.invalid"], scratch_dir)
+        _git(["config", "user.name", "Test"], scratch_dir)
+        (scratch_dir / "README.md").write_text("test\n", encoding="utf-8")
+        _git(["add", "README.md"], scratch_dir)
+        _git(["commit", "-q", "-m", "initial"], scratch_dir)
+        _git(["remote", "add", "origin", str(bare_dir)], scratch_dir)
+        _git(["push", "-q", "-u", "origin", "main"], scratch_dir)
+
+    return bare_dir
+
+
+def set_config(repo_dir, key, value):
+    _git(["config", key, value], repo_dir)
 
 
 def run_ocw(args, cwd, meter_on_path=False, meter_home=None, extra_env=None, path_prepend=None, timeout=30):
@@ -177,6 +213,12 @@ def read_events(home):
 def extract_run_id(stdout):
     match = RUN_LINE_RE.search(stdout)
     assert match, f"no 'run:' line found in stdout:\n{stdout}"
+    return match.group(1)
+
+
+def extract_repo_name(stdout):
+    match = REPO_LINE_RE.search(stdout)
+    assert match, f"no 'repo:' line found in stdout:\n{stdout}"
     return match.group(1)
 
 
@@ -634,6 +676,127 @@ class VscodeAutoLaunchRegressionTests(OcwTestCase):
             text=True,
             timeout=30,
         )
+
+
+class BareRepoTests(unittest.TestCase):
+    """bare リポジトリ対応 (ADR DOC-2608062258 §2.1/§2.2/§2.3, 孫1 プロンプト項目2)."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.bare_dir = make_bare_repo(self.tmpdir.name)
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_create_from_bare_repo_creates_sibling_worktree(self):
+        result = run_ocw(["widget-maker"], self.bare_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        worktree_dir = self.bare_dir.parent / "widget-maker"
+        self.assertTrue(worktree_dir.is_dir())
+        # make_bare_repo() deliberately configures no origin remote of its
+        # own, so there's no origin/HEAD to resolve base_ref from -- it
+        # must fall back to repo_root's own HEAD (ADR §3.10) instead of
+        # blowing up under set -euo pipefail.
+        self.assertIn("base:        main", result.stdout)
+
+    def test_ls_works_from_bare_repo(self):
+        create = run_ocw(["widget-maker"], self.bare_dir)
+        self.assertEqual(create.returncode, 0, create.stderr)
+
+        result = run_ocw(["ls"], self.bare_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("(bare)", result.stdout)
+        self.assertIn("widget-maker", result.stdout)
+
+    def test_repo_name_strips_dot_git_suffix_for_bare_repo(self):
+        # No ocw.repoName and no origin remote -> falls all the way to the
+        # path-based guess, which for a bare repo strips ".git" off the
+        # directory's own basename (ADR §3.6 step 3).
+        result = run_ocw(["widget-maker"], self.bare_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(extract_repo_name(result.stdout), "proj")
+
+
+class RepoNameResolutionTests(OcwTestCase):
+    """repo_name 解決順 (ADR DOC-2608062258 §3.6): ocw.repoName > origin URL
+    の basename > パス推測。"""
+
+    def test_ocw_repo_name_config_wins(self):
+        set_config(self.repo_root, "ocw.repoName", "custom-name")
+
+        result = run_ocw(["widget-maker"], self.repo_root)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(extract_repo_name(result.stdout), "custom-name")
+
+    def test_repo_name_derives_from_origin_url_when_unset(self):
+        # make_repo()'s origin remote is <root>/origin.git -> basename with
+        # ".git" stripped is "origin".
+        result = run_ocw(["widget-maker"], self.repo_root)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(extract_repo_name(result.stdout), "origin")
+
+
+class WorktreeDirTemplateTests(OcwTestCase):
+    """ocw.worktreeDir の雛形展開・検証・掃除境界の逆算 (ADR DOC-2608062258
+    §3.4 / §3.5 / §2.9)."""
+
+    def test_default_template_matches_current_layout(self):
+        # No ocw.worktreeDir set: the default `{repo_parent}/{name}` must
+        # produce exactly the pre-孫1 hardcoded dirname(repo_root)/<slug>
+        # path -- the completion condition's "unchanged default behavior"
+        # made into its own explicit assertion.
+        result = run_ocw(["widget-maker"], self.repo_root)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        worktree_dir = self.repo_root.parent / "widget-maker"
+        self.assertTrue(worktree_dir.is_dir())
+
+    def test_nested_template_changes_creation_location(self):
+        set_config(self.repo_root, "ocw.worktreeDir", "{repo_root}/.worktrees/{name}")
+
+        result = run_ocw(["widget-maker"], self.repo_root)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        worktree_dir = self.repo_root / ".worktrees" / "widget-maker"
+        self.assertTrue(worktree_dir.is_dir())
+        self.assertFalse((self.repo_root.parent / "widget-maker").exists())
+
+    def test_tilde_expansion(self):
+        # HOME is swapped to a tempdir for this one process invocation
+        # only -- the real $HOME is never touched.
+        fake_home = pathlib.Path(self.tmpdir.name) / "fake-home"
+        fake_home.mkdir()
+        set_config(self.repo_root, "ocw.worktreeDir", "~/.cache/ocw/{repo}/{name}")
+
+        result = run_ocw(["widget-maker"], self.repo_root, extra_env={"HOME": str(fake_home)})
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        # repo_name derives from make_repo()'s origin remote (origin.git).
+        worktree_dir = fake_home / ".cache" / "ocw" / "origin" / "widget-maker"
+        self.assertTrue(worktree_dir.is_dir())
+
+    def test_unknown_placeholder_dies_naming_the_key(self):
+        set_config(self.repo_root, "ocw.worktreeDir", "{nope}/{name}")
+
+        result = run_ocw(["widget-maker"], self.repo_root)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("{nope}", result.stderr)
+        self.assertFalse((self.repo_root.parent / "widget-maker").exists())
+
+    def test_template_without_name_placeholder_dies(self):
+        set_config(self.repo_root, "ocw.worktreeDir", "{repo_parent}/fixed")
+
+        result = run_ocw(["widget-maker"], self.repo_root)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("{name}", result.stderr)
+
+    def test_relative_template_dies(self):
+        set_config(self.repo_root, "ocw.worktreeDir", "relative/{name}")
+
+        result = run_ocw(["widget-maker"], self.repo_root)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse((self.repo_root.parent / "relative").exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 背景

`ocw` は git worktree を作るためのツールですが、これまで「ブランチ名は必ず `ai/<slug>`」「ワークツリー名にスラッシュを入れられない」「`<project>/main` + 兄弟ワークツリーというレイアウト固定」「マージ済み判定は ancestry のみ」の4つをハードコードで前提にしていました。この4つを外部化・再定義する傘ブランチ `ai/ocw-naming-and-layout` の1本目の作業です。

方式の比較検討は ADR DOC-2608062258（`docs/adr/DOC-2608062258_ocw-worktree-naming-and-layout.md`）で確定済みです。

## このプルリクエストの目的

`ocw` の設定機構（git config `ocw.*`）とリポジトリコンテキストの解決を再構築します。命名（`ai/` 接頭辞・スラッシュ対応）と `ocw rm` の逆引き解決・マージ判定の再定義は別の孫ブランチの担当であり、このプルリクエストのスコープには含みません。

## 実装内容

- git config `ocw.*` を読む共通ヘルパ（`ocw_config_get` / `ocw_config_get_bool`）を新設しました
- `init_repo_context()` を bare リポジトリ対応に作り直しました
  - `invocation_root`（今いる worktree）は取れなくてもよい値にし、bare リポジトリの中から実行しても即座には落ちないようにしました
  - `repo_root` の取得を `git worktree list --porcelain` の先頭エントリからの逆引き一本にまとめ、bare 判定を追加しました
- `repo_name` の解決順を「`ocw.repoName` 設定 > origin URL の basename > パスからの推測（bare は `.git` を剥がす、`main`/`master`/`trunk` なら親ディレクトリ名を使う）」に変更しました。以前は常にワークツリーの親ディレクトリ名を使っていたため、bare 構成では意図しない名前になっていました
- `ocw.worktreeDir` というフルパス雛形1本でワークツリーの配置先を表現できるようにしました
  - プレースホルダは `{repo_root}` `{repo_parent}` `{repo}` `{name}` の4つ
  - 先頭の `~` は `$HOME` に展開します
  - 未知のプレースホルダ（例: `{nope}`）はタイプミスとして検出し停止します
  - `{name}` を含まない雛形、展開後に相対パスになる雛形も停止します
  - 将来 `ocw rm` が空ディレクトリを掃除する際の境界（`{name}` より前の最後の `/` まで）もここで計算しています
- `create_worktree` / `remove_worktree` のワークツリーパス計算を、上記の雛形展開経由に繋ぎ替えました
- ワークツリー作成時の基準ブランチ（`base_ref`）の既定値解決に、origin の HEAD が引けない場合のフォールバック（リポジトリ自身の HEAD）を追加しました。bare リポジトリで origin remote を持たない構成でも動作します

**設定を何も変更しない場合の挙動は現行と完全に同一です。** ワークツリーの作成先パスは既定 `{repo_parent}/{name}` であり、これは変更前のハードコードされたパスと一致します。

## レビューで見てほしいところ

- `resolve_repo_name()` の解決順（`ocw.repoName` > origin URL > パス推測）について、origin remote が設定されている実運用環境（`git clone` した通常のチェックアウト）では、これまでの「親ディレクトリ名」から「origin リポジトリ名」に表示名が変わります。パスにも動作にも影響しない表示専用の変更ですが、意図した仕様変更か確認をお願いします（ADR §3.6 で確定済みの決定です）
- `ocw.worktreeDir` の `~` 展開部分は、`case` パターンでの実装だと shellcheck の SC2088（「引用符内の `~` は展開されない」）警告が誤検知として出たため、パラメータ展開ベースの実装に変更しています。抑制ディレクティブは使わず構造を変えて解消しました
- `resolve_worktree_layout()` の掃除境界（`worktree_cleanup_boundary`）は今回のプルリクエストでは計算するのみで、実際の掃除処理（`ocw rm` 側）はまだ使っていません。次の孫ブランチで使われる想定です

## テスト結果

- `pre-commit run --all-files`: 全て通過
- `python3 -m unittest discover -s bin/tests -v`: 211件（既存193件 + 追加18件）全て通過
- `bin/tests/lint.sh`: 通過
- `tests/deploy_smoke.sh`: 全チェック合格（`bin/ocw` を触ったため実行）

## 今後の予定

この傘ブランチの残りの作業として、命名規則の変更（`ai/` 接頭辞廃止・スラッシュ対応）、`ocw rm` の逆引き解決とマージ判定の再定義、関連文書の更新が続きます。

## 自己レビュー

- 正当性: 計画書「孫1用プロンプト」の項目1〜6（設定リーダ・bare対応・repo_name解決順・雛形展開/検証/掃除境界逆算・呼び出し側の繋ぎ替え・base_refのbare対応）を全て実装。命名（`ai/` 接頭辞・スラッシュ）と `ocw rm` の逆引き解決は計画書どおりスコープ外として未着手
- エッジケース: 空/未設定の設定キー・bareリポジトリでのorigin不在・`~`単体/`~/`以下・未知プレースホルダ・`{name}`欠落・相対パス・`set -euo pipefail`下でのコマンド失敗（実装中に `symbolic-ref refs/remotes/origin/HEAD` の失敗が捕捉されておらずスクリプトが無言で落ちるバグを実機確認で発見し修正済み）を確認
- テスト: 211 examples, 0 failures（既存193件 + 追加18件）。追加テストは bare作成/ls/repo_name、雛形展開の正常系・異常系、repo_name解決順の3ルートをカバー
- 無関係変更: なし（`bin/ocw` と `bin/tests/test_ocw.py` のみ）
