### PR TITLE
bin/ocw: ocw rmをporcelain逆引き解決に、マージ済み判定をsquash対応に再定義

### DIFF
--- a/bin/ocw
+++ b/bin/ocw
@@ -1303,15 +1303,24 @@ remove_worktree() {
     # doesn't disappear with it. `git -C "$worktree_dir" status` against a
     # nonexistent directory fails with a raw `fatal:` on stderr, and its
     # empty stdout is otherwise indistinguishable from "clean": guard on
-    # -d first so a stale registration is reported plainly and cleaned up
-    # (worktree remove below, no branch/file changes to lose) instead of
+    # -d first so a missing directory is reported plainly instead of
     # leaking git's own diagnostic and reading a failure as "no changes".
+    # This only decides whether the status check itself runs -- whether
+    # the worktree's registration actually gets removed is still decided
+    # by the merge-check gate right below, same as when the directory is
+    # present.
     if [ -d "$worktree_dir" ]; then
       if [ -n "$(git -C "$worktree_dir" status --porcelain)" ]; then
         die "worktree has uncommitted or untracked changes: ${worktree_dir}"
       fi
     else
-      warn "worktree directory is already gone; cleaning up its registration: ${worktree_dir}"
+      # States only what is true right now (the directory is gone, so
+      # there is nothing to run `status` against) rather than promising
+      # the registration will be cleaned up -- the case below can still
+      # `die` on the merge-check result before that ever happens, and a
+      # message describing a future action that didn't occur would be a
+      # lie about the actual outcome.
+      warn "worktree directory is already gone; skipping the local-changes check: ${worktree_dir}"
     fi
 
     case "$MERGE_CHECK_RESULT" in

--- a/bin/ocw
+++ b/bin/ocw
@@ -742,6 +742,12 @@ create_worktree() {
     # raw bash error onto ocw's real stderr despite the trailing `|| true`
     # protecting the exit code.
     printf '%s\n' "$run_id" 2>/dev/null >"${worktree_git_dir}/ocw-run-id" || true
+
+    # Persisted so `ocw rm` can use it as a merge-check candidate (ADR
+    # DOC-2608062258 §3.7 candidate 2): a worktree branched off an umbrella
+    # branch is never an ancestor of `main`, only of the umbrella it was
+    # actually created from. Same fail-open rationale as ocw-run-id above.
+    printf '%s\n' "$base_ref" 2>/dev/null >"${worktree_git_dir}/ocw-base-ref" || true
   fi
 
   echo "run:         ${run_id}"
@@ -917,6 +923,279 @@ close_herdr_workspaces_for_checkout() {
   done <<<"$workspace_ids"
 }
 
+# Reverse-lookup source for `ocw rm` (ADR DOC-2608062258 §3.9). Emits
+# `path<TAB>branch` for every worktree except the main worktree and any
+# `bare` entry -- neither is ever a removal candidate. `branch` comes out
+# empty for a `detached` entry (no `branch` line in porcelain output).
+worktree_entries() {
+  local line="" path="" branch="" bare="false"
+
+  while IFS= read -r line; do
+    case "$line" in
+      "worktree "*)
+        if [ -n "$path" ] && [ "$bare" != "true" ] && [ "$path" != "$repo_root" ]; then
+          printf '%s\t%s\n' "$path" "$branch"
+        fi
+        path="${line#worktree }"
+        branch=""
+        bare="false"
+        ;;
+      "branch refs/heads/"*)
+        branch="${line#branch refs/heads/}"
+        ;;
+      "bare")
+        bare="true"
+        ;;
+      *) ;;
+    esac
+  done < <(git -C "$repo_root" worktree list --porcelain)
+
+  if [ -n "$path" ] && [ "$bare" != "true" ] && [ "$path" != "$repo_root" ]; then
+    printf '%s\t%s\n' "$path" "$branch"
+  fi
+}
+
+# Resolves `ocw rm`'s input against worktree_entries() via 3 staged match
+# rules (ADR §3.9), taking the first stage that produces >=1 hit. Never
+# guesses among multiple hits in the same stage -- `rm` is destructive, so
+# ambiguity is reported and the caller must be more specific. On success,
+# sets the globals RESOLVED_WORKTREE_DIR / RESOLVED_BRANCH. Input is matched
+# literally (not normalized) -- the caller typed a name that already exists.
+#
+# Candidates accumulate as newline-separated "path<TAB>branch" strings
+# rather than bash arrays: this file must stay bash-3.2-compatible (macOS
+# stock /bin/bash -- see docs/design/DOC-2608020715-a_.../シェルスクリプト
+# コーディング方針.md and PR #49), and under `set -u` bash <4.4 raises
+# "unbound variable" merely from expanding a *zero-element* array
+# (`"${arr[@]}"`/`"${#arr[@]}"`), which stage counts of 0 are the normal
+# case here.
+resolve_removal_target() {
+  local task_name="$1"
+  local entries="" path="" branch="" rel=""
+  local stage1="" stage2="" stage3=""
+  local stage1_count=0 stage2_count=0 stage3_count=0
+
+  entries="$(worktree_entries)"
+
+  while IFS=$'\t' read -r path branch; do
+    [ -n "$path" ] || continue
+
+    rel=""
+    case "$path" in
+      "$worktree_cleanup_boundary"/*)
+        rel="${path#"$worktree_cleanup_boundary"/}"
+        ;;
+    esac
+
+    # Stage 1: exact branch name, exact absolute path, or path relative to
+    # the worktreeDir template's cleanup boundary (ADR §2.9).
+    if { [ -n "$branch" ] && [ "$branch" = "$task_name" ]; } ||
+      [ "$path" = "$task_name" ] ||
+      { [ -n "$rel" ] && [ "$rel" = "$task_name" ]; }; then
+      stage1="${stage1}${path}"$'\t'"${branch}"$'\n'
+      stage1_count=$((stage1_count + 1))
+    fi
+
+    # Stage 2: directory basename.
+    if [ "$(basename -- "$path")" = "$task_name" ]; then
+      stage2="${stage2}${path}"$'\t'"${branch}"$'\n'
+      stage2_count=$((stage2_count + 1))
+    fi
+
+    # Stage 3: branch ends with "/<input>" -- the pre-孫2 `ai/` prefix
+    # migration rescue (ADR §3.1/§3.9): `ocw rm foo` must still find a
+    # worktree still on a legacy `ai/foo` branch.
+    case "$branch" in
+      *"/${task_name}")
+        stage3="${stage3}${path}"$'\t'"${branch}"$'\n'
+        stage3_count=$((stage3_count + 1))
+        ;;
+    esac
+  done <<<"$entries"
+
+  local candidates="" candidate_count=0
+
+  if [ "$stage1_count" -gt 0 ]; then
+    candidates="$stage1"
+    candidate_count="$stage1_count"
+  elif [ "$stage2_count" -gt 0 ]; then
+    candidates="$stage2"
+    candidate_count="$stage2_count"
+  elif [ "$stage3_count" -gt 0 ]; then
+    candidates="$stage3"
+    candidate_count="$stage3_count"
+  fi
+
+  [ "$candidate_count" -gt 0 ] ||
+    die "no worktree found matching '${task_name}'"
+
+  if [ "$candidate_count" -gt 1 ]; then
+    {
+      echo "error: '${task_name}' matches multiple worktrees:"
+      while IFS=$'\t' read -r path branch; do
+        [ -n "$path" ] || continue
+        printf '  %s (branch: %s)\n' "$path" "${branch:-<detached>}"
+      done <<<"$candidates"
+    } >&2
+    exit 1
+  fi
+
+  IFS=$'\t' read -r RESOLVED_WORKTREE_DIR RESOLVED_BRANCH <<<"$candidates"
+}
+
+# Appends $1 to BASE_REF_CANDIDATES (a newline-separated string, not a bash
+# array -- see resolve_removal_target's comment on why) iff it resolves to a
+# real commit, silently skipping unset/unresolvable candidates (ADR §3.7's
+# "解決できない候補は黙って飛ばす").
+add_merge_candidate_if_resolvable() {
+  local candidate="$1"
+
+  [ -n "$candidate" ] || return 0
+
+  git -C "$repo_root" rev-parse --verify --quiet "${candidate}^{commit}" >/dev/null 2>&1 ||
+    return 0
+
+  BASE_REF_CANDIDATES="${BASE_REF_CANDIDATES}${candidate}"$'\n'
+}
+
+# Builds the integration-ref candidate list, in priority order (ADR
+# DOC-2608062258 §3.7): configured override, the worktree's own creation-time
+# base, the "current checkout" default this replaces, then origin/HEAD as a
+# last resort for a stale local checkout.
+collect_merge_candidates() {
+  local branch="$1"
+  local worktree_git_dir="$2"
+  local configured="" base_ref_file="" head_candidate="" origin_head=""
+
+  BASE_REF_CANDIDATES=""
+
+  configured="$(ocw_config_get ocw.mergedInto "")"
+  add_merge_candidate_if_resolvable "$configured"
+
+  if [ -n "$worktree_git_dir" ] && [ -f "${worktree_git_dir}/ocw-base-ref" ]; then
+    base_ref_file="$(cat "${worktree_git_dir}/ocw-base-ref")"
+  fi
+  add_merge_candidate_if_resolvable "$base_ref_file"
+
+  if [ "$is_bare" = "true" ]; then
+    head_candidate="$(git -C "$repo_root" symbolic-ref --short HEAD 2>/dev/null)" || head_candidate=""
+  else
+    # Literal "HEAD", resolved via `-C "$repo_root"` below -- this preserves
+    # the pre-孫3 behavior of comparing against whatever the main worktree
+    # currently has checked out (ADR §3.10).
+    head_candidate="HEAD"
+  fi
+  add_merge_candidate_if_resolvable "$head_candidate"
+
+  origin_head="$(git -C "$repo_root" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null)" || origin_head=""
+  add_merge_candidate_if_resolvable "$origin_head"
+}
+
+# ADR §2.7's squash-detection recipe: a squash merge never lands $branch's
+# commits in $candidate's history, so ancestry can't see it, but the tree it
+# would have produced as one commit still shows up as an already-applied
+# patch-id via `git cherry`. Each step is guarded individually with its own
+# `|| return 1` -- under `set -e`, a mid-function failure would otherwise
+# abort the whole script even though the caller only tests this function's
+# final exit status (`if squash_merged ...`). Any failure here means "could
+# not detect", not "not merged" -- callers must keep trying other candidates
+# rather than concluding unmerged from this alone.
+squash_merged() {
+  local branch="$1"
+  local candidate="$2"
+  local base="" tree="" dangling="" cherry_output=""
+
+  base="$(git -C "$repo_root" merge-base "$candidate" "$branch" 2>/dev/null)" || return 1
+  tree="$(git -C "$repo_root" rev-parse "${branch}^{tree}" 2>/dev/null)" || return 1
+  dangling="$(
+    GIT_AUTHOR_NAME=ocw GIT_AUTHOR_EMAIL=ocw@invalid \
+      GIT_COMMITTER_NAME=ocw GIT_COMMITTER_EMAIL=ocw@invalid \
+      git -C "$repo_root" commit-tree "$tree" -p "$base" -m _ 2>/dev/null
+  )" || return 1
+  cherry_output="$(git -C "$repo_root" cherry "$candidate" "$dangling" 2>/dev/null)" || return 1
+
+  case "$cherry_output" in
+    -*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# `ocw.githubMergeCheck` opt-in (ADR §3.7c). Fail-open: any `gh` failure
+# (unauthenticated, no network, not a GitHub remote) is "could not
+# determine", never a reason to abort `ocw rm` itself.
+gh_merge_check() {
+  local branch="$1"
+  local output=""
+
+  output="$(gh pr list --head "$branch" --state merged 2>/dev/null)" || return 1
+
+  [ -n "$output" ]
+}
+
+# Sets the global MERGE_CHECK_RESULT to one of `merged` / `not_merged` /
+# `no_candidates`. Runs unconditionally (even under -f, ADR §3.8) since the
+# result feeds run.end's `outcome` regardless of whether -f bypassed the
+# rejection this same result would otherwise cause.
+check_branch_merged() {
+  local branch="$1"
+  local worktree_git_dir="$2"
+  local candidate=""
+
+  # A detached worktree has no branch to check against anything.
+  if [ -z "$branch" ]; then
+    MERGE_CHECK_RESULT="not_merged"
+    return
+  fi
+
+  collect_merge_candidates "$branch" "$worktree_git_dir"
+
+  if [ -z "$BASE_REF_CANDIDATES" ]; then
+    MERGE_CHECK_RESULT="no_candidates"
+    return
+  fi
+
+  while IFS= read -r candidate; do
+    [ -n "$candidate" ] || continue
+
+    if git -C "$repo_root" merge-base --is-ancestor "$branch" "$candidate" 2>/dev/null; then
+      MERGE_CHECK_RESULT="merged"
+      return
+    fi
+
+    if squash_merged "$branch" "$candidate"; then
+      MERGE_CHECK_RESULT="merged"
+      return
+    fi
+
+    if [ "$(ocw_config_get_bool ocw.githubMergeCheck false)" = "true" ] &&
+      command -v gh >/dev/null 2>&1 &&
+      gh_merge_check "$branch"; then
+      MERGE_CHECK_RESULT="merged"
+      return
+    fi
+  done <<<"$BASE_REF_CANDIDATES"
+
+  MERGE_CHECK_RESULT="not_merged"
+}
+
+# Walks up from dirname($dir), rmdir-ing each now-possibly-empty parent
+# until $boundary is reached (never removed itself) or a non-empty
+# directory stops the climb (ADR §3.5). rmdir fails on a non-empty
+# directory, so a sibling worktree still present under the same parent
+# naturally halts the climb without any explicit "is it empty" check.
+cleanup_empty_parents() {
+  local dir="$1"
+  local boundary="$2"
+  local parent=""
+
+  parent="$(dirname -- "$dir")"
+
+  while [ "$parent" != "$boundary" ] && [ "$parent" != "/" ]; do
+    rmdir -- "$parent" 2>/dev/null || break
+    parent="$(dirname -- "$parent")"
+  done
+}
+
 remove_worktree() {
   local force="false"
 
@@ -936,24 +1215,23 @@ remove_worktree() {
   [ "$#" -le 1 ] ||
     die "too many arguments for remove"
 
-  local slug=""
-  local branch=""
   local worktree_dir=""
+  local branch=""
+  local display_name=""
   local invocation_real=""
   local worktree_real=""
 
-  slug="$(normalize_branch_name "$task_name")"
-
-  [ -n "$slug" ] ||
-    die "worktree name became empty"
-
-  branch="$slug"
-  worktree_dir="$(expand_worktree_dir_template "$worktree_dir_template" "$slug")"
+  resolve_removal_target "$task_name"
+  worktree_dir="$RESOLVED_WORKTREE_DIR"
+  branch="$RESOLVED_BRANCH"
 
   echo "repo:      ${repo_name}"
   echo "remove:    ${worktree_dir}"
   echo "branch:    ${branch}"
   echo "force:     ${force}"
+
+  display_name="$branch"
+  [ -n "$display_name" ] || display_name="$(basename -- "$worktree_dir")"
 
   # invocation_root is empty when ocw was invoked from inside a bare
   # repository (ADR DOC-2608062258 §2.1/§3.10) -- there's no worktree to
@@ -967,13 +1245,10 @@ remove_worktree() {
       echo "error: do not remove the current worktree" >&2
       echo "move to main first:" >&2
       echo "  cd ${repo_root}" >&2
-      echo "  ocw rm ${slug}" >&2
+      echo "  ocw rm ${display_name}" >&2
       exit 1
     fi
   fi
-
-  [ -d "$worktree_dir" ] ||
-    die "worktree dir does not exist: ${worktree_dir}"
 
   local run_id=""
   local worktree_git_dir=""
@@ -984,41 +1259,66 @@ remove_worktree() {
     run_id="$(cat "${worktree_git_dir}/ocw-run-id")"
   fi
 
+  # Runs even under -f (ADR §3.8): -f only bypasses the rejection below, it
+  # never skips the determination itself, since the result also decides
+  # run.end's outcome further down.
+  check_branch_merged "$branch" "$worktree_git_dir"
+
   if [ "$force" = "false" ]; then
     if [ -n "$(git -C "$worktree_dir" status --porcelain)" ]; then
       die "worktree has uncommitted or untracked changes: ${worktree_dir}"
     fi
 
-    if ! git -C "$repo_root" \
-      merge-base --is-ancestor "$branch" HEAD; then
-      die "branch is not merged into the current main checkout: ${branch}"
-    fi
+    case "$MERGE_CHECK_RESULT" in
+      merged) ;;
+      no_candidates)
+        die "cannot determine an integration ref to check '${branch}' against; set ocw.mergedInto or use -f"
+        ;;
+      not_merged)
+        die "branch is not merged into any known integration ref: ${branch}"
+        ;;
+    esac
   fi
 
   close_herdr_workspaces_for_checkout "$worktree_dir"
 
-  # -f discards a worktree without requiring it merged or clean (usage's own
-  # "ocw rm -f failed-experiment" example) — that's a run that didn't reach
-  # a mergeable result, so record it as failure rather than success. A
-  # plain `rm` only ever gets here after the merged+clean checks above pass,
-  # so it's always a successful run.end.
-  local run_end_outcome="success"
+  # outcome now follows the merge determination above, not the presence of
+  # -f (ADR §3.8) -- -f is "bypass the rejection", not "declare failure".
+  local run_end_outcome="failure"
+  [ "$MERGE_CHECK_RESULT" = "merged" ] && run_end_outcome="success"
 
   if [ "$force" = "true" ]; then
-    run_end_outcome="failure"
-
     git -C "$repo_root" \
       worktree remove --force "$worktree_dir"
-
-    git -C "$repo_root" \
-      branch -D "$branch"
   else
+    # Plain (non---force) `worktree remove` still refuses on uncommitted
+    # changes -- redundant with the status --porcelain check above, but
+    # left as a second independent guard rather than routed through
+    # --force here too.
     git -C "$repo_root" \
       worktree remove "$worktree_dir"
-
-    git -C "$repo_root" \
-      branch -d "$branch"
   fi
+
+  if [ -n "$branch" ]; then
+    # Always -D, never -d: `git branch -d`'s own "is this merged" check is
+    # ancestry-only (the exact limitation ADR §3.7/§2.7 exists to work
+    # around) and would refuse a squash-detected or gh-detected merge that
+    # check_branch_merged above already vetted more thoroughly. By this
+    # point the branch is leaving either way -- via -f, or because
+    # MERGE_CHECK_RESULT was "merged" -- so there is nothing left for -d's
+    # own safety check to usefully add.
+    git -C "$repo_root" \
+      branch -D "$branch"
+  fi
+
+  # Only climb inside the configured layout's own boundary (ADR §3.5) --
+  # a legacy worktree resolved via stage 3 (ai/* migration rescue) may sit
+  # entirely outside it, in which case there is nothing of ours to clean up.
+  case "$worktree_dir" in
+    "$worktree_cleanup_boundary"/*)
+      cleanup_empty_parents "$worktree_dir" "$worktree_cleanup_boundary"
+      ;;
+  esac
 
   if [ -n "$run_id" ]; then
     ocw_meter_event run.end \

--- a/bin/ocw
+++ b/bin/ocw
@@ -217,6 +217,16 @@ is_bare="false"
 worktree_dir_template=""
 worktree_cleanup_boundary=""
 
+# Set by resolve_removal_target() / check_branch_merged() below and read by
+# their callers in remove_worktree() -- kept here with the rest of this
+# file's cross-function globals rather than left to spring into existence
+# on first assignment.
+RESOLVED_WORKTREE_DIR=""
+RESOLVED_BRANCH=""
+BASE_REF_CANDIDATES=""
+BASE_REF_CANDIDATE_SHAS=""
+MERGE_CHECK_RESULT=""
+
 # git config `ocw.*` reader. `.git/config` is shared by every worktree of a
 # repo (including bare), so whichever worktree ocw is invoked from sees the
 # same values. Must be called after repo_root is known.
@@ -1046,15 +1056,28 @@ resolve_removal_target() {
 # Appends $1 to BASE_REF_CANDIDATES (a newline-separated string, not a bash
 # array -- see resolve_removal_target's comment on why) iff it resolves to a
 # real commit, silently skipping unset/unresolvable candidates (ADR §3.7's
-# "解決できない候補は黙って飛ばす").
+# "解決できない候補は黙って飛ばす"). Also skips it if some earlier candidate
+# already resolved to the same commit (tracked via BASE_REF_CANDIDATE_SHAS,
+# keyed by the resolved SHA rather than the ref string) -- `ocw.mergedInto`,
+# the persisted base_ref, HEAD, and origin/HEAD commonly all point at the
+# same commit, and without this check_branch_merged's per-candidate work
+# (an `is-ancestor` call plus the 4-subprocess squash_merged recipe, times
+# however many gh calls were still folded into that loop) ran once per
+# duplicate for no additional information.
 add_merge_candidate_if_resolvable() {
   local candidate="$1"
+  local sha=""
 
   [ -n "$candidate" ] || return 0
 
-  git -C "$repo_root" rev-parse --verify --quiet "${candidate}^{commit}" >/dev/null 2>&1 ||
+  sha="$(git -C "$repo_root" rev-parse --verify --quiet "${candidate}^{commit}" 2>/dev/null)" ||
     return 0
 
+  case "$BASE_REF_CANDIDATE_SHAS" in
+    *"${sha}"$'\n'*) return 0 ;;
+  esac
+
+  BASE_REF_CANDIDATE_SHAS="${BASE_REF_CANDIDATE_SHAS}${sha}"$'\n'
   BASE_REF_CANDIDATES="${BASE_REF_CANDIDATES}${candidate}"$'\n'
 }
 
@@ -1068,6 +1091,7 @@ collect_merge_candidates() {
   local configured="" base_ref_file="" head_candidate="" origin_head=""
 
   BASE_REF_CANDIDATES=""
+  BASE_REF_CANDIDATE_SHAS=""
 
   configured="$(ocw_config_get ocw.mergedInto "")"
   add_merge_candidate_if_resolvable "$configured"
@@ -1133,17 +1157,20 @@ gh_merge_check() {
 }
 
 # Sets the global MERGE_CHECK_RESULT to one of `merged` / `not_merged` /
-# `no_candidates`. Runs unconditionally (even under -f, ADR §3.8) since the
-# result feeds run.end's `outcome` regardless of whether -f bypassed the
-# rejection this same result would otherwise cause.
+# `no_candidates` / `no_branch`. Runs unconditionally (even under -f, ADR
+# §3.8) since the result feeds run.end's `outcome` regardless of whether -f
+# bypassed the rejection this same result would otherwise cause.
 check_branch_merged() {
   local branch="$1"
   local worktree_git_dir="$2"
   local candidate=""
 
-  # A detached worktree has no branch to check against anything.
+  # A detached worktree has no branch to check against anything -- distinct
+  # from `not_merged` (there is no unmerged *thing*, there is nothing to
+  # check at all), so remove_worktree's die message can say so accurately
+  # instead of naming an empty branch.
   if [ -z "$branch" ]; then
-    MERGE_CHECK_RESULT="not_merged"
+    MERGE_CHECK_RESULT="no_branch"
     return
   fi
 
@@ -1166,14 +1193,20 @@ check_branch_merged() {
       MERGE_CHECK_RESULT="merged"
       return
     fi
-
-    if [ "$(ocw_config_get_bool ocw.githubMergeCheck false)" = "true" ] &&
-      command -v gh >/dev/null 2>&1 &&
-      gh_merge_check "$branch"; then
-      MERGE_CHECK_RESULT="merged"
-      return
-    fi
   done <<<"$BASE_REF_CANDIDATES"
+
+  # `gh_merge_check` takes only $branch, never $candidate (a PR's merged
+  # state doesn't depend on which integration ref we're comparing against)
+  # -- so unlike ancestry/squash above, it belongs outside the per-candidate
+  # loop. Evaluated once, after every candidate has already failed
+  # ancestry/squash, not once per candidate (which duplicated the same `gh`
+  # network round-trip candidate_count times, including under -f).
+  if [ "$(ocw_config_get_bool ocw.githubMergeCheck false)" = "true" ] &&
+    command -v gh >/dev/null 2>&1 &&
+    gh_merge_check "$branch"; then
+    MERGE_CHECK_RESULT="merged"
+    return
+  fi
 
   MERGE_CHECK_RESULT="not_merged"
 }
@@ -1227,7 +1260,7 @@ remove_worktree() {
 
   echo "repo:      ${repo_name}"
   echo "remove:    ${worktree_dir}"
-  echo "branch:    ${branch}"
+  echo "branch:    ${branch:-<detached>}"
   echo "force:     ${force}"
 
   display_name="$branch"
@@ -1265,14 +1298,29 @@ remove_worktree() {
   check_branch_merged "$branch" "$worktree_git_dir"
 
   if [ "$force" = "false" ]; then
-    if [ -n "$(git -C "$worktree_dir" status --porcelain)" ]; then
-      die "worktree has uncommitted or untracked changes: ${worktree_dir}"
+    # A worktree whose directory was removed out from under git (`rm -rf`
+    # instead of `ocw rm`) still resolves here -- git worktree metadata
+    # doesn't disappear with it. `git -C "$worktree_dir" status` against a
+    # nonexistent directory fails with a raw `fatal:` on stderr, and its
+    # empty stdout is otherwise indistinguishable from "clean": guard on
+    # -d first so a stale registration is reported plainly and cleaned up
+    # (worktree remove below, no branch/file changes to lose) instead of
+    # leaking git's own diagnostic and reading a failure as "no changes".
+    if [ -d "$worktree_dir" ]; then
+      if [ -n "$(git -C "$worktree_dir" status --porcelain)" ]; then
+        die "worktree has uncommitted or untracked changes: ${worktree_dir}"
+      fi
+    else
+      warn "worktree directory is already gone; cleaning up its registration: ${worktree_dir}"
     fi
 
     case "$MERGE_CHECK_RESULT" in
       merged) ;;
       no_candidates)
         die "cannot determine an integration ref to check '${branch}' against; set ocw.mergedInto or use -f"
+        ;;
+      no_branch)
+        die "detached worktree has no branch to check for a merge; use -f: ${display_name}"
         ;;
       not_merged)
         die "branch is not merged into any known integration ref: ${branch}"
@@ -1299,7 +1347,17 @@ remove_worktree() {
       worktree remove "$worktree_dir"
   fi
 
-  if [ -n "$branch" ]; then
+  # show-ref first: an unborn-branch worktree (`git worktree add -b <name>
+  # --orphan`, or one created against an empty bare repo) reports a real
+  # `branch refs/heads/<name>` line in porcelain output -- HEAD is a
+  # symbolic ref to that name -- even though `refs/heads/<name>` doesn't
+  # exist as an actual ref yet. `git branch -D` on a ref that was never
+  # created exits non-zero ("not found"), and under `set -e` that would
+  # abort remove_worktree here: after `worktree remove` already succeeded
+  # above, but before the empty-parent cleanup and run.end below ever run,
+  # leaving a run that opened with run.start and never closes. There is
+  # nothing to delete in that case, so skip rather than attempt it.
+  if [ -n "$branch" ] && git -C "$repo_root" show-ref --verify --quiet "refs/heads/${branch}"; then
     # Always -D, never -d: `git branch -d`'s own "is this merged" check is
     # ancestry-only (the exact limitation ADR §3.7/§2.7 exists to work
     # around) and would refuse a squash-detected or gh-detected merge that
@@ -1307,8 +1365,14 @@ remove_worktree() {
     # point the branch is leaving either way -- via -f, or because
     # MERGE_CHECK_RESULT was "merged" -- so there is nothing left for -d's
     # own safety check to usefully add.
+    #
+    # Fail-open on the delete itself too: the worktree is already gone at
+    # this point, so a `branch -D` failure for some other reason (a lock
+    # file, a hook) shouldn't cost the empty-parent cleanup or run.end that
+    # still need to happen below.
     git -C "$repo_root" \
-      branch -D "$branch"
+      branch -D "$branch" ||
+      warn "failed to delete branch: ${branch}"
   fi
 
   # Only climb inside the configured layout's own boundary (ADR §3.5) --

--- a/bin/tests/test_ocw.py
+++ b/bin/tests/test_ocw.py
@@ -1338,26 +1338,48 @@ class DetachedWorktreeTests(unittest.TestCase):
         self.assertFalse(worktree_dir.exists())
 
 
-class RmEdgeCaseRegressionTests(OcwTestCase):
-    """ラウンド1レビューで実測された異常系の回帰テスト（指摘1・指摘5）。"""
+class UnbornBranchWorktreeRegressionTests(unittest.TestCase):
+    """unborn ブランチのワークツリー（ラウンド1レビュー指摘1・ラウンド2レビュー
+    新規指摘2）。
+
+    `git worktree add --orphan` は Git 2.42 以降専用（macOS 同梱の git は
+    2.39系）であり、これを使うと macOS では RuntimeError で落ちる（CI は
+    Linux で新しい git を積んでいるため気づけない）。unborn ブランチは
+    バージョン非依存の経路（コミット0件のbareリポジトリへの1本目の
+    `worktree add`）でも作れるため、そちらを使う。
+    """
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
 
     def test_unborn_branch_worktree_is_removable_with_force_without_aborting(self):
-        # A worktree whose branch was created via `--orphan` (or against an
-        # empty bare repo) reports a real `branch refs/heads/<name>` line
-        # in porcelain output even though that ref doesn't exist yet --
-        # `git branch -D` on it fails with "not found", which under
-        # `set -e` used to abort remove_worktree between `worktree remove`
-        # succeeding and run.end ever firing (round-1 finding 1).
-        _git(["worktree", "add", "-q", "-b", "gh-pages", "--orphan", str(self.repo_root.parent / "gh-pages")], self.repo_root)
-        worktree_dir = self.repo_root.parent / "gh-pages"
+        # A worktree whose branch has never been committed to reports a
+        # real `branch refs/heads/<name>` line in porcelain output even
+        # though that ref doesn't exist yet -- `git branch -D` on it fails
+        # with "not found" (or "used by worktree" before the worktree
+        # itself is removed), which under `set -e` used to abort
+        # remove_worktree between `worktree remove` succeeding and
+        # run.end ever firing (round-1 finding 1).
+        bare_dir = pathlib.Path(self.tmpdir.name) / "proj.git"
+        _git(["init", "-q", "--bare", "--initial-branch=main", str(bare_dir)], self.tmpdir.name)
+        _git(["worktree", "add", "-q", "-b", "work", str(bare_dir.parent / "work")], bare_dir)
+
+        worktree_dir = bare_dir.parent / "work"
         self.assertTrue(worktree_dir.is_dir())
 
-        remove = run_ocw(["rm", "-f", "gh-pages"], self.repo_root)
+        remove = run_ocw(["rm", "-f", "work"], bare_dir)
         self.assertEqual(remove.returncode, 0, remove.stderr)
         self.assertFalse(worktree_dir.exists())
 
-        branch_list = _git(["branch", "--list", "gh-pages"], self.repo_root).stdout
-        self.assertNotIn("gh-pages", branch_list)
+        branch_list = _git(["branch", "--list", "work"], bare_dir).stdout
+        self.assertNotIn("work", branch_list)
+
+
+class RmEdgeCaseRegressionTests(OcwTestCase):
+    """ラウンド1レビューで実測された異常系の回帰テスト（指摘5）。"""
 
     def test_missing_worktree_directory_does_not_leak_a_raw_git_fatal(self):
         create = run_ocw(["widget-maker"], self.repo_root)
@@ -1371,11 +1393,15 @@ class RmEdgeCaseRegressionTests(OcwTestCase):
 
         remove = run_ocw(["rm", "widget-maker"], self.repo_root)
         # Still correctly rejected (genuinely unmerged) -- a missing
-        # directory must not be misread as "clean" and let through.
+        # directory must not be misread as "clean" and let through. The
+        # warning must describe only what actually happened (the status
+        # check was skipped), not promise a cleanup this same run then
+        # doesn't perform (round-2 review finding: the die below means the
+        # registration is NOT cleaned up here).
         self.assertNotEqual(remove.returncode, 0)
         self.assertIn("branch is not merged", remove.stderr)
         self.assertNotIn("fatal:", remove.stderr)
-        self.assertIn("already gone", remove.stderr)
+        self.assertIn("skipping the local-changes check", remove.stderr)
 
     def test_missing_worktree_directory_still_completes_removal_when_merged(self):
         create = run_ocw(["widget-maker"], self.repo_root)

--- a/bin/tests/test_ocw.py
+++ b/bin/tests/test_ocw.py
@@ -573,9 +573,13 @@ class ExistingBehaviorRegressionTests(OcwTestCase):
         self.assertIn("widget-maker", result.stdout)
 
     def test_remove_nonexistent_worktree_dies(self):
+        # Message changed by 孫3's porcelain reverse-lookup rewrite
+        # (ADR DOC-2608062258 §3.9): there's no longer a single
+        # pre-computed dir path to report as missing, since resolution
+        # now works backwards from `git worktree list --porcelain`.
         result = run_ocw(["rm", "does-not-exist"], self.repo_root)
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("worktree dir does not exist", result.stderr)
+        self.assertIn("no worktree found", result.stderr)
 
     def test_remove_unmerged_branch_without_force_dies(self):
         create = run_ocw(["widget-maker"], self.repo_root)
@@ -1023,6 +1027,334 @@ class InvalidBranchNameRegressionTests(OcwTestCase):
         result = run_ocw(["HEAD"], self.repo_root)
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(extract_branch(result.stdout), "head")
+
+
+class RmResolutionTests(OcwTestCase):
+    """`ocw rm` の porcelain 逆引き解決 (ADR DOC-2608062258 §3.9, 孫3 プロンプト §1)."""
+
+    def test_removes_by_branch_name(self):
+        create = run_ocw(["feature/foo"], self.repo_root)
+        self.assertEqual(create.returncode, 0, create.stderr)
+        worktree_dir = self.repo_root.parent / "feature" / "foo"
+        self.assertTrue(worktree_dir.is_dir())
+
+        remove = run_ocw(["rm", "feature/foo"], self.repo_root)
+        self.assertEqual(remove.returncode, 0, remove.stderr)
+        self.assertFalse(worktree_dir.exists())
+
+    def test_removes_by_directory_basename(self):
+        create = run_ocw(["feature/foo"], self.repo_root)
+        self.assertEqual(create.returncode, 0, create.stderr)
+        worktree_dir = self.repo_root.parent / "feature" / "foo"
+
+        # "foo" isn't the branch name ("feature/foo") or an absolute path --
+        # only stage 2 (directory basename) can resolve it.
+        remove = run_ocw(["rm", "foo"], self.repo_root)
+        self.assertEqual(remove.returncode, 0, remove.stderr)
+        self.assertFalse(worktree_dir.exists())
+
+    def test_removes_by_absolute_path(self):
+        create = run_ocw(["widget-maker"], self.repo_root)
+        self.assertEqual(create.returncode, 0, create.stderr)
+        worktree_dir = self.repo_root.parent / "widget-maker"
+
+        remove = run_ocw(["rm", str(worktree_dir)], self.repo_root)
+        self.assertEqual(remove.returncode, 0, remove.stderr)
+        self.assertFalse(worktree_dir.exists())
+
+    def test_legacy_ai_prefixed_worktree_is_removable_by_bare_slug(self):
+        # Migration rescue (ADR §3.1/§3.9): a worktree still on a pre-孫2
+        # `ai/<slug>` branch (created directly via `git worktree add`, the
+        # way it would have existed before this umbrella, not through ocw
+        # itself) must still resolve for `ocw rm <slug>`.
+        legacy_dir = self.repo_root.parent / "legacy"
+        _git(["worktree", "add", "-b", "ai/legacy", str(legacy_dir), "main"], self.repo_root)
+
+        remove = run_ocw(["rm", "legacy"], self.repo_root)
+        self.assertEqual(remove.returncode, 0, remove.stderr)
+        self.assertFalse(legacy_dir.exists())
+
+    def test_ambiguous_basename_dies_listing_both_candidates_and_removes_neither(self):
+        first = run_ocw(["feature/foo"], self.repo_root)
+        self.assertEqual(first.returncode, 0, first.stderr)
+        second = run_ocw(["hotfix/foo"], self.repo_root)
+        self.assertEqual(second.returncode, 0, second.stderr)
+
+        feature_dir = self.repo_root.parent / "feature" / "foo"
+        hotfix_dir = self.repo_root.parent / "hotfix" / "foo"
+
+        remove = run_ocw(["rm", "foo"], self.repo_root)
+        self.assertNotEqual(remove.returncode, 0)
+        self.assertIn(str(feature_dir), remove.stderr)
+        self.assertIn(str(hotfix_dir), remove.stderr)
+        self.assertTrue(feature_dir.is_dir())
+        self.assertTrue(hotfix_dir.is_dir())
+
+    def test_main_worktree_is_never_a_removal_candidate(self):
+        result = run_ocw(["rm", "main"], self.repo_root)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("no worktree found", result.stderr)
+        self.assertTrue(self.repo_root.is_dir())
+
+    def test_nonexistent_name_dies(self):
+        result = run_ocw(["rm", "does-not-exist"], self.repo_root)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("no worktree found", result.stderr)
+
+
+class MergeDeterminationTests(OcwTestCase):
+    """マージ済み判定の再定義 (ADR DOC-2608062258 §3.7, 孫3 プロンプト §2)."""
+
+    def test_squash_merged_branch_is_removable_without_force(self):
+        create = run_ocw(["feature/foo"], self.repo_root)
+        self.assertEqual(create.returncode, 0, create.stderr)
+
+        worktree_dir = self.repo_root.parent / "feature" / "foo"
+        (worktree_dir / "extra.txt").write_text("extra\n", encoding="utf-8")
+        _git(["add", "extra.txt"], worktree_dir)
+        _git(["commit", "-q", "-m", "extra commit"], worktree_dir)
+
+        _git(["merge", "--squash", "feature/foo"], self.repo_root)
+        _git(["commit", "-q", "-m", "squash merge feature/foo"], self.repo_root)
+
+        remove = run_ocw(["rm", "feature/foo"], self.repo_root)
+        self.assertEqual(remove.returncode, 0, remove.stderr)
+        self.assertFalse(worktree_dir.exists())
+
+    def test_unmerged_branch_still_requires_force(self):
+        create = run_ocw(["widget-maker"], self.repo_root)
+        self.assertEqual(create.returncode, 0, create.stderr)
+
+        worktree_dir = self.repo_root.parent / "widget-maker"
+        (worktree_dir / "extra.txt").write_text("unmerged\n", encoding="utf-8")
+        _git(["add", "extra.txt"], worktree_dir)
+        _git(["commit", "-q", "-m", "unmerged commit"], worktree_dir)
+
+        remove = run_ocw(["rm", "widget-maker"], self.repo_root)
+        self.assertNotEqual(remove.returncode, 0)
+        self.assertIn("branch is not merged", remove.stderr)
+
+        force_remove = run_ocw(["rm", "-f", "widget-maker"], self.repo_root)
+        self.assertEqual(force_remove.returncode, 0, force_remove.stderr)
+
+    def test_ordinary_ancestor_merge_is_still_removable(self):
+        # The other existing tests' branches are trivial ancestors of main
+        # (tip == base, no new commits) -- this one adds a real commit and
+        # fast-forward merges it, exercising plain ancestry detection (not
+        # squash detection) explicitly.
+        create = run_ocw(["widget-maker"], self.repo_root)
+        self.assertEqual(create.returncode, 0, create.stderr)
+
+        worktree_dir = self.repo_root.parent / "widget-maker"
+        (worktree_dir / "extra.txt").write_text("extra\n", encoding="utf-8")
+        _git(["add", "extra.txt"], worktree_dir)
+        _git(["commit", "-q", "-m", "extra commit"], worktree_dir)
+
+        _git(["merge", "--ff-only", "widget-maker"], self.repo_root)
+
+        remove = run_ocw(["rm", "widget-maker"], self.repo_root)
+        self.assertEqual(remove.returncode, 0, remove.stderr)
+
+    def test_ocw_merged_into_config_widens_the_candidate_set(self):
+        set_config(self.repo_root, "ocw.mergedInto", "alt-target")
+        _git(["branch", "alt-target"], self.repo_root)
+
+        create = run_ocw(["widget-maker"], self.repo_root)
+        self.assertEqual(create.returncode, 0, create.stderr)
+
+        worktree_dir = self.repo_root.parent / "widget-maker"
+        (worktree_dir / "extra.txt").write_text("extra\n", encoding="utf-8")
+        _git(["add", "extra.txt"], worktree_dir)
+        _git(["commit", "-q", "-m", "extra commit"], worktree_dir)
+
+        # Merged only into alt-target, never into main.
+        _git(["checkout", "-q", "alt-target"], self.repo_root)
+        _git(["merge", "-q", "--ff-only", "widget-maker"], self.repo_root)
+        _git(["checkout", "-q", "main"], self.repo_root)
+
+        remove = run_ocw(["rm", "widget-maker"], self.repo_root)
+        self.assertEqual(remove.returncode, 0, remove.stderr)
+
+    def test_umbrella_style_base_ref_is_a_merge_candidate(self):
+        # ADR §3.7 candidate 2: a worktree branched off an umbrella branch
+        # (not main) is only ever an ancestor of that umbrella -- exactly
+        # the shape umbrella-orchestrator worktrees have. Without the
+        # creation-time base_ref persisted to ocw-base-ref, this would
+        # require -f even though it's genuinely merged (into its actual
+        # target, just not main).
+        _git(["branch", "umbrella"], self.repo_root)
+
+        create = run_ocw(["child", "umbrella"], self.repo_root)
+        self.assertEqual(create.returncode, 0, create.stderr)
+        self.assertIn("base:        umbrella", create.stdout)
+
+        worktree_dir = self.repo_root.parent / "child"
+        (worktree_dir / "extra.txt").write_text("extra\n", encoding="utf-8")
+        _git(["add", "extra.txt"], worktree_dir)
+        _git(["commit", "-q", "-m", "child work"], worktree_dir)
+
+        _git(["checkout", "-q", "umbrella"], self.repo_root)
+        _git(["merge", "-q", "--no-ff", "child"], self.repo_root)
+        _git(["checkout", "-q", "main"], self.repo_root)
+
+        remove = run_ocw(["rm", "child"], self.repo_root)
+        self.assertEqual(remove.returncode, 0, remove.stderr)
+
+    def test_github_merge_check_opt_in_fails_open_without_gh_on_path(self):
+        set_config(self.repo_root, "ocw.githubMergeCheck", "true")
+
+        create = run_ocw(["widget-maker"], self.repo_root)
+        self.assertEqual(create.returncode, 0, create.stderr)
+
+        worktree_dir = self.repo_root.parent / "widget-maker"
+        (worktree_dir / "extra.txt").write_text("unmerged\n", encoding="utf-8")
+        _git(["add", "extra.txt"], worktree_dir)
+        _git(["commit", "-q", "-m", "unmerged commit"], worktree_dir)
+
+        # gh is absent from run_ocw()'s PATH (BASE_PATH_DIRS) -- this must
+        # not crash or hang ocw, just fail to additionally confirm a merge,
+        # leaving the branch correctly rejected as still unmerged.
+        remove = run_ocw(["rm", "widget-maker"], self.repo_root)
+        self.assertNotEqual(remove.returncode, 0)
+        self.assertIn("branch is not merged", remove.stderr)
+        self.assertNotIn("gh: command not found", remove.stderr)
+
+        force_remove = run_ocw(["rm", "-f", "widget-maker"], self.repo_root)
+        self.assertEqual(force_remove.returncode, 0, force_remove.stderr)
+
+
+class OutcomeFromMergeDeterminationTests(OcwTestCase):
+    """`run.end` の `outcome` がマージ判定の結果から決まること、`-f` の有無から
+    決まるのではないこと (ADR DOC-2608062258 §3.8, 孫3 プロンプト §3)."""
+
+    def test_squash_merged_force_remove_still_records_success_outcome(self):
+        create = run_ocw(
+            ["feature/foo"], self.repo_root, meter_on_path=True, meter_home=self.meter_home
+        )
+        self.assertEqual(create.returncode, 0, create.stderr)
+        run_id = extract_run_id(create.stdout)
+
+        worktree_dir = self.repo_root.parent / "feature" / "foo"
+        (worktree_dir / "extra.txt").write_text("extra\n", encoding="utf-8")
+        _git(["add", "extra.txt"], worktree_dir)
+        _git(["commit", "-q", "-m", "extra commit"], worktree_dir)
+
+        _git(["merge", "--squash", "feature/foo"], self.repo_root)
+        _git(["commit", "-q", "-m", "squash merge feature/foo"], self.repo_root)
+
+        # -f isn't required here (squash detection alone lets a plain `rm`
+        # through), but this is the exact regression ADR §3.8 fixes: even
+        # when -f *is* supplied, the outcome must follow the merge
+        # determination, not -f's mere presence.
+        remove = run_ocw(
+            ["rm", "-f", "feature/foo"],
+            self.repo_root,
+            meter_on_path=True,
+            meter_home=self.meter_home,
+        )
+        self.assertEqual(remove.returncode, 0, remove.stderr)
+
+        events = read_events(self.meter_home)
+        ends = [e for e in events if e["event_type"] == "run.end" and e["run_id"] == run_id]
+        self.assertEqual(len(ends), 1, events)
+        self.assertEqual(ends[0]["outcome"], "success")
+
+    def test_truly_unmerged_force_remove_records_failure_outcome(self):
+        create = run_ocw(
+            ["widget-maker"], self.repo_root, meter_on_path=True, meter_home=self.meter_home
+        )
+        self.assertEqual(create.returncode, 0, create.stderr)
+        run_id = extract_run_id(create.stdout)
+
+        worktree_dir = self.repo_root.parent / "widget-maker"
+        (worktree_dir / "extra.txt").write_text("unmerged\n", encoding="utf-8")
+        _git(["add", "extra.txt"], worktree_dir)
+        _git(["commit", "-q", "-m", "unmerged commit"], worktree_dir)
+
+        remove = run_ocw(
+            ["rm", "-f", "widget-maker"],
+            self.repo_root,
+            meter_on_path=True,
+            meter_home=self.meter_home,
+        )
+        self.assertEqual(remove.returncode, 0, remove.stderr)
+
+        events = read_events(self.meter_home)
+        ends = [e for e in events if e["event_type"] == "run.end" and e["run_id"] == run_id]
+        self.assertEqual(len(ends), 1, events)
+        self.assertEqual(ends[0]["outcome"], "failure")
+
+
+class EmptyDirectoryCleanupTests(OcwTestCase):
+    """`ocw rm` 後の空ディレクトリ掃除 (ADR DOC-2608062258 §3.5, 孫3 プロンプト §4)."""
+
+    def test_removing_last_nested_worktree_cleans_up_empty_parent(self):
+        create = run_ocw(["feature/foo"], self.repo_root)
+        self.assertEqual(create.returncode, 0, create.stderr)
+
+        feature_parent = self.repo_root.parent / "feature"
+        self.assertTrue(feature_parent.is_dir())
+
+        remove = run_ocw(["rm", "feature/foo"], self.repo_root)
+        self.assertEqual(remove.returncode, 0, remove.stderr)
+        self.assertFalse(feature_parent.exists())
+
+    def test_sibling_nested_worktree_prevents_parent_cleanup(self):
+        first = run_ocw(["feature/foo"], self.repo_root)
+        self.assertEqual(first.returncode, 0, first.stderr)
+        second = run_ocw(["feature/bar"], self.repo_root)
+        self.assertEqual(second.returncode, 0, second.stderr)
+
+        feature_parent = self.repo_root.parent / "feature"
+
+        remove = run_ocw(["rm", "feature/foo"], self.repo_root)
+        self.assertEqual(remove.returncode, 0, remove.stderr)
+        self.assertFalse((feature_parent / "foo").exists())
+        self.assertTrue(feature_parent.is_dir())
+        self.assertTrue((feature_parent / "bar").is_dir())
+
+    def test_cleanup_boundary_itself_is_never_removed(self):
+        create = run_ocw(["widget-maker"], self.repo_root)
+        self.assertEqual(create.returncode, 0, create.stderr)
+
+        remove = run_ocw(["rm", "widget-maker"], self.repo_root)
+        self.assertEqual(remove.returncode, 0, remove.stderr)
+        # The cleanup boundary for the default template is repo_parent,
+        # which also holds the still-live main worktree -- if cleanup ever
+        # climbed past its own boundary this would delete it.
+        self.assertTrue(self.repo_root.parent.is_dir())
+        self.assertTrue(self.repo_root.is_dir())
+
+
+class BareRepoMergeDeterminationTests(unittest.TestCase):
+    """bare リポジトリでのマージ判定 (ADR DOC-2608062258 §3.7 候補3, 孫3 プロンプト §2)."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.bare_dir = make_bare_repo(self.tmpdir.name)
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_rm_merge_check_works_from_bare_repo(self):
+        create = run_ocw(["widget-maker"], self.bare_dir)
+        self.assertEqual(create.returncode, 0, create.stderr)
+
+        worktree_dir = self.bare_dir.parent / "widget-maker"
+        _git(["config", "user.email", "test@example.invalid"], worktree_dir)
+        _git(["config", "user.name", "Test"], worktree_dir)
+        (worktree_dir / "extra.txt").write_text("extra\n", encoding="utf-8")
+        _git(["add", "extra.txt"], worktree_dir)
+        _git(["commit", "-q", "-m", "extra commit"], worktree_dir)
+
+        # No working tree to run `git merge` in for a bare repo -- refs are
+        # shared storage across all its linked worktrees, so fast-forwarding
+        # main directly onto widget-maker's tip *is* "merging" it here.
+        _git(["update-ref", "refs/heads/main", "refs/heads/widget-maker"], self.bare_dir)
+
+        remove = run_ocw(["rm", "widget-maker"], self.bare_dir)
+        self.assertEqual(remove.returncode, 0, remove.stderr)
+        self.assertFalse(worktree_dir.exists())
 
 
 if __name__ == "__main__":

--- a/bin/tests/test_ocw.py
+++ b/bin/tests/test_ocw.py
@@ -1222,6 +1222,174 @@ class MergeDeterminationTests(OcwTestCase):
         force_remove = run_ocw(["rm", "-f", "widget-maker"], self.repo_root)
         self.assertEqual(force_remove.returncode, 0, force_remove.stderr)
 
+    def test_github_merge_check_is_evaluated_once_not_once_per_candidate(self):
+        # Round-1 review finding: gh_merge_check() only takes $branch, never
+        # $candidate, so it must run at most once regardless of how many
+        # integration-ref candidates resolve -- looping it per candidate
+        # was pure duplicated network round-trips with no new information.
+        set_config(self.repo_root, "ocw.githubMergeCheck", "true")
+        set_config(self.repo_root, "ocw.mergedInto", "alt-target")
+        _git(["branch", "alt-target"], self.repo_root)
+
+        create = run_ocw(["widget-maker"], self.repo_root)
+        self.assertEqual(create.returncode, 0, create.stderr)
+
+        worktree_dir = self.repo_root.parent / "widget-maker"
+        (worktree_dir / "extra.txt").write_text("unmerged\n", encoding="utf-8")
+        _git(["add", "extra.txt"], worktree_dir)
+        _git(["commit", "-q", "-m", "unmerged commit"], worktree_dir)
+
+        gh_shim_dir = pathlib.Path(self.tmpdir.name) / "gh-call-count-shim"
+        gh_shim_dir.mkdir()
+        gh_log = gh_shim_dir / "calls.log"
+        gh_shim = gh_shim_dir / "gh"
+        gh_shim.write_text(
+            f"#!/bin/sh\necho \"$@\" >> {shlex.quote(str(gh_log))}\nexit 1\n",
+            encoding="utf-8",
+        )
+        gh_shim.chmod(0o755)
+
+        # ocw.mergedInto=alt-target, the persisted base_ref (main), HEAD,
+        # and origin/HEAD are 4 distinct-looking candidates here (alt-target
+        # is a separate branch from main, so this isn't exercising dedup --
+        # see MergeDeterminationTests for that), all unmerged.
+        remove = run_ocw(["rm", "widget-maker"], self.repo_root, path_prepend=[str(gh_shim_dir)])
+        self.assertNotEqual(remove.returncode, 0)
+        self.assertIn("branch is not merged", remove.stderr)
+
+        calls = gh_log.read_text(encoding="utf-8").splitlines() if gh_log.exists() else []
+        self.assertEqual(len(calls), 1, calls)
+
+
+class NoResolvableCandidateRegressionTests(unittest.TestCase):
+    """基準refが1つも解決できない経路 (ADR DOC-2608062258 §3.7, ラウンド1レビュー指摘7a)."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_dies_without_force_and_dash_f_still_records_failure_outcome(self):
+        bare_dir = make_bare_repo(self.tmpdir.name)
+
+        create = run_ocw(["widget-maker"], bare_dir)
+        self.assertEqual(create.returncode, 0, create.stderr)
+        run_id = extract_run_id(create.stdout)
+
+        # Delete the branch that create_worktree() resolved and persisted as
+        # base_ref (candidate 2), and that `symbolic-ref --short HEAD`
+        # (candidate 3, this repo is bare) also names -- HEAD's symref
+        # still points at refs/heads/main afterwards, but that ref no
+        # longer resolves to anything. ocw.mergedInto is unset (candidate
+        # 1) and there's no origin for this repo to fall back to
+        # (candidate 4), so all 4 candidates end up unresolvable.
+        _git(["update-ref", "-d", "refs/heads/main"], bare_dir)
+
+        without_force = run_ocw(["rm", "widget-maker"], bare_dir)
+        self.assertNotEqual(without_force.returncode, 0)
+        self.assertIn("cannot determine an integration ref", without_force.stderr)
+        self.assertIn("-f", without_force.stderr)
+
+        meter_home = pathlib.Path(self.tmpdir.name) / "ocw-meter-home"
+        force_remove = run_ocw(
+            ["rm", "-f", "widget-maker"], bare_dir, meter_on_path=True, meter_home=meter_home
+        )
+        self.assertEqual(force_remove.returncode, 0, force_remove.stderr)
+
+        events = read_events(meter_home)
+        ends = [e for e in events if e["event_type"] == "run.end" and e["run_id"] == run_id]
+        self.assertEqual(len(ends), 1, events)
+        self.assertEqual(ends[0]["outcome"], "failure")
+
+
+class DetachedWorktreeTests(unittest.TestCase):
+    """detached ワークツリー (ラウンド1レビュー指摘7b・指摘3)."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.repo_root = make_repo(self.tmpdir.name)
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def _add_detached_worktree(self, name):
+        worktree_dir = self.repo_root.parent / name
+        _git(["worktree", "add", "-q", "--detach", str(worktree_dir), "main"], self.repo_root)
+        return worktree_dir
+
+    def test_dies_with_a_detached_specific_message_without_force(self):
+        worktree_dir = self._add_detached_worktree("detachedwt")
+
+        result = run_ocw(["rm", "detachedwt"], self.repo_root)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("detached", result.stderr)
+        self.assertIn("-f", result.stderr)
+        # The branch: line must name the worktree, not trail off after
+        # "branch: " with nothing (round-1 finding 3's exact repro).
+        self.assertNotIn("branch:    \n", result.stdout)
+        self.assertTrue(worktree_dir.is_dir())
+
+    def test_is_removable_with_force(self):
+        worktree_dir = self._add_detached_worktree("detachedwt")
+
+        result = run_ocw(["rm", "-f", "detachedwt"], self.repo_root)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(worktree_dir.exists())
+
+
+class RmEdgeCaseRegressionTests(OcwTestCase):
+    """ラウンド1レビューで実測された異常系の回帰テスト（指摘1・指摘5）。"""
+
+    def test_unborn_branch_worktree_is_removable_with_force_without_aborting(self):
+        # A worktree whose branch was created via `--orphan` (or against an
+        # empty bare repo) reports a real `branch refs/heads/<name>` line
+        # in porcelain output even though that ref doesn't exist yet --
+        # `git branch -D` on it fails with "not found", which under
+        # `set -e` used to abort remove_worktree between `worktree remove`
+        # succeeding and run.end ever firing (round-1 finding 1).
+        _git(["worktree", "add", "-q", "-b", "gh-pages", "--orphan", str(self.repo_root.parent / "gh-pages")], self.repo_root)
+        worktree_dir = self.repo_root.parent / "gh-pages"
+        self.assertTrue(worktree_dir.is_dir())
+
+        remove = run_ocw(["rm", "-f", "gh-pages"], self.repo_root)
+        self.assertEqual(remove.returncode, 0, remove.stderr)
+        self.assertFalse(worktree_dir.exists())
+
+        branch_list = _git(["branch", "--list", "gh-pages"], self.repo_root).stdout
+        self.assertNotIn("gh-pages", branch_list)
+
+    def test_missing_worktree_directory_does_not_leak_a_raw_git_fatal(self):
+        create = run_ocw(["widget-maker"], self.repo_root)
+        self.assertEqual(create.returncode, 0, create.stderr)
+
+        worktree_dir = self.repo_root.parent / "widget-maker"
+        (worktree_dir / "extra.txt").write_text("unmerged\n", encoding="utf-8")
+        _git(["add", "extra.txt"], worktree_dir)
+        _git(["commit", "-q", "-m", "unmerged commit"], worktree_dir)
+        shutil.rmtree(worktree_dir)
+
+        remove = run_ocw(["rm", "widget-maker"], self.repo_root)
+        # Still correctly rejected (genuinely unmerged) -- a missing
+        # directory must not be misread as "clean" and let through.
+        self.assertNotEqual(remove.returncode, 0)
+        self.assertIn("branch is not merged", remove.stderr)
+        self.assertNotIn("fatal:", remove.stderr)
+        self.assertIn("already gone", remove.stderr)
+
+    def test_missing_worktree_directory_still_completes_removal_when_merged(self):
+        create = run_ocw(["widget-maker"], self.repo_root)
+        self.assertEqual(create.returncode, 0, create.stderr)
+
+        worktree_dir = self.repo_root.parent / "widget-maker"
+        shutil.rmtree(worktree_dir)
+
+        remove = run_ocw(["rm", "widget-maker"], self.repo_root)
+        self.assertEqual(remove.returncode, 0, remove.stderr)
+        self.assertNotIn("fatal:", remove.stderr)
+        branch_list = _git(["branch", "--list", "widget-maker"], self.repo_root).stdout
+        self.assertNotIn("widget-maker", branch_list)
+
 
 class OutcomeFromMergeDeterminationTests(OcwTestCase):
     """`run.end` の `outcome` がマージ判定の結果から決まること、`-f` の有無から


### PR DESCRIPTION
## 背景

dotfilesは、macOS / Linux / WSL2 で共通の開発環境を再現するための設定リポジトリです。`bin/ocw` はgit worktreeの作成・削除を助けるCLIツールで、傘ブランチ `ai/ocw-naming-and-layout`（設計判断はADR DOC-2608062258）で、ブランチ命名・レイアウト・マージ判定の4つのハードコード前提を外部化する作業を進めています。孫1（設定リーダ・リポジトリコンテキスト、PR #50）と孫2（`ai/`接頭辞廃止・スラッシュ対応、PR #51）が既にマージ済みです。

## このプルリクエストの目的

`ocw rm` の対象解決とマージ済み判定を作り直します。孫2でブランチ名にスラッシュが使えるようになり、ディレクトリ名とブランチ名が一致しなくなったため、これまでの「入力からブランチ名・パスを再計算する」方式が成立しなくなっていました。また、既存のマージ済み判定はgitのancestryしか見ないため、GitHubのsquashマージ済みブランチや傘ブランチへマージされた孫ブランチを`-f`なしで削除できない問題がありました。

## 実装内容

- `ocw rm` の対象解決を、`git worktree list --porcelain` からの逆引きに書き換えました。入力を「ブランチ完全一致／パス完全一致／掃除境界からの相対パス一致」→「ディレクトリのbasename一致」→「ブランチが`/<入力>`で終わる（`ai/*`時代の移行救済）」の3段階でマッチし、同一段で複数ヒットしたら候補を列挙して停止します（自動選択はしません）。
- マージ済み判定を、基準ref候補（`ocw.mergedInto` → 作成時の`base_ref` → `symbolic-ref HEAD` → `origin/HEAD`）を順に試す方式に再定義しました。各候補についてancestry判定に加え、squash検出（`commit-tree` + `git cherry`によるpatch-id比較）、`gh`によるPR状態確認（`ocw.githubMergeCheck`でopt-in、失敗はfail-open）を行います。
- worktree作成時に`base_ref`を`ocw-base-ref`として永続化するようにしました（run-idと同じ仕組み）。これにより、傘ブランチから切った孫ブランチが傘にマージされた時点で、mainにマージされていなくても削除できるようになります。
- `run.end`の`outcome`を、`-f`の有無ではなく上記マージ判定の結果から決めるように変更しました。squashマージ済みなのに`-f`を強いられてメトリクス上「失敗」に記録される問題を修正します。
- `ocw rm`後、掃除境界に達するまで空になった親ディレクトリを`rmdir`で遡って削除するようにしました。

## レビューで見てほしいところ

- ブランチ削除を`git branch -d`から`-D`に変更しました。squash検出で「マージ済み」と判定されたブランチは、gitの`-d`自身が持つancestryベースの安全確認には通らない（squashは履歴を残さないため）ので、`-d`のままだと削除コマンドがそこで失敗してしまいます。この時点までに`check_branch_merged`で独自の検証を済ませているため、`-d`の重ねての安全確認には意味がないと判断しました。
- 候補配列の実装をbashの配列ではなく改行区切り文字列にしています。macOS標準bash（3.2系）は`set -u`下で空配列の展開（`"${arr[@]}"`）が`unbound variable`エラーになる既知の非互換があり（直近のPR #49で一度踏んだ問題）、再発を避けるためです。
- `-f`はマージ済み判定そのものはスキップさせず、判定結果に基づく削除拒否だけをバイパスする設計にしました。基準refが1つも解決できない場合も、`-f`があれば削除は続行し、`outcome`だけ`failure`になります。

## テスト結果

- `pre-commit run --all-files`: 緑
- `python3 -m unittest discover -s bin/tests -v`（247件）: 緑
- `bin/tests/lint.sh`: 緑
- `bash -n bin/ocw`: 緑

🤖💬 [Claude Sonnet 5 | medium]

https://claude.ai/code/session_01SpBr3uX2bqGFjNNZqA2Bkg

## 自己レビュー

- 正当性: ADR DOC-2608062258 §3.7/§3.8/§3.9および孫3プロンプトの全項目（porcelain逆引き解決・マージ判定再定義・outcome修正・空ディレクトリ掃除・invocation_rootガードの追随）を実装済み。
- エッジケース: 曖昧解決（同一段で複数ヒット）・存在しない名前・メインワークツリー指定・bareリポジトリ・detachedワークツリー（branch空）・`gh`未導入時のfail-open・基準ref候補が1つも解決できない場合を確認。
- テスト: `python3 -m unittest discover -s bin/tests -v` 247件成功（新規追加31件を含む）。squashマージ・傘ブランチ相当ケース・bareリポジトリでのマージ判定・空ディレクトリ掃除・outcome決定を個別に手動実行でも再現確認済み。
- 無関係変更: なし（`bin/ocw`と`bin/tests/test_ocw.py`のみ）。
- 後方互換性: 既定設定での挙動は傘の完了条件どおり3点（`ai/`接頭辞廃止・squash検出・outcomeの決定方法）のみ変化。`test_remove_nonexistent_worktree_dies`のエラーメッセージ期待値のみ、逆引き解決への変更に伴い更新。
