### PR TITLE
ocw-meterのストア衛生を直す: テスト汚染の停止・refusalプルーニング修正・診断掃除サブコマンド新設

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -493,7 +493,9 @@ rm ~/.local/state/ocw-meter/events/2026-01-*.jsonl
 `state/session-pr-links.json`（`ingest`がtranscriptの`pr-link`行から学習したsession→PRの対応。
 増分実行をまたいで保持される）/
 `state/meter-errors.jsonl`（`meter.error`自己診断専用。
-`events/`とは別ファイルにすることで、後勝ちdedupによるイベントファイル書き換えと競合せずlock無しで追記できる）/
+`events/`とは別ファイルにすることで、後勝ちdedupによるイベントファイル書き換えと競合せずlock無しで追記できる。
+ただし `ocw-meter prune-diagnostics --apply` はこのファイルを丸ごと書き換える唯一の例外で、
+書き換えの瞬間と重なった追記1行を失う可能性がある）/
 `state/quota-last-sample.json`（`snapshot-quota`のサンプリング間隔自制・同一window内の異常値検知に使う
 直近サンプルの状態）/
 `raw/YYYY-MM-DD/*.json`（`OCW_METER_RAW=1`のときのみ。`snapshot-quota`が保存するredaction済みの

--- a/bin/README.md
+++ b/bin/README.md
@@ -349,6 +349,14 @@ ocw-meter prune-diagnostics [--older-than <days>] [--apply]
 | `snapshot-quota` | **常に exit 0 かつ必ずstdoutに表示文字列を出す**（statusLineが壊れて画面が崩れる事態を絶対に避ける。event/bind-pr以上に厳格なfail-open） |
 | `validate` / `report` / `ingest` / `prune-diagnostics` | 失敗したら非ゼロで落ちる（壊れたデータを黙って集計しない） |
 
+**`prune-diagnostics` の既定保持期間（30日）について**: これは運用上のリテンションポリシーであり、
+「今すぐ全部消す」既定ではない。数日〜1週間前にできたばかりのエントリ（一時的な設定ミスの記録など）を
+今すぐ後始末したい場合は、`--older-than` に小さい値を明示する（例:
+`ocw-meter prune-diagnostics --older-than 1 --apply`）。
+`OCW_METER_HOME`（またはその既定値）と `$HOME` 由来の既定rootの両方を調べる
+（`state/quota-worktree-refusal.json` は常に既定rootにしか書かれないため。片方がGitワークツリー内で
+使えなくても、もう片方が生きていれば処理を続ける）。
+
 **`--repo <owner>/<name>`（`--pr`・standalone `--month`専用。孫5後半で追加）**:
 
 `~/.local/state/ocw-meter`は本マシンの`ocw-meter`が向いた**全リポジトリで共有される1つのストア**だが、

--- a/bin/README.md
+++ b/bin/README.md
@@ -337,13 +337,17 @@ ocw-meter report --reconcile [--month <YYYY-MM>] [--provider-total <model>=<toke
 
 # statusLineコマンドとして呼ばれ、stdinのJSONからquota.sampleを1行append、表示文字列をstdoutへ返す
 ocw-meter snapshot-quota
+
+# state/meter-errors.jsonl・state/quota-worktree-refusal.jsonの古いエントリを掃除する（events/には触れない）。
+# 既定はdry-run。--applyで実削除、--older-than <日数>で保持期間指定（既定30日）
+ocw-meter prune-diagnostics [--older-than <days>] [--apply]
 ```
 
 | サブコマンド | 失敗時の挙動 |
 |---|---|
 | `event` / `bind-pr` | **常に exit 0**。stderrに1行warnのみ。本番フローを止めない |
 | `snapshot-quota` | **常に exit 0 かつ必ずstdoutに表示文字列を出す**（statusLineが壊れて画面が崩れる事態を絶対に避ける。event/bind-pr以上に厳格なfail-open） |
-| `validate` / `report` / `ingest` | 失敗したら非ゼロで落ちる（壊れたデータを黙って集計しない） |
+| `validate` / `report` / `ingest` / `prune-diagnostics` | 失敗したら非ゼロで落ちる（壊れたデータを黙って集計しない） |
 
 **`--repo <owner>/<name>`（`--pr`・standalone `--month`専用。孫5後半で追加）**:
 

--- a/bin/ocw-meter
+++ b/bin/ocw-meter
@@ -190,9 +190,14 @@ subcommands:
     back to the default root whenever OCW_METER_HOME itself is refused
     for resolving inside a Git worktree). A root that itself resolves
     inside a Git worktree is skipped, not fatal, as long as the other
-    one is reachable. A corrupt (unparseable, or not a JSON object)
-    quota-worktree-refusal.json is reported as such, not silently
-    treated as empty; --apply replaces it with a fresh empty state.
+    one is reachable. The two roots are compared by RESOLVED path, so a
+    trailing slash or a symlink does not make the same real directory
+    look like two roots and get double-counted. The roots actually
+    checked are always printed, and meter-errors.jsonl gets a per-root
+    breakdown whenever more than one contributed to the total. A
+    corrupt (unparseable, or not a JSON object) quota-worktree-
+    refusal.json is reported as such, not silently treated as empty;
+    --apply replaces it with a fresh empty state.
 
     Always reports both a removed count and a kept count, plus (as
     informational-only text, never as a deletion criterion) how many of
@@ -4071,9 +4076,18 @@ def record_quota_sample(obj):
     # path), so `refusal_paths` still ends up None via that check, no
     # new paradox introduced.
     default_root = default_storage_root()
-    refusal_paths = (
-        Paths(default_root) if (default_root and not in_git_worktree(default_root)) else None
-    )
+    # 孫1 round-2 review finding 1: `default_root == root` is exactly the
+    # common case the round-1 fix above stopped short-circuiting on
+    # (OCW_METER_HOME unset) — so `in_git_worktree(default_root)` below
+    # and `in_git_worktree(root)` a few lines down were now hitting the
+    # SAME path with two separate `git rev-parse --is-inside-work-tree`
+    # subprocess calls per `snapshot-quota` invocation, exactly the
+    # doubled cost this function's own docstring and the comment on the
+    # per-session throttle check above both say to avoid. Evaluate it
+    # ONCE here and reuse the result for `root` whenever the two paths
+    # are identical.
+    default_root_is_worktree = bool(default_root) and in_git_worktree(default_root)
+    refusal_paths = Paths(default_root) if (default_root and not default_root_is_worktree) else None
     refusal_state = {}
     if refusal_paths is not None:
         # Already pruned of anything >24h old (see load_and_prune_
@@ -4086,7 +4100,8 @@ def record_quota_sample(obj):
         if last_refused_at is not None and (now - last_refused_at).total_seconds() < interval:
             return  # still within the suppression window from a previous refusal
 
-    if in_git_worktree(root):
+    root_is_worktree = default_root_is_worktree if (default_root and default_root == root) else in_git_worktree(root)
+    if root_is_worktree:
         print(
             f"warning: OCW_METER_HOME ({root}) resolves inside a Git worktree; "
             "refusing to write there (no quota.sample recorded)",
@@ -4332,6 +4347,17 @@ def _parse_prune_diagnostics_args(args):
     return apply_changes, older_than_days
 
 
+def _resolve_path_str(path):
+    """Same normalization `in_git_worktree` applies internally (resolve,
+    falling back to the original on OSError) — used here so dedup
+    compares REAL locations, not surface path spelling."""
+    p = pathlib.Path(path)
+    try:
+        return str(p.resolve())
+    except OSError:
+        return str(p)
+
+
 def _diagnostic_target_roots():
     """The distinct, reachable storage roots ocw-meter's OWN diagnostics
     can actually live under (孫1 round-1 review finding 2):
@@ -4344,11 +4370,30 @@ def _diagnostic_target_roots():
     load_and_prune_worktree_refusal_state's docstring) — never under a
     custom OCW_METER_HOME. A root that itself resolves inside a Git
     worktree is skipped, not fatal for the whole subcommand: the other
-    root may still be reachable and worth cleaning."""
+    root may still be reachable and worth cleaning.
+
+    Dedup compares RESOLVED paths (孫1 round-2 review finding 2): a bare
+    string comparison let a trailing slash or a symlink hop make
+    `storage_root()` and `default_storage_root()` look like two
+    different roots when they were the same real directory, so
+    `state/meter-errors.jsonl` got read (and counted) twice — dry-run
+    and `--apply` then disagreed on how many lines would be removed.
+    The RESOLVED path is also what gets returned and used to build
+    `Paths(...)` downstream, so every consumer sees the same
+    canonicalized root `in_git_worktree` itself already compares
+    against."""
     roots = []
+    seen = set()
     for candidate in (storage_root(), default_storage_root()):
-        if candidate and candidate not in roots and not in_git_worktree(candidate):
-            roots.append(candidate)
+        if not candidate:
+            continue
+        resolved = _resolve_path_str(candidate)
+        if resolved in seen:
+            continue
+        if in_git_worktree(resolved):
+            continue
+        seen.add(resolved)
+        roots.append(resolved)
     return roots
 
 
@@ -4430,7 +4475,13 @@ def cmd_prune_diagnostics(args):
     legitimately end up at either, and quota-worktree-refusal.json is
     ALWAYS at the default root regardless of OCW_METER_HOME. A root
     that resolves inside a Git worktree is skipped, not fatal: the
-    other root may still be reachable.
+    other root may still be reachable. The two are compared by
+    RESOLVED path, so a trailing slash or a symlink hop never makes the
+    same real directory look like two different roots (which would
+    otherwise double-count state/meter-errors.jsonl). The roots
+    actually selected are always printed, and state/meter-errors.jsonl
+    gets a per-root breakdown whenever more than one of them
+    contributed to the total.
 
     Default is dry-run: reports counts without writing anything. Only
     --apply rewrites the files, and only entries older than
@@ -4466,6 +4517,12 @@ def cmd_prune_diagnostics(args):
         )
         return 0
 
+    # 孫1 round-2 review finding 4: with two files now possibly spread
+    # across two DIFFERENT physical directories, a single aggregate
+    # count no longer says which store actually gets rewritten. Always
+    # print which roots `_diagnostic_target_roots()` actually selected.
+    print(f"  checked roots: {', '.join(target_roots)}")
+
     def _report(label, dropped, kept_count, dropped_test_like):
         verb = "removed" if apply_changes else "would remove"
         suffix = f" ({dropped_test_like} of those look test-derived, heuristic only)" if dropped_test_like else ""
@@ -4474,6 +4531,7 @@ def cmd_prune_diagnostics(args):
     errors_dropped_total = 0
     errors_kept_total = 0
     errors_dropped_test_like_total = 0
+    per_root_error_reports = []
     for root in target_roots:
         paths = Paths(root)
         if not paths.meter_errors_file.exists():
@@ -4490,12 +4548,22 @@ def cmd_prune_diagnostics(args):
             except OSError as exc:
                 print(f"error: failed to rewrite {paths.meter_errors_file}: {exc}", file=sys.stderr)
                 return 1
+        per_root_error_reports.append((root, dropped, len(kept), dropped_test_like))
         errors_dropped_total += dropped
         errors_kept_total += len(kept)
         errors_dropped_test_like_total += dropped_test_like
     _report("state/meter-errors.jsonl", errors_dropped_total, errors_kept_total, errors_dropped_test_like_total)
+    if len(per_root_error_reports) > 1:
+        # More than one physical file actually contributed to the total
+        # above — break it down so it is clear which store each part
+        # came (or will come) from.
+        verb = "removed" if apply_changes else "would remove"
+        for root, dropped, kept_count, dropped_test_like in per_root_error_reports:
+            suffix = f" ({dropped_test_like} test-derived)" if dropped_test_like else ""
+            print(f"    {root}: {verb} {dropped}, kept {kept_count}{suffix}")
 
     default_root = default_storage_root()
+    default_root = _resolve_path_str(default_root) if default_root else None
     if default_root is None or default_root not in target_roots:
         print("  state/quota-worktree-refusal.json: default storage root unreachable — 0 removed, 0 kept")
         return 0

--- a/bin/ocw-meter
+++ b/bin/ocw-meter
@@ -177,7 +177,23 @@ subcommands:
     territory, and `prune` remains deliberately unimplemented — see
     notes below). Default is dry-run: reports how many entries in each
     file are older than --older-than days (default 30) without
-    modifying either file; pass --apply to actually rewrite them.
+    modifying either file; pass --apply to actually rewrite them. A
+    SMALLER --older-than is usually needed to clean up entries left
+    over from a recent one-off misconfiguration (they will not be that
+    old yet) — this is a retention policy for ongoing hygiene, not a
+    "clean everything now" default.
+
+    Checks BOTH OCW_METER_HOME (or its own default when unset) and the
+    $HOME-derived default root: quota-worktree-refusal.json is ALWAYS
+    written under the latter regardless of OCW_METER_HOME, and
+    meter-errors.jsonl can end up under either (emit_meter_error falls
+    back to the default root whenever OCW_METER_HOME itself is refused
+    for resolving inside a Git worktree). A root that itself resolves
+    inside a Git worktree is skipped, not fatal, as long as the other
+    one is reachable. A corrupt (unparseable, or not a JSON object)
+    quota-worktree-refusal.json is reported as such, not silently
+    treated as empty; --apply replaces it with a fresh empty state.
+
     Always reports both a removed count and a kept count, plus (as
     informational-only text, never as a deletion criterion) how many of
     the removed entries look test-derived by path shape. Fail-loud
@@ -703,6 +719,18 @@ class Paths:
         # the main lock made the write_event_lock_timeout diagnostic
         # self-defeating: it would need the very lock it's reporting as
         # unavailable).
+        #
+        # ONE exception (孫1, 計画書 DOC-2608081456【4】後始末, round-1
+        # review finding 4): `cmd_prune_diagnostics --apply` rewrites
+        # this file wholesale (mkstemp + os.replace) to drop aged-out
+        # lines. That is a deliberate, human-invoked, infrequent hygiene
+        # operation, not a background writer — `emit_meter_error` itself
+        # still never touches the main lock for this file. The narrow
+        # accepted risk: an `emit_meter_error` append landing in the
+        # exact instant between prune-diagnostics reading the old inode
+        # and replacing it is lost (one low-value diagnostic line, not
+        # silently corrupted data — os.replace is atomic, so readers
+        # never see a half-written file).
         self.meter_errors_file = self.state_dir / "meter-errors.jsonl"
 
 
@@ -3828,7 +3856,7 @@ def save_quota_state(paths, state):
     save_json_state_file(paths, QUOTA_STATE_FILENAME, state)
 
 
-def load_worktree_refusal_state(paths, now=None):
+def load_and_prune_worktree_refusal_state(paths, now=None):
     """Reads quota-worktree-refusal.json and prunes entries older than
     QUOTA_SESSION_STATE_MAX_AGE_SECONDS on every read, not only when a
     NEW refusal is about to be recorded (孫1, 計画書 DOC-2608081456【6】:
@@ -3836,6 +3864,15 @@ def load_worktree_refusal_state(paths, now=None):
     branch below, so once a misconfiguration stopped happening the last
     stale entries sat in the file forever — 37 of them, all >24h old, on
     this machine's real store).
+
+    Named `load_and_prune_*`, not `load_*`, on purpose (孫1 round-1
+    review finding 9): every other `load_*` function in this file
+    (`load_json_state_file` / `load_quota_state` / `load_ingest_cursor` /
+    `load_session_pr_links`) is a pure read, and this one is not — it
+    can write. `cmd_prune_diagnostics` deliberately calls
+    `load_json_state_file` directly instead of this function, precisely
+    to avoid that write side effect; the name difference is what makes
+    that choice legible at the call site.
 
     If pruning actually dropped something, the pruned result is written
     straight back so the file shrinks on the very next call after the
@@ -4016,18 +4053,34 @@ def record_quota_sample(obj):
     # worktree, there is nowhere left to cache the refusal — `root`
     # simply gets re-checked every call in that (rare, doubly-
     # misconfigured) case, same as before this suppression existed.
+    #
+    # 孫1 round-1 review finding 1: this used to additionally require
+    # `default_root != root` before even LOADING (and therefore
+    # pruning) the file — which meant the read-time pruning added
+    # above never ran in the single most common configuration of all:
+    # OCW_METER_HOME unset, so `storage_root()` and
+    # `default_storage_root()` resolve to the identical path. That is
+    # exactly the "misconfiguration has stopped" state 計画書
+    # DOC-2608081456【6】 is about, so the 37 stale entries found on
+    # this machine's real store would never have actually been pruned.
+    # Dropping that equality check is safe: the only reason it existed
+    # was to avoid writing the cache INTO the very root being refused,
+    # and that is already fully handled by the `not
+    # in_git_worktree(default_root)` check alone — if `default_root ==
+    # root` and `root` is refused, `default_root` is refused too (same
+    # path), so `refusal_paths` still ends up None via that check, no
+    # new paradox introduced.
     default_root = default_storage_root()
     refusal_paths = (
-        Paths(default_root)
-        if (default_root and default_root != root and not in_git_worktree(default_root))
-        else None
+        Paths(default_root) if (default_root and not in_git_worktree(default_root)) else None
     )
     refusal_state = {}
     if refusal_paths is not None:
-        # Already pruned of anything >24h old (see load_worktree_refusal_
-        # state's own docstring) — reused below instead of re-loading, so
-        # a refusal doesn't pay for reading+pruning the file twice.
-        refusal_state = load_worktree_refusal_state(refusal_paths, now)
+        # Already pruned of anything >24h old (see load_and_prune_
+        # worktree_refusal_state's own docstring) — reused below instead
+        # of re-loading, so a refusal doesn't pay for reading+pruning the
+        # file twice.
+        refusal_state = load_and_prune_worktree_refusal_state(refusal_paths, now)
         last_refused_at = refusal_state.get(root)
         last_refused_at = parse_ts(last_refused_at) if isinstance(last_refused_at, str) else None
         if last_refused_at is not None and (now - last_refused_at).total_seconds() < interval:
@@ -4279,6 +4332,90 @@ def _parse_prune_diagnostics_args(args):
     return apply_changes, older_than_days
 
 
+def _diagnostic_target_roots():
+    """The distinct, reachable storage roots ocw-meter's OWN diagnostics
+    can actually live under (孫1 round-1 review finding 2):
+    `storage_root()` (OCW_METER_HOME, or its own default when unset) is
+    where `emit_meter_error` normally appends state/meter-errors.jsonl,
+    and `default_storage_root()` ($HOME-derived) is BOTH where
+    `emit_meter_error` falls back to whenever `storage_root()` itself is
+    refused for resolving inside a Git worktree, AND the ONLY place
+    state/quota-worktree-refusal.json is ever written (see
+    load_and_prune_worktree_refusal_state's docstring) — never under a
+    custom OCW_METER_HOME. A root that itself resolves inside a Git
+    worktree is skipped, not fatal for the whole subcommand: the other
+    root may still be reachable and worth cleaning."""
+    roots = []
+    for candidate in (storage_root(), default_storage_root()):
+        if candidate and candidate not in roots and not in_git_worktree(candidate):
+            roots.append(candidate)
+    return roots
+
+
+def _split_meter_errors_by_age(raw_text, now, max_age):
+    kept = []
+    dropped = 0
+    dropped_test_like = 0
+    for line in raw_text.splitlines():
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            # Not this subcommand's job to quarantine malformed lines —
+            # that is `validate`'s contract, and it only applies to
+            # events/*.jsonl. Keep anything unparseable rather than
+            # guess whether it is stale.
+            kept.append(line)
+            continue
+        ts = parse_ts(event.get("ts")) if isinstance(event, dict) else None
+        if ts is not None and (now - ts) > max_age:
+            dropped += 1
+            if _looks_test_derived(line):
+                dropped_test_like += 1
+        else:
+            kept.append(line)
+    return kept, dropped, dropped_test_like
+
+
+def _rewrite_meter_errors_file(paths, kept_lines):
+    if kept_lines:
+        ensure_dir(paths.state_dir, 0o700)
+        tmp_fd, tmp_path = tempfile.mkstemp(dir=str(paths.state_dir), prefix=".tmp-", suffix=".jsonl")
+        try:
+            with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
+                fh.write("\n".join(kept_lines) + "\n")
+            os.chmod(tmp_path, 0o600)
+            os.replace(tmp_path, paths.meter_errors_file)
+        except Exception:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_path)
+            raise
+    else:
+        paths.meter_errors_file.unlink()
+
+
+def _read_worktree_refusal_state_raw(paths):
+    """Like load_json_state_file, but distinguishes "absent/empty" from
+    "present but unparseable" (孫1 round-1 review finding 8) — silently
+    treating a corrupt file as `{}` (load_json_state_file's own
+    contract, correct for every OTHER caller) let prune-diagnostics
+    report "kept 0" for a file that, in fact, was still sitting there
+    corrupt and untouched. Returns (data, was_corrupt)."""
+    path = paths.state_dir / QUOTA_WORKTREE_REFUSAL_FILENAME
+    if not path.exists():
+        return {}, False
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return {}, True
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return {}, True
+    return (data, False) if isinstance(data, dict) else ({}, True)
+
+
 def cmd_prune_diagnostics(args):
     """Cleans up ocw-meter's OWN diagnostic/state sidecar files —
     state/meter-errors.jsonl and state/quota-worktree-refusal.json —
@@ -4287,61 +4424,99 @@ def cmd_prune_diagnostics(args):
     stays intentionally unimplemented (bin/README.md) — this subcommand
     does not revisit that decision (計画書 DOC-2608081456【6】).
 
+    Checks BOTH `storage_root()` (OCW_METER_HOME, or its default) and
+    `default_storage_root()` ($HOME-derived) — see
+    _diagnostic_target_roots — since ocw-meter's own diagnostics can
+    legitimately end up at either, and quota-worktree-refusal.json is
+    ALWAYS at the default root regardless of OCW_METER_HOME. A root
+    that resolves inside a Git worktree is skipped, not fatal: the
+    other root may still be reachable.
+
     Default is dry-run: reports counts without writing anything. Only
-    --apply rewrites the two files, and only entries older than
+    --apply rewrites the files, and only entries older than
     --older-than days (default 30 — long enough that a human skimming
     `report`'s "meter.error diagnostics: N lines" footer roughly once a
     month still sees a genuine problem before it becomes eligible for
     cleanup, short enough that a one-off misconfiguration from months
-    ago does not linger forever) are ever removed. Fail-loud (non-zero
-    on unexpected error) like validate/report/ingest, not fail-open
-    like event/bind-pr/snapshot-quota — silently swallowing a failure
-    here would hide whether cleanup actually ran."""
+    ago does not linger forever) are ever removed. This default will
+    NOT immediately clean up entries only a few days old — pass a
+    smaller --older-than for that (see bin/README.md). Fail-loud
+    (non-zero on unexpected error) like validate/report/ingest, not
+    fail-open like event/bind-pr/snapshot-quota — silently swallowing a
+    failure here would hide whether cleanup actually ran."""
     try:
         apply_changes, older_than_days = _parse_prune_diagnostics_args(args)
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
 
-    root = storage_root()
-    if in_git_worktree(root):
-        print(f"error: OCW_METER_HOME ({root}) resolves inside a Git worktree; refusing to operate", file=sys.stderr)
-        return 1
-
-    paths = Paths(root)
     now = datetime.now(timezone.utc)
     max_age = timedelta(days=older_than_days)
+    target_roots = _diagnostic_target_roots()
 
-    meter_errors_kept = []
-    meter_errors_dropped = 0
-    meter_errors_dropped_test_like = 0
-    if paths.meter_errors_file.exists():
+    mode = "applied" if apply_changes else "dry-run (pass --apply to actually delete)"
+    print(f"prune-diagnostics: {mode}, --older-than {older_than_days}d")
+
+    if not target_roots:
+        print(
+            "  no reachable storage root (OCW_METER_HOME and the default "
+            "$HOME-derived root are both unset or resolve inside a Git "
+            "worktree) — nothing to clean",
+            file=sys.stderr,
+        )
+        return 0
+
+    def _report(label, dropped, kept_count, dropped_test_like):
+        verb = "removed" if apply_changes else "would remove"
+        suffix = f" ({dropped_test_like} of those look test-derived, heuristic only)" if dropped_test_like else ""
+        print(f"  {label}: {verb} {dropped}, kept {kept_count}{suffix}")
+
+    errors_dropped_total = 0
+    errors_kept_total = 0
+    errors_dropped_test_like_total = 0
+    for root in target_roots:
+        paths = Paths(root)
+        if not paths.meter_errors_file.exists():
+            continue
         try:
             raw_text = paths.meter_errors_file.read_text(encoding="utf-8")
         except OSError as exc:
             print(f"error: could not read {paths.meter_errors_file}: {exc}", file=sys.stderr)
             return 1
-        for line in raw_text.splitlines():
-            if not line.strip():
-                continue
+        kept, dropped, dropped_test_like = _split_meter_errors_by_age(raw_text, now, max_age)
+        if apply_changes and dropped:
             try:
-                event = json.loads(line)
-            except json.JSONDecodeError:
-                # Not this subcommand's job to quarantine malformed
-                # lines — that is `validate`'s contract, and it only
-                # applies to events/*.jsonl. Keep anything unparseable
-                # rather than guess whether it is stale.
-                meter_errors_kept.append(line)
-                continue
-            ts = parse_ts(event.get("ts")) if isinstance(event, dict) else None
-            if ts is not None and (now - ts) > max_age:
-                meter_errors_dropped += 1
-                if _looks_test_derived(line):
-                    meter_errors_dropped_test_like += 1
-            else:
-                meter_errors_kept.append(line)
+                _rewrite_meter_errors_file(paths, kept)
+            except OSError as exc:
+                print(f"error: failed to rewrite {paths.meter_errors_file}: {exc}", file=sys.stderr)
+                return 1
+        errors_dropped_total += dropped
+        errors_kept_total += len(kept)
+        errors_dropped_test_like_total += dropped_test_like
+    _report("state/meter-errors.jsonl", errors_dropped_total, errors_kept_total, errors_dropped_test_like_total)
 
-    refusal_raw = load_json_state_file(paths, QUOTA_WORKTREE_REFUSAL_FILENAME)
+    default_root = default_storage_root()
+    if default_root is None or default_root not in target_roots:
+        print("  state/quota-worktree-refusal.json: default storage root unreachable — 0 removed, 0 kept")
+        return 0
+
+    refusal_paths = Paths(default_root)
+    refusal_raw, corrupt = _read_worktree_refusal_state_raw(refusal_paths)
+    if corrupt:
+        if apply_changes:
+            try:
+                save_worktree_refusal_state(refusal_paths, {})
+            except OSError as exc:
+                print(f"error: failed to rewrite quota-worktree-refusal.json: {exc}", file=sys.stderr)
+                return 1
+            print("  state/quota-worktree-refusal.json: could not parse (corrupt or not a JSON object) — replaced with an empty state")
+        else:
+            print(
+                "  state/quota-worktree-refusal.json: could not parse (corrupt or not a JSON object) "
+                "— pass --apply to replace it with an empty state"
+            )
+        return 0
+
     refusal_kept = {}
     refusal_dropped = 0
     refusal_dropped_test_like = 0
@@ -4354,48 +4529,14 @@ def cmd_prune_diagnostics(args):
         else:
             refusal_kept[bad_root] = checked_at
 
-    if apply_changes:
-        if meter_errors_dropped:
-            try:
-                if meter_errors_kept:
-                    ensure_dir(paths.state_dir, 0o700)
-                    tmp_fd, tmp_path = tempfile.mkstemp(dir=str(paths.state_dir), prefix=".tmp-", suffix=".jsonl")
-                    try:
-                        with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
-                            fh.write("\n".join(meter_errors_kept) + "\n")
-                        os.chmod(tmp_path, 0o600)
-                        os.replace(tmp_path, paths.meter_errors_file)
-                    except Exception:
-                        with contextlib.suppress(OSError):
-                            os.unlink(tmp_path)
-                        raise
-                else:
-                    paths.meter_errors_file.unlink()
-            except OSError as exc:
-                print(f"error: failed to rewrite {paths.meter_errors_file}: {exc}", file=sys.stderr)
-                return 1
-        if refusal_dropped:
-            try:
-                save_worktree_refusal_state(paths, refusal_kept)
-            except OSError as exc:
-                print(f"error: failed to rewrite quota-worktree-refusal.json: {exc}", file=sys.stderr)
-                return 1
+    if apply_changes and refusal_dropped:
+        try:
+            save_worktree_refusal_state(refusal_paths, refusal_kept)
+        except OSError as exc:
+            print(f"error: failed to rewrite quota-worktree-refusal.json: {exc}", file=sys.stderr)
+            return 1
 
-    mode = "applied" if apply_changes else "dry-run (pass --apply to actually delete)"
-    print(f"prune-diagnostics: {mode}, --older-than {older_than_days}d")
-
-    def _line(label, dropped, kept_count, dropped_test_like):
-        verb = "removed" if apply_changes else "would remove"
-        suffix = f" ({dropped_test_like} of those look test-derived, heuristic only)" if dropped_test_like else ""
-        print(f"  {label}: {verb} {dropped}, kept {kept_count}{suffix}")
-
-    _line("state/meter-errors.jsonl", meter_errors_dropped, len(meter_errors_kept), meter_errors_dropped_test_like)
-    _line(
-        "state/quota-worktree-refusal.json",
-        refusal_dropped,
-        len(refusal_kept),
-        refusal_dropped_test_like,
-    )
+    _report("state/quota-worktree-refusal.json", refusal_dropped, len(refusal_kept), refusal_dropped_test_like)
     return 0
 
 

--- a/bin/ocw-meter
+++ b/bin/ocw-meter
@@ -24,6 +24,7 @@ usage:
   ocw-meter bind-pr --run <run_id> --pr <n> [--url <url>]
   ocw-meter ingest [--since <rfc3339-ts>]
   ocw-meter snapshot-quota
+  ocw-meter prune-diagnostics [--older-than <days>] [--apply]
   ocw-meter validate [--file <path>]
   ocw-meter report [--pr <n>] [--repo <owner>/<name>] [--json]
   ocw-meter report --phase [--pr <n>] [--repo <owner>/<name>] [--json]
@@ -169,6 +170,20 @@ subcommands:
     samples sharing the same `window_id` is flagged (completeness:
     "partial", stderr warning) rather than silently trusted.
 
+  prune-diagnostics [--older-than <days>] [--apply]
+    Cleans up ocw-meter's OWN diagnostic/state sidecar files —
+    state/meter-errors.jsonl and state/quota-worktree-refusal.json —
+    ONLY. Never touches events/*.jsonl (deleting events is `prune`'s
+    territory, and `prune` remains deliberately unimplemented — see
+    notes below). Default is dry-run: reports how many entries in each
+    file are older than --older-than days (default 30) without
+    modifying either file; pass --apply to actually rewrite them.
+    Always reports both a removed count and a kept count, plus (as
+    informational-only text, never as a deletion criterion) how many of
+    the removed entries look test-derived by path shape. Fail-loud
+    (non-zero exit) on unexpected failure, like validate/report/ingest
+    — unlike event/bind-pr/snapshot-quota's fail-open contract.
+
 environment:
   OCW_METER_HOME
     default: $HOME/.local/state/ocw-meter
@@ -275,7 +290,7 @@ case "$cmd" in
     usage
     exit 0
     ;;
-  event | bind-pr | validate | report | ingest | snapshot-quota)
+  event | bind-pr | validate | report | ingest | snapshot-quota | prune-diagnostics)
     ;;
   *)
     usage >&2
@@ -392,7 +407,7 @@ import sys
 import tempfile
 import time
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 SCHEMA_VERSION = 1
 # Bumped whenever `ingest`'s transcript-line -> usage.message extraction
@@ -3813,8 +3828,35 @@ def save_quota_state(paths, state):
     save_json_state_file(paths, QUOTA_STATE_FILENAME, state)
 
 
-def load_worktree_refusal_state(paths):
-    return load_json_state_file(paths, QUOTA_WORKTREE_REFUSAL_FILENAME)
+def load_worktree_refusal_state(paths, now=None):
+    """Reads quota-worktree-refusal.json and prunes entries older than
+    QUOTA_SESSION_STATE_MAX_AGE_SECONDS on every read, not only when a
+    NEW refusal is about to be recorded (孫1, 計画書 DOC-2608081456【6】:
+    previously the only pruning happened inside the write-a-new-refusal
+    branch below, so once a misconfiguration stopped happening the last
+    stale entries sat in the file forever — 37 of them, all >24h old, on
+    this machine's real store).
+
+    If pruning actually dropped something, the pruned result is written
+    straight back so the file shrinks on the very next call after the
+    misconfiguration stops (no NEW refusal is needed to trigger cleanup
+    anymore). The overwhelmingly common case — nothing has ever been
+    refused, or nothing here has expired yet — stays a pure read with no
+    write I/O: `snapshot-quota` calls this on essentially every
+    statusLine tick (~60s throttle), so paying for a write on every call
+    would be wasteful for machines that never hit this path at all."""
+    raw = load_json_state_file(paths, QUOTA_WORKTREE_REFUSAL_FILENAME)
+    if now is None:
+        now = datetime.now(timezone.utc)
+    pruned = {}
+    for bad_root, checked_at in raw.items():
+        checked_ts = parse_ts(checked_at) if isinstance(checked_at, str) else None
+        if checked_ts is not None and (now - checked_ts).total_seconds() <= QUOTA_SESSION_STATE_MAX_AGE_SECONDS:
+            pruned[bad_root] = checked_at
+    if len(pruned) != len(raw):
+        with contextlib.suppress(Exception):
+            save_worktree_refusal_state(paths, pruned)
+    return pruned
 
 
 def save_worktree_refusal_state(paths, state):
@@ -3980,8 +4022,12 @@ def record_quota_sample(obj):
         if (default_root and default_root != root and not in_git_worktree(default_root))
         else None
     )
+    refusal_state = {}
     if refusal_paths is not None:
-        refusal_state = load_worktree_refusal_state(refusal_paths)
+        # Already pruned of anything >24h old (see load_worktree_refusal_
+        # state's own docstring) — reused below instead of re-loading, so
+        # a refusal doesn't pay for reading+pruning the file twice.
+        refusal_state = load_worktree_refusal_state(refusal_paths, now)
         last_refused_at = refusal_state.get(root)
         last_refused_at = parse_ts(last_refused_at) if isinstance(last_refused_at, str) else None
         if last_refused_at is not None and (now - last_refused_at).total_seconds() < interval:
@@ -3996,11 +4042,7 @@ def record_quota_sample(obj):
         emit_meter_error(root, "storage_home_inside_git_worktree", None)
         if refusal_paths is not None:
             with contextlib.suppress(Exception):
-                updated = {}
-                for bad_root, checked_at in load_worktree_refusal_state(refusal_paths).items():
-                    checked_ts = parse_ts(checked_at) if isinstance(checked_at, str) else None
-                    if checked_ts is not None and (now - checked_ts).total_seconds() <= QUOTA_SESSION_STATE_MAX_AGE_SECONDS:
-                        updated[bad_root] = checked_at
+                updated = dict(refusal_state)
                 updated[root] = iso_utc(now)
                 save_worktree_refusal_state(refusal_paths, updated)
         return
@@ -4190,6 +4232,173 @@ def cmd_snapshot_quota(args):
     return 0
 
 
+# ── subcommand: prune-diagnostics (孫1, 計画書 DOC-2608081456【4】【6】) ──
+
+PRUNE_DIAGNOSTICS_DEFAULT_OLDER_THAN_DAYS = 30
+
+# Best-effort heuristic ONLY — see _looks_test_derived below. Never used
+# to decide what actually gets deleted (age is the only deletion
+# criterion); shown in dry-run/apply output purely as extra context.
+_TEST_ARTIFACT_PATH_HINT = "ocw-meter-home"
+
+
+def _looks_test_derived(text):
+    """Real test fixtures across bin/tests/test_ocw_meter.py always name
+    their throwaway storage root literally "...ocw-meter-home" (see
+    OcwMeterTestCase.home and every `bad_home = <repo>/ocw-meter-home`
+    variant used to exercise the worktree-refusal path) — a name a real
+    misconfiguration is very unlikely to coincidentally share. False
+    negatives (a differently-named test fixture) are expected and fine:
+    this is informational only, never a deletion criterion (計画書
+    DOC-2608081456 孫1プロンプト: 「削除条件にはしない」)."""
+    return isinstance(text, str) and _TEST_ARTIFACT_PATH_HINT in text
+
+
+def _parse_prune_diagnostics_args(args):
+    apply_changes = False
+    older_than_days = PRUNE_DIAGNOSTICS_DEFAULT_OLDER_THAN_DAYS
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg == "--apply":
+            apply_changes = True
+            i += 1
+        elif arg == "--older-than":
+            if i + 1 >= len(args):
+                raise ValueError("--older-than requires a value")
+            raw = args[i + 1]
+            try:
+                older_than_days = int(raw)
+            except ValueError:
+                raise ValueError(f"--older-than expects an integer number of days, got: {raw}") from None
+            if older_than_days < 0:
+                raise ValueError("--older-than must not be negative")
+            i += 2
+        else:
+            raise ValueError(f"unrecognized argument: {arg}")
+    return apply_changes, older_than_days
+
+
+def cmd_prune_diagnostics(args):
+    """Cleans up ocw-meter's OWN diagnostic/state sidecar files —
+    state/meter-errors.jsonl and state/quota-worktree-refusal.json —
+    and ONLY those two. Deliberately never touches events/*.jsonl:
+    deleting observation events is `prune`'s territory, and `prune`
+    stays intentionally unimplemented (bin/README.md) — this subcommand
+    does not revisit that decision (計画書 DOC-2608081456【6】).
+
+    Default is dry-run: reports counts without writing anything. Only
+    --apply rewrites the two files, and only entries older than
+    --older-than days (default 30 — long enough that a human skimming
+    `report`'s "meter.error diagnostics: N lines" footer roughly once a
+    month still sees a genuine problem before it becomes eligible for
+    cleanup, short enough that a one-off misconfiguration from months
+    ago does not linger forever) are ever removed. Fail-loud (non-zero
+    on unexpected error) like validate/report/ingest, not fail-open
+    like event/bind-pr/snapshot-quota — silently swallowing a failure
+    here would hide whether cleanup actually ran."""
+    try:
+        apply_changes, older_than_days = _parse_prune_diagnostics_args(args)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    root = storage_root()
+    if in_git_worktree(root):
+        print(f"error: OCW_METER_HOME ({root}) resolves inside a Git worktree; refusing to operate", file=sys.stderr)
+        return 1
+
+    paths = Paths(root)
+    now = datetime.now(timezone.utc)
+    max_age = timedelta(days=older_than_days)
+
+    meter_errors_kept = []
+    meter_errors_dropped = 0
+    meter_errors_dropped_test_like = 0
+    if paths.meter_errors_file.exists():
+        try:
+            raw_text = paths.meter_errors_file.read_text(encoding="utf-8")
+        except OSError as exc:
+            print(f"error: could not read {paths.meter_errors_file}: {exc}", file=sys.stderr)
+            return 1
+        for line in raw_text.splitlines():
+            if not line.strip():
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                # Not this subcommand's job to quarantine malformed
+                # lines — that is `validate`'s contract, and it only
+                # applies to events/*.jsonl. Keep anything unparseable
+                # rather than guess whether it is stale.
+                meter_errors_kept.append(line)
+                continue
+            ts = parse_ts(event.get("ts")) if isinstance(event, dict) else None
+            if ts is not None and (now - ts) > max_age:
+                meter_errors_dropped += 1
+                if _looks_test_derived(line):
+                    meter_errors_dropped_test_like += 1
+            else:
+                meter_errors_kept.append(line)
+
+    refusal_raw = load_json_state_file(paths, QUOTA_WORKTREE_REFUSAL_FILENAME)
+    refusal_kept = {}
+    refusal_dropped = 0
+    refusal_dropped_test_like = 0
+    for bad_root, checked_at in refusal_raw.items():
+        checked_ts = parse_ts(checked_at) if isinstance(checked_at, str) else None
+        if checked_ts is not None and (now - checked_ts) > max_age:
+            refusal_dropped += 1
+            if _looks_test_derived(bad_root):
+                refusal_dropped_test_like += 1
+        else:
+            refusal_kept[bad_root] = checked_at
+
+    if apply_changes:
+        if meter_errors_dropped:
+            try:
+                if meter_errors_kept:
+                    ensure_dir(paths.state_dir, 0o700)
+                    tmp_fd, tmp_path = tempfile.mkstemp(dir=str(paths.state_dir), prefix=".tmp-", suffix=".jsonl")
+                    try:
+                        with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
+                            fh.write("\n".join(meter_errors_kept) + "\n")
+                        os.chmod(tmp_path, 0o600)
+                        os.replace(tmp_path, paths.meter_errors_file)
+                    except Exception:
+                        with contextlib.suppress(OSError):
+                            os.unlink(tmp_path)
+                        raise
+                else:
+                    paths.meter_errors_file.unlink()
+            except OSError as exc:
+                print(f"error: failed to rewrite {paths.meter_errors_file}: {exc}", file=sys.stderr)
+                return 1
+        if refusal_dropped:
+            try:
+                save_worktree_refusal_state(paths, refusal_kept)
+            except OSError as exc:
+                print(f"error: failed to rewrite quota-worktree-refusal.json: {exc}", file=sys.stderr)
+                return 1
+
+    mode = "applied" if apply_changes else "dry-run (pass --apply to actually delete)"
+    print(f"prune-diagnostics: {mode}, --older-than {older_than_days}d")
+
+    def _line(label, dropped, kept_count, dropped_test_like):
+        verb = "removed" if apply_changes else "would remove"
+        suffix = f" ({dropped_test_like} of those look test-derived, heuristic only)" if dropped_test_like else ""
+        print(f"  {label}: {verb} {dropped}, kept {kept_count}{suffix}")
+
+    _line("state/meter-errors.jsonl", meter_errors_dropped, len(meter_errors_kept), meter_errors_dropped_test_like)
+    _line(
+        "state/quota-worktree-refusal.json",
+        refusal_dropped,
+        len(refusal_kept),
+        refusal_dropped_test_like,
+    )
+    return 0
+
+
 # ── entry point ──────────────────────────────────────────────────────
 
 def main():
@@ -4236,13 +4445,15 @@ def main():
                 emit_meter_error(storage_root(), "cmd_snapshot_quota_unexpected_exception", exc)
             return 0
 
-    if cmd in ("validate", "report", "ingest"):
+    if cmd in ("validate", "report", "ingest", "prune-diagnostics"):
         try:
             if cmd == "validate":
                 return cmd_validate(rest)
             if cmd == "report":
                 return cmd_report(rest)
-            return cmd_ingest(rest)
+            if cmd == "ingest":
+                return cmd_ingest(rest)
+            return cmd_prune_diagnostics(rest)
         except Exception as exc:
             print(f"error: ocw-meter {cmd} failed: {redact_text(f'{type(exc).__name__}: {exc}')}", file=sys.stderr)
             return 1

--- a/bin/tests/test_ocw_meter.py
+++ b/bin/tests/test_ocw_meter.py
@@ -50,9 +50,27 @@ import sys
 import tempfile
 import time
 import unittest
+from datetime import datetime, timedelta, timezone
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
 OCW_METER = REPO_ROOT / "bin" / "ocw-meter"
+
+# ocw-meter's OWN fallback logic (emit_meter_error, the worktree-refusal
+# suppression cache) derives paths from real $HOME whenever OCW_METER_HOME
+# itself is refused (resolves inside a Git worktree) — not just from
+# OCW_METER_HOME. A test that forgets to override $HOME too therefore
+# silently writes into the developer's REAL ~/.local/state/ocw-meter
+# whenever it exercises that path (found live on this machine — see
+# docs/planning/DOC-2608081456_..._計画.md【4】: 37 stale worktree-refusal
+# entries and 6 meter-error diagnostics, all test-shaped). run_meter/
+# run_snapshot_quota below default $HOME to this ONE throwaway directory,
+# shared for the whole test run, whenever a caller doesn't explicitly pass
+# its own via extra_env — every OTHER test either never exercises a
+# $HOME-derived fallback path at all (OCW_METER_HOME points at a plain,
+# non-worktree tempdir, so ocw-meter never looks at $HOME) or already
+# passes its own explicit extra_env={"HOME": ...} to control exactly where
+# the fallback lands, so sharing this directory never collides with them.
+_TEST_DEFAULT_HOME = tempfile.mkdtemp(prefix="ocw-meter-test-default-home-")
 
 
 def run_meter(args, home, extra_env=None, timeout=30, cwd=None):
@@ -62,6 +80,8 @@ def run_meter(args, home, extra_env=None, timeout=30, cwd=None):
     # under, so assertions about "unset -> null" stay meaningful.
     for key in ("OCW_RUN_ID", "OCW_ROLE", "HERDR_WORKSPACE_ID", "HERDR_PANE_ID"):
         env.pop(key, None)
+    if not extra_env or "HOME" not in extra_env:
+        env["HOME"] = _TEST_DEFAULT_HOME
     if extra_env:
         env.update(extra_env)
     return subprocess.run(
@@ -82,6 +102,8 @@ def run_snapshot_quota(stdin_text, home, extra_env=None, timeout=30):
     env["OCW_METER_HOME"] = str(home)
     for key in ("OCW_RUN_ID", "OCW_ROLE", "HERDR_WORKSPACE_ID", "HERDR_PANE_ID"):
         env.pop(key, None)
+    if not extra_env or "HOME" not in extra_env:
+        env["HOME"] = _TEST_DEFAULT_HOME
     if extra_env:
         env.update(extra_env)
     return subprocess.run(
@@ -93,6 +115,22 @@ def run_snapshot_quota(stdin_text, home, extra_env=None, timeout=30):
         text=True,
         timeout=timeout,
     )
+
+
+def real_ocw_meter_home_snapshot():
+    """Fingerprints the developer's REAL ~/.local/state/ocw-meter (if it
+    exists) as {relative_path: (size, mtime_ns)} — turns the manual "did
+    the real store change?" check from 計画書 DOC-2608081456 全孫共通の注意
+    §4 into something a test can assert on directly."""
+    root = pathlib.Path(os.path.expanduser("~")) / ".local" / "state" / "ocw-meter"
+    if not root.exists():
+        return {}
+    snapshot = {}
+    for path in root.rglob("*"):
+        if path.is_file():
+            st = path.stat()
+            snapshot[str(path.relative_to(root))] = (st.st_size, st.st_mtime_ns)
+    return snapshot
 
 
 def read_events(home):
@@ -2147,6 +2185,13 @@ class SnapshotQuotaBasicsTests(OcwMeterTestCase):
         self.assertEqual(event["raw_ref"], str(raw_files[0]))
 
     def test_git_worktree_home_refuses_write_but_still_prints_display(self):
+        # 孫1 (計画書 DOC-2608081456【4】): this test deliberately does NOT
+        # pass its own extra_env={"HOME": ...} — it exists specifically to
+        # exercise run_snapshot_quota's DEFAULT isolation (see
+        # _TEST_DEFAULT_HOME above). Before that fix, the meter.error
+        # fallback this triggers landed in this developer's real
+        # ~/.local/state/ocw-meter every single test run.
+        real_home_before = real_ocw_meter_home_snapshot()
         repo_dir = pathlib.Path(self.tmpdir.name) / "repo"
         subprocess.run(["git", "init", "-q", str(repo_dir)], check=True)
         bad_home = repo_dir / "ocw-meter-home"
@@ -2155,6 +2200,264 @@ class SnapshotQuotaBasicsTests(OcwMeterTestCase):
         self.assertEqual(result.stdout.strip(), "5h:37% 7d:12% ctx:24%")
         self.assertIn("resolves inside a Git worktree", result.stderr)
         self.assertFalse((bad_home / "events").exists())
+
+        # The refusal's meter.error self-diagnostic must land under the
+        # isolated $HOME the helper substituted, not the real one.
+        fallback_root = pathlib.Path(_TEST_DEFAULT_HOME) / ".local" / "state" / "ocw-meter"
+        diagnostics = read_meter_errors(fallback_root)
+        self.assertTrue(
+            any(d["stage"] == "storage_home_inside_git_worktree" for d in diagnostics),
+            "expected the worktree-refusal meter.error under the isolated $HOME fallback",
+        )
+        self.assertEqual(real_ocw_meter_home_snapshot(), real_home_before)
+
+
+class HomeIsolationContractTests(OcwMeterTestCase):
+    """孫1 (計画書 DOC-2608081456【4】): a contract test for run_meter/
+    run_snapshot_quota themselves, not for ocw-meter — any test in this
+    file that forgets to override $HOME must still never touch the
+    developer's real ~/.local/state/ocw-meter, because the helpers
+    default it to a throwaway directory unless a test opts out."""
+
+    def test_run_snapshot_quota_never_touches_the_real_home_without_an_explicit_override(self):
+        before = real_ocw_meter_home_snapshot()
+        repo_dir = pathlib.Path(self.tmpdir.name) / "repo-for-home-isolation-contract"
+        subprocess.run(["git", "init", "-q", str(repo_dir)], check=True)
+        bad_home = repo_dir / "ocw-meter-home"
+        # Triggers the one code path (worktree-refusal fallback) that
+        # ever reads $HOME at all — anything less would pass trivially.
+        result = run_snapshot_quota(json.dumps(CLAUDE_STATUSLINE_SAMPLE), bad_home)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(real_ocw_meter_home_snapshot(), before)
+
+    def test_run_meter_never_touches_the_real_home_without_an_explicit_override(self):
+        before = real_ocw_meter_home_snapshot()
+        repo_dir = pathlib.Path(self.tmpdir.name) / "repo-for-home-isolation-contract-2"
+        subprocess.run(["git", "init", "-q", str(repo_dir)], check=True)
+        bad_home = repo_dir / "ocw-meter-home"
+        result = run_meter(["event", "run.start", "--idempotency-key", "k1"], bad_home)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(real_ocw_meter_home_snapshot(), before)
+
+
+def _iso(dt):
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{dt.microsecond // 1000:03d}Z"
+
+
+def _write_worktree_refusal_state(home, entries):
+    # The refusal cache lives at the DEFAULT storage root
+    # ($HOME/.local/state/ocw-meter), not at $HOME itself — mirrors
+    # default_storage_root() in bin/ocw-meter.
+    state_dir = pathlib.Path(home) / ".local" / "state" / "ocw-meter" / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    path = state_dir / "quota-worktree-refusal.json"
+    path.write_text(json.dumps(entries), encoding="utf-8")
+    return path
+
+
+class WorktreeRefusalPruningTests(OcwMeterTestCase):
+    """孫1 (計画書 DOC-2608081456【6】): quota-worktree-refusal.json used to
+    only drop entries older than QUOTA_SESSION_STATE_MAX_AGE_SECONDS (24h)
+    at the moment a NEW refusal was recorded — once refusals stopped
+    happening, stale entries sat in the file forever (37 of them, all
+    >24h old, found on this machine's real store). Pruning must now also
+    happen on every READ, so a normal (non-refusing) `snapshot-quota`
+    call cleans them up too."""
+
+    def _fresh_default_home(self):
+        # The refusal cache always lives at the DEFAULT ($HOME-derived)
+        # root, never at OCW_METER_HOME itself (see
+        # load_worktree_refusal_state's docstring in bin/ocw-meter) — this
+        # must be a directory distinct from self.home (OCW_METER_HOME) for
+        # that caching code path to engage at all.
+        default_home = pathlib.Path(self.tmpdir.name) / "fake-home-for-pruning"
+        default_home.mkdir()
+        return default_home
+
+    def _call(self, default_home):
+        return run_snapshot_quota(
+            json.dumps(CLAUDE_STATUSLINE_SAMPLE),
+            self.home,
+            extra_env={"HOME": str(default_home), "OCW_METER_QUOTA_INTERVAL": "0"},
+        )
+
+    def test_stale_entries_are_pruned_on_a_normal_non_refusing_call(self):
+        default_home = self._fresh_default_home()
+        old_ts = _iso(datetime.now(timezone.utc) - timedelta(hours=25))
+        state_path = _write_worktree_refusal_state(default_home, {"/some/old/bad/root": old_ts})
+
+        result = self._call(default_home)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(json.loads(state_path.read_text(encoding="utf-8")), {})
+
+    def test_entries_within_24h_are_kept(self):
+        default_home = self._fresh_default_home()
+        recent_ts = _iso(datetime.now(timezone.utc) - timedelta(hours=1))
+        state_path = _write_worktree_refusal_state(default_home, {"/some/recent/bad/root": recent_ts})
+
+        result = self._call(default_home)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(
+            json.loads(state_path.read_text(encoding="utf-8")),
+            {"/some/recent/bad/root": recent_ts},
+        )
+
+    def test_stale_and_fresh_entries_mixed_only_stale_ones_are_dropped(self):
+        default_home = self._fresh_default_home()
+        old_ts = _iso(datetime.now(timezone.utc) - timedelta(hours=25))
+        recent_ts = _iso(datetime.now(timezone.utc) - timedelta(hours=1))
+        state_path = _write_worktree_refusal_state(
+            default_home, {"/old/root": old_ts, "/recent/root": recent_ts}
+        )
+
+        result = self._call(default_home)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(
+            json.loads(state_path.read_text(encoding="utf-8")),
+            {"/recent/root": recent_ts},
+        )
+
+    def test_mtime_is_unchanged_when_nothing_needs_pruning(self):
+        # No wasted write-back on the common case: snapshot-quota is
+        # called on essentially every statusLine tick (~60s throttle), so
+        # a machine with zero or all-fresh refusal entries must not pay
+        # for a rewrite on every single call.
+        default_home = self._fresh_default_home()
+        recent_ts = _iso(datetime.now(timezone.utc) - timedelta(hours=1))
+        state_path = _write_worktree_refusal_state(default_home, {"/recent/root": recent_ts})
+        mtime_before = state_path.stat().st_mtime_ns
+
+        result = self._call(default_home)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(state_path.stat().st_mtime_ns, mtime_before)
+
+
+def _write_meter_errors(home, event_dicts):
+    state_dir = pathlib.Path(home) / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    path = state_dir / "meter-errors.jsonl"
+    path.write_text("".join(json.dumps(d, ensure_ascii=False) + "\n" for d in event_dicts), encoding="utf-8")
+    return path
+
+
+def _write_refusal_state_under_ocw_meter_home(home, entries):
+    # Unlike snapshot-quota's suppression cache (always at the DEFAULT,
+    # $HOME-derived root — see WorktreeRefusalPruningTests above),
+    # prune-diagnostics operates on Paths(storage_root()) directly, i.e.
+    # OCW_METER_HOME itself.
+    state_dir = pathlib.Path(home) / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    path = state_dir / "quota-worktree-refusal.json"
+    path.write_text(json.dumps(entries), encoding="utf-8")
+    return path
+
+
+class PruneDiagnosticsTests(OcwMeterTestCase):
+    """孫1 (計画書 DOC-2608081456【4】の後始末): `ocw-meter prune-diagnostics`
+    cleans up state/meter-errors.jsonl and state/quota-worktree-
+    refusal.json only, dry-run by default."""
+
+    def _seed(self):
+        old_ts = _iso(datetime.now(timezone.utc) - timedelta(days=31))
+        new_ts = _iso(datetime.now(timezone.utc) - timedelta(days=1))
+        errors_path = _write_meter_errors(
+            self.home,
+            [
+                {
+                    "schema_version": 1, "event_type": "meter.error",
+                    "idempotency_key": "meter-error:storage_home_inside_git_worktree:old",
+                    "ts": old_ts, "stage": "storage_home_inside_git_worktree", "completeness": "unknown",
+                },
+                {
+                    "schema_version": 1, "event_type": "meter.error",
+                    "idempotency_key": "meter-error:storage_home_inside_git_worktree:new",
+                    "ts": new_ts, "stage": "storage_home_inside_git_worktree", "completeness": "unknown",
+                },
+            ],
+        )
+        refusal_path = _write_refusal_state_under_ocw_meter_home(
+            self.home, {"/old/root": old_ts, "/new/root": new_ts}
+        )
+        return old_ts, new_ts, errors_path, refusal_path
+
+    def test_dry_run_default_removes_nothing_but_reports_counts(self):
+        old_ts, new_ts, errors_path, refusal_path = self._seed()
+
+        result = run_meter(["prune-diagnostics"], self.home)
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("dry-run", result.stdout)
+        self.assertIn("would remove 1, kept 1", result.stdout)
+
+        self.assertEqual(len(errors_path.read_text(encoding="utf-8").splitlines()), 2)
+        self.assertEqual(len(json.loads(refusal_path.read_text(encoding="utf-8"))), 2)
+
+    def test_apply_removes_only_old_entries(self):
+        old_ts, new_ts, errors_path, refusal_path = self._seed()
+
+        result = run_meter(["prune-diagnostics", "--apply"], self.home)
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("applied", result.stdout)
+        self.assertIn("removed 1, kept 1", result.stdout)
+
+        remaining_errors = [
+            json.loads(line) for line in errors_path.read_text(encoding="utf-8").splitlines() if line.strip()
+        ]
+        self.assertEqual(len(remaining_errors), 1)
+        self.assertEqual(remaining_errors[0]["ts"], new_ts)
+
+        self.assertEqual(json.loads(refusal_path.read_text(encoding="utf-8")), {"/new/root": new_ts})
+
+    def test_older_than_overrides_the_default_retention(self):
+        old_ts, new_ts, errors_path, refusal_path = self._seed()
+        # new_ts is 1 day old; --older-than 0 makes even that eligible.
+        result = run_meter(["prune-diagnostics", "--older-than", "0", "--apply"], self.home)
+        self.assertEqual(result.returncode, 0)
+        # Every entry was eligible, so the emptied meter-errors.jsonl is
+        # removed outright rather than left behind as a 0-byte file.
+        self.assertFalse(errors_path.exists())
+        self.assertEqual(json.loads(refusal_path.read_text(encoding="utf-8")), {})
+
+    def test_events_directory_is_never_touched(self):
+        old_ts, _new_ts, _errors_path, _refusal_path = self._seed()
+        # A real event, well outside the retention window, in events/ —
+        # must survive byte-for-byte. Deleting observation events is
+        # `prune`'s territory (deliberately unimplemented); this
+        # subcommand must never touch events/*.jsonl.
+        run_meter(["event", "run.start", "--idempotency-key", "k1", "--ts", old_ts], self.home)
+        events_dir = self.home / "events"
+        before = {p.name: p.read_bytes() for p in events_dir.glob("*.jsonl")}
+        self.assertTrue(before)
+
+        result = run_meter(["prune-diagnostics", "--apply"], self.home)
+        self.assertEqual(result.returncode, 0)
+
+        after = {p.name: p.read_bytes() for p in events_dir.glob("*.jsonl")}
+        self.assertEqual(before, after)
+
+    def test_missing_target_files_report_zero_and_exit_zero(self):
+        result = run_meter(["prune-diagnostics"], self.home)
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("would remove 0, kept 0", result.stdout)
+
+        result_apply = run_meter(["prune-diagnostics", "--apply"], self.home)
+        self.assertEqual(result_apply.returncode, 0)
+        self.assertIn("removed 0, kept 0", result_apply.stdout)
+
+    def test_corrupt_refusal_json_does_not_crash(self):
+        state_dir = self.home / "state"
+        state_dir.mkdir(parents=True, exist_ok=True)
+        (state_dir / "quota-worktree-refusal.json").write_text("{not valid json", encoding="utf-8")
+
+        result = run_meter(["prune-diagnostics", "--apply"], self.home)
+        self.assertEqual(result.returncode, 0)
+
+    def test_negative_older_than_is_rejected(self):
+        result = run_meter(["prune-diagnostics", "--older-than", "-1"], self.home)
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_non_numeric_older_than_is_rejected(self):
+        result = run_meter(["prune-diagnostics", "--older-than", "not-a-number"], self.home)
+        self.assertNotEqual(result.returncode, 0)
 
 
 class SnapshotQuotaThrottleTests(OcwMeterTestCase):

--- a/bin/tests/test_ocw_meter.py
+++ b/bin/tests/test_ocw_meter.py
@@ -2585,6 +2585,80 @@ class PruneDiagnosticsTests(OcwMeterTestCase):
         self.assertEqual(result.returncode, 0)
         self.assertFalse(errors_path.exists())
 
+    def test_trailing_slash_ocw_meter_home_does_not_double_count_meter_errors(self):
+        # round-2 review finding 2: storage_root() and
+        # default_storage_root() were deduped by bare string equality —
+        # a trailing slash on OCW_METER_HOME made the SAME real
+        # directory look like two distinct roots, so meter-errors.jsonl
+        # got read (and reported) twice, and dry-run/--apply disagreed.
+        fake_home = pathlib.Path(self.tmpdir.name) / "fake-home-for-trailing-slash"
+        fake_home.mkdir()
+        default_root = fake_home / ".local" / "state" / "ocw-meter"
+        old_ts = _iso(datetime.now(timezone.utc) - timedelta(days=31))
+        errors_path = _write_meter_errors(
+            default_root,
+            [
+                {
+                    "schema_version": 1, "event_type": "meter.error",
+                    "idempotency_key": "meter-error:storage_home_inside_git_worktree:old",
+                    "ts": old_ts, "stage": "storage_home_inside_git_worktree", "completeness": "unknown",
+                },
+            ],
+        )
+        # Same real directory as default_storage_root() would compute,
+        # spelled with a trailing slash as OCW_METER_HOME.
+        ocw_meter_home_with_slash = str(default_root) + "/"
+
+        result = run_meter(["prune-diagnostics"], ocw_meter_home_with_slash, extra_env={"HOME": str(fake_home)})
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("would remove 1, kept 0", result.stdout)
+
+        result_apply = run_meter(
+            ["prune-diagnostics", "--apply"], ocw_meter_home_with_slash, extra_env={"HOME": str(fake_home)}
+        )
+        self.assertEqual(result_apply.returncode, 0)
+        self.assertIn("removed 1, kept 0", result_apply.stdout)
+        # The only entry was dropped, so the file is removed outright
+        # (same convention as an emptied meter-errors.jsonl elsewhere) —
+        # if it had instead been double-counted, this would still exist
+        # with the second, incorrectly-kept "copy" of the entry.
+        self.assertFalse(errors_path.exists())
+
+    def test_per_root_breakdown_shown_when_both_roots_have_meter_errors(self):
+        # round-2 review finding 4: once meter-errors.jsonl could live
+        # under either root, the aggregate count alone no longer says
+        # which physical file(s) actually get rewritten.
+        fake_home = pathlib.Path(self.tmpdir.name) / "fake-home-for-breakdown"
+        fake_home.mkdir()
+        default_root = fake_home / ".local" / "state" / "ocw-meter"
+        old_ts = _iso(datetime.now(timezone.utc) - timedelta(days=31))
+        _write_meter_errors(
+            default_root,
+            [
+                {
+                    "schema_version": 1, "event_type": "meter.error",
+                    "idempotency_key": "meter-error:storage_home_inside_git_worktree:default",
+                    "ts": old_ts, "stage": "storage_home_inside_git_worktree", "completeness": "unknown",
+                },
+            ],
+        )
+        _write_meter_errors(
+            self.home,
+            [
+                {
+                    "schema_version": 1, "event_type": "meter.error",
+                    "idempotency_key": "meter-error:write_event_lock_timeout:custom",
+                    "ts": old_ts, "stage": "write_event_lock_timeout", "completeness": "unknown",
+                },
+            ],
+        )
+
+        result = run_meter(["prune-diagnostics"], self.home, extra_env={"HOME": str(fake_home)})
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("would remove 2, kept 0", result.stdout)
+        self.assertIn(str(pathlib.Path(default_root).resolve()), result.stdout)
+        self.assertIn(str(pathlib.Path(self.home).resolve()), result.stdout)
+
     def test_negative_older_than_is_rejected(self):
         result = run_meter(["prune-diagnostics", "--older-than", "-1"], self.home)
         self.assertNotEqual(result.returncode, 0)

--- a/bin/tests/test_ocw_meter.py
+++ b/bin/tests/test_ocw_meter.py
@@ -39,11 +39,14 @@ completion criteria this maps to (idempotency, message.id dedup,
 message.content non-exposure, cost formula, price-table versioning).
 """
 
+import atexit
 import concurrent.futures
+import hashlib
 import json
 import os
 import pathlib
 import pty
+import shutil
 import stat
 import subprocess
 import sys
@@ -62,15 +65,45 @@ OCW_METER = REPO_ROOT / "bin" / "ocw-meter"
 # silently writes into the developer's REAL ~/.local/state/ocw-meter
 # whenever it exercises that path (found live on this machine — see
 # docs/planning/DOC-2608081456_..._計画.md【4】: 37 stale worktree-refusal
-# entries and 6 meter-error diagnostics, all test-shaped). run_meter/
-# run_snapshot_quota below default $HOME to this ONE throwaway directory,
-# shared for the whole test run, whenever a caller doesn't explicitly pass
-# its own via extra_env — every OTHER test either never exercises a
-# $HOME-derived fallback path at all (OCW_METER_HOME points at a plain,
-# non-worktree tempdir, so ocw-meter never looks at $HOME) or already
-# passes its own explicit extra_env={"HOME": ...} to control exactly where
-# the fallback lands, so sharing this directory never collides with them.
-_TEST_DEFAULT_HOME = tempfile.mkdtemp(prefix="ocw-meter-test-default-home-")
+# entries and 6 meter-error diagnostics, all test-shaped).
+#
+# run_meter/run_snapshot_quota default $HOME (whenever a caller doesn't
+# explicitly pass its own via extra_env) to a directory keyed off `home`
+# (the OCW_METER_HOME argument), under this ONE scratch root — not a
+# single directory shared process-wide, and not a plain sibling of
+# `home` either (孫1 round-1 review findings 7 and 9, plus a round-2
+# fix for a bug the first attempt at finding 9 introduced):
+#
+# - **Independence** (finding 9): a single shared fallback directory let
+#   one test's write silently satisfy another, unrelated test's
+#   `idempotency_key`-deduped assertion (`emit_meter_error`'s dedup key
+#   is `meter-error:<stage>:<YYYY-MM-DD>` — two tests hitting the same
+#   stage on the same day only ever produce ONE line, written by
+#   whichever ran first). Keying the fallback directory off `home`,
+#   which is unique per call site in this file, means each test's own
+#   write path is what actually gets exercised and asserted on.
+# - **Cleanup** (finding 7): a single `atexit`-registered scratch root
+#   covers every per-`home` subdirectory ever created, however many
+#   distinct `home` values this file uses, instead of leaking one
+#   never-cleaned directory per test run.
+# - A first attempt at this made the fallback a plain SIBLING of `home`
+#   (`<home>-home-env-fallback`) to piggyback on `self.tmpdir`'s own
+#   cleanup. That breaks for exactly the tests worth having (the
+#   worktree-refusal ones): when `home` sits inside a throwaway Git repo
+#   (e.g. `repo_dir / "ocw-meter-home"`), a sibling of `home` sits
+#   inside that SAME repo, so `default_storage_root()` built from it
+#   resolves inside a Git worktree too — `emit_meter_error`'s own
+#   `in_git_worktree(target_root)` guard then refuses to write the
+#   diagnostic at all, silently defeating the very scenario under test.
+#   Hashing `home` into a name under a fixed, git-free scratch root
+#   sidesteps that entirely.
+_HOME_FALLBACK_SCRATCH_ROOT = tempfile.mkdtemp(prefix="ocw-meter-test-home-fallbacks-")
+atexit.register(shutil.rmtree, _HOME_FALLBACK_SCRATCH_ROOT, ignore_errors=True)
+
+
+def _default_home_for(home):
+    digest = hashlib.sha1(str(home).encode("utf-8")).hexdigest()[:16]
+    return str(pathlib.Path(_HOME_FALLBACK_SCRATCH_ROOT) / digest)
 
 
 def run_meter(args, home, extra_env=None, timeout=30, cwd=None):
@@ -81,7 +114,7 @@ def run_meter(args, home, extra_env=None, timeout=30, cwd=None):
     for key in ("OCW_RUN_ID", "OCW_ROLE", "HERDR_WORKSPACE_ID", "HERDR_PANE_ID"):
         env.pop(key, None)
     if not extra_env or "HOME" not in extra_env:
-        env["HOME"] = _TEST_DEFAULT_HOME
+        env["HOME"] = _default_home_for(home)
     if extra_env:
         env.update(extra_env)
     return subprocess.run(
@@ -103,7 +136,7 @@ def run_snapshot_quota(stdin_text, home, extra_env=None, timeout=30):
     for key in ("OCW_RUN_ID", "OCW_ROLE", "HERDR_WORKSPACE_ID", "HERDR_PANE_ID"):
         env.pop(key, None)
     if not extra_env or "HOME" not in extra_env:
-        env["HOME"] = _TEST_DEFAULT_HOME
+        env["HOME"] = _default_home_for(home)
     if extra_env:
         env.update(extra_env)
     return subprocess.run(
@@ -117,20 +150,35 @@ def run_snapshot_quota(stdin_text, home, extra_env=None, timeout=30):
     )
 
 
-def real_ocw_meter_home_snapshot():
-    """Fingerprints the developer's REAL ~/.local/state/ocw-meter (if it
-    exists) as {relative_path: (size, mtime_ns)} — turns the manual "did
-    the real store change?" check from 計画書 DOC-2608081456 全孫共通の注意
-    §4 into something a test can assert on directly."""
+def real_ocw_meter_home_contamination_fingerprint():
+    """A NARROW fingerprint of the developer's REAL
+    ~/.local/state/ocw-meter — deliberately NOT a full directory
+    snapshot (孫1 round-1 review finding 5): Claude Code's own statusLine
+    hook calls the real `ocw-meter snapshot-quota` roughly every 60s
+    independently of this test run, touching
+    events/YYYY-MM-DD.jsonl / state/quota-last-sample.json /
+    state/seen-keys/YYYY-MM.txt on this developer's machine — legitimate
+    activity a before/after full-tree equality check flags as a false
+    positive. This instead looks only at what a HOME-isolation bug in
+    THIS test file could plausibly cause: new test-shaped keys appearing
+    in quota-worktree-refusal.json, or meter-errors.jsonl growing."""
     root = pathlib.Path(os.path.expanduser("~")) / ".local" / "state" / "ocw-meter"
-    if not root.exists():
-        return {}
-    snapshot = {}
-    for path in root.rglob("*"):
-        if path.is_file():
-            st = path.stat()
-            snapshot[str(path.relative_to(root))] = (st.st_size, st.st_mtime_ns)
-    return snapshot
+    refusal_path = root / "state" / "quota-worktree-refusal.json"
+    test_like_refusal_keys = set()
+    if refusal_path.exists():
+        try:
+            data = json.loads(refusal_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            data = {}
+        if isinstance(data, dict):
+            test_like_refusal_keys = {k for k in data if "ocw-meter-home" in k}
+    meter_errors_path = root / "state" / "meter-errors.jsonl"
+    meter_errors_line_count = 0
+    if meter_errors_path.exists():
+        meter_errors_line_count = len(
+            [line for line in meter_errors_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        )
+    return test_like_refusal_keys, meter_errors_line_count
 
 
 def read_events(home):
@@ -2188,10 +2236,10 @@ class SnapshotQuotaBasicsTests(OcwMeterTestCase):
         # 孫1 (計画書 DOC-2608081456【4】): this test deliberately does NOT
         # pass its own extra_env={"HOME": ...} — it exists specifically to
         # exercise run_snapshot_quota's DEFAULT isolation (see
-        # _TEST_DEFAULT_HOME above). Before that fix, the meter.error
+        # _default_home_for above). Before that fix, the meter.error
         # fallback this triggers landed in this developer's real
         # ~/.local/state/ocw-meter every single test run.
-        real_home_before = real_ocw_meter_home_snapshot()
+        real_home_before = real_ocw_meter_home_contamination_fingerprint()
         repo_dir = pathlib.Path(self.tmpdir.name) / "repo"
         subprocess.run(["git", "init", "-q", str(repo_dir)], check=True)
         bad_home = repo_dir / "ocw-meter-home"
@@ -2202,14 +2250,16 @@ class SnapshotQuotaBasicsTests(OcwMeterTestCase):
         self.assertFalse((bad_home / "events").exists())
 
         # The refusal's meter.error self-diagnostic must land under the
-        # isolated $HOME the helper substituted, not the real one.
-        fallback_root = pathlib.Path(_TEST_DEFAULT_HOME) / ".local" / "state" / "ocw-meter"
+        # isolated $HOME the helper substituted for THIS call (derived
+        # from bad_home — round-1 review finding 9's per-call
+        # isolation), not the real one.
+        fallback_root = pathlib.Path(_default_home_for(bad_home)) / ".local" / "state" / "ocw-meter"
         diagnostics = read_meter_errors(fallback_root)
         self.assertTrue(
             any(d["stage"] == "storage_home_inside_git_worktree" for d in diagnostics),
             "expected the worktree-refusal meter.error under the isolated $HOME fallback",
         )
-        self.assertEqual(real_ocw_meter_home_snapshot(), real_home_before)
+        self.assertEqual(real_ocw_meter_home_contamination_fingerprint(), real_home_before)
 
 
 class HomeIsolationContractTests(OcwMeterTestCase):
@@ -2220,7 +2270,7 @@ class HomeIsolationContractTests(OcwMeterTestCase):
     default it to a throwaway directory unless a test opts out."""
 
     def test_run_snapshot_quota_never_touches_the_real_home_without_an_explicit_override(self):
-        before = real_ocw_meter_home_snapshot()
+        before = real_ocw_meter_home_contamination_fingerprint()
         repo_dir = pathlib.Path(self.tmpdir.name) / "repo-for-home-isolation-contract"
         subprocess.run(["git", "init", "-q", str(repo_dir)], check=True)
         bad_home = repo_dir / "ocw-meter-home"
@@ -2228,16 +2278,16 @@ class HomeIsolationContractTests(OcwMeterTestCase):
         # ever reads $HOME at all — anything less would pass trivially.
         result = run_snapshot_quota(json.dumps(CLAUDE_STATUSLINE_SAMPLE), bad_home)
         self.assertEqual(result.returncode, 0)
-        self.assertEqual(real_ocw_meter_home_snapshot(), before)
+        self.assertEqual(real_ocw_meter_home_contamination_fingerprint(), before)
 
     def test_run_meter_never_touches_the_real_home_without_an_explicit_override(self):
-        before = real_ocw_meter_home_snapshot()
+        before = real_ocw_meter_home_contamination_fingerprint()
         repo_dir = pathlib.Path(self.tmpdir.name) / "repo-for-home-isolation-contract-2"
         subprocess.run(["git", "init", "-q", str(repo_dir)], check=True)
         bad_home = repo_dir / "ocw-meter-home"
         result = run_meter(["event", "run.start", "--idempotency-key", "k1"], bad_home)
         self.assertEqual(result.returncode, 0)
-        self.assertEqual(real_ocw_meter_home_snapshot(), before)
+        self.assertEqual(real_ocw_meter_home_contamination_fingerprint(), before)
 
 
 def _iso(dt):
@@ -2267,9 +2317,10 @@ class WorktreeRefusalPruningTests(OcwMeterTestCase):
     def _fresh_default_home(self):
         # The refusal cache always lives at the DEFAULT ($HOME-derived)
         # root, never at OCW_METER_HOME itself (see
-        # load_worktree_refusal_state's docstring in bin/ocw-meter) — this
-        # must be a directory distinct from self.home (OCW_METER_HOME) for
-        # that caching code path to engage at all.
+        # load_and_prune_worktree_refusal_state's docstring in
+        # bin/ocw-meter) — this must be a directory distinct from
+        # self.home (OCW_METER_HOME) for that caching code path to
+        # engage at all.
         default_home = pathlib.Path(self.tmpdir.name) / "fake-home-for-pruning"
         default_home.mkdir()
         return default_home
@@ -2280,6 +2331,42 @@ class WorktreeRefusalPruningTests(OcwMeterTestCase):
             self.home,
             extra_env={"HOME": str(default_home), "OCW_METER_QUOTA_INTERVAL": "0"},
         )
+
+    def test_stale_entries_are_pruned_when_ocw_meter_home_is_unset_matching_the_default_root(self):
+        # round-1 review finding 1: THE single most common real
+        # configuration is OCW_METER_HOME unset entirely, in which case
+        # bin/ocw-meter's own bash wrapper defaults it to
+        # `$HOME/.local/state/ocw-meter` — i.e. `storage_root() ==
+        # default_storage_root()`. An earlier version of the read-time
+        # pruning fix additionally required the two to DIFFER before
+        # even loading (and therefore pruning) the file, which silently
+        # skipped pruning in exactly this configuration — the one this
+        # machine's real 37 stale entries needed. This reproduces that
+        # configuration directly (OCW_METER_HOME left unset, unlike
+        # every other test in this class, which always sets it via
+        # run_snapshot_quota's `home` argument).
+        home = pathlib.Path(self.tmpdir.name) / "home-for-unset-ocw-meter-home"
+        home.mkdir()
+        old_ts = _iso(datetime.now(timezone.utc) - timedelta(hours=25))
+        state_path = _write_worktree_refusal_state(home, {"/some/old/bad/root": old_ts})
+
+        env = dict(os.environ)
+        env.pop("OCW_METER_HOME", None)
+        env["HOME"] = str(home)
+        env["OCW_METER_QUOTA_INTERVAL"] = "0"
+        for key in ("OCW_RUN_ID", "OCW_ROLE", "HERDR_WORKSPACE_ID", "HERDR_PANE_ID"):
+            env.pop(key, None)
+        result = subprocess.run(
+            [str(OCW_METER), "snapshot-quota"],
+            cwd=str(REPO_ROOT),
+            env=env,
+            input=json.dumps(CLAUDE_STATUSLINE_SAMPLE),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(json.loads(state_path.read_text(encoding="utf-8")), {})
 
     def test_stale_entries_are_pruned_on_a_normal_non_refusing_call(self):
         default_home = self._fresh_default_home()
@@ -2340,12 +2427,16 @@ def _write_meter_errors(home, event_dicts):
     return path
 
 
-def _write_refusal_state_under_ocw_meter_home(home, entries):
-    # Unlike snapshot-quota's suppression cache (always at the DEFAULT,
-    # $HOME-derived root — see WorktreeRefusalPruningTests above),
-    # prune-diagnostics operates on Paths(storage_root()) directly, i.e.
-    # OCW_METER_HOME itself.
-    state_dir = pathlib.Path(home) / "state"
+def _write_refusal_state_at_default_root(ocw_meter_home, entries):
+    # round-1 review finding 2: quota-worktree-refusal.json is ALWAYS at
+    # the DEFAULT ($HOME-derived) root, never under a custom
+    # OCW_METER_HOME — same as WorktreeRefusalPruningTests'
+    # _write_worktree_refusal_state above. run_meter (used without an
+    # explicit extra_env={"HOME": ...} override here) defaults $HOME to
+    # `_default_home_for(ocw_meter_home)`, so that is where
+    # prune-diagnostics will actually look.
+    default_home = _default_home_for(ocw_meter_home)
+    state_dir = pathlib.Path(default_home) / ".local" / "state" / "ocw-meter" / "state"
     state_dir.mkdir(parents=True, exist_ok=True)
     path = state_dir / "quota-worktree-refusal.json"
     path.write_text(json.dumps(entries), encoding="utf-8")
@@ -2375,7 +2466,7 @@ class PruneDiagnosticsTests(OcwMeterTestCase):
                 },
             ],
         )
-        refusal_path = _write_refusal_state_under_ocw_meter_home(
+        refusal_path = _write_refusal_state_at_default_root(
             self.home, {"/old/root": old_ts, "/new/root": new_ts}
         )
         return old_ts, new_ts, errors_path, refusal_path
@@ -2443,13 +2534,56 @@ class PruneDiagnosticsTests(OcwMeterTestCase):
         self.assertEqual(result_apply.returncode, 0)
         self.assertIn("removed 0, kept 0", result_apply.stdout)
 
-    def test_corrupt_refusal_json_does_not_crash(self):
-        state_dir = self.home / "state"
-        state_dir.mkdir(parents=True, exist_ok=True)
-        (state_dir / "quota-worktree-refusal.json").write_text("{not valid json", encoding="utf-8")
+    def test_corrupt_refusal_json_is_reported_as_corrupt_not_silently_treated_as_empty(self):
+        # round-1 review finding 8: silently treating a corrupt file as
+        # {} (load_json_state_file's normal, correct behavior for every
+        # OTHER caller) let this subcommand report "kept 0" for a file
+        # that, in fact, was still sitting there unreadable. The dry-run
+        # output must say so, and --apply must repair it (replace with a
+        # valid empty state), not just avoid crashing.
+        default_home = _default_home_for(self.home)
+        refusal_path = pathlib.Path(default_home) / ".local" / "state" / "ocw-meter" / "state" / "quota-worktree-refusal.json"
+        refusal_path.parent.mkdir(parents=True, exist_ok=True)
+        refusal_path.write_text("{not valid json", encoding="utf-8")
 
-        result = run_meter(["prune-diagnostics", "--apply"], self.home)
+        result = run_meter(["prune-diagnostics"], self.home)
         self.assertEqual(result.returncode, 0)
+        self.assertIn("could not parse", result.stdout)
+        # Untouched in dry-run.
+        self.assertEqual(refusal_path.read_text(encoding="utf-8"), "{not valid json")
+
+        result_apply = run_meter(["prune-diagnostics", "--apply"], self.home)
+        self.assertEqual(result_apply.returncode, 0)
+        self.assertIn("replaced with an empty state", result_apply.stdout)
+        self.assertEqual(json.loads(refusal_path.read_text(encoding="utf-8")), {})
+
+    def test_meter_errors_under_the_default_root_fallback_are_also_cleaned(self):
+        # round-1 review finding 2: emit_meter_error falls back to the
+        # DEFAULT ($HOME-derived) root whenever OCW_METER_HOME itself is
+        # refused for resolving inside a Git worktree — this subcommand
+        # must reach diagnostics stored there too, not only under
+        # OCW_METER_HOME (which, in this exact scenario, cannot hold
+        # ANY of ocw-meter's own files at all).
+        repo_dir = pathlib.Path(self.tmpdir.name) / "repo-for-default-root-fallback"
+        subprocess.run(["git", "init", "-q", str(repo_dir)], check=True)
+        bad_home = repo_dir / "ocw-meter-home"
+        fake_home = pathlib.Path(self.tmpdir.name) / "fake-home-for-default-root-fallback"
+        fake_home.mkdir()
+        old_ts = _iso(datetime.now(timezone.utc) - timedelta(days=31))
+        errors_path = _write_meter_errors(
+            fake_home / ".local" / "state" / "ocw-meter",
+            [
+                {
+                    "schema_version": 1, "event_type": "meter.error",
+                    "idempotency_key": "meter-error:storage_home_inside_git_worktree:old",
+                    "ts": old_ts, "stage": "storage_home_inside_git_worktree", "completeness": "unknown",
+                },
+            ],
+        )
+
+        result = run_meter(["prune-diagnostics", "--apply"], bad_home, extra_env={"HOME": str(fake_home)})
+        self.assertEqual(result.returncode, 0)
+        self.assertFalse(errors_path.exists())
 
     def test_negative_older_than_is_rejected(self):
         result = run_meter(["prune-diagnostics", "--older-than", "-1"], self.home)


### PR DESCRIPTION
## 背景

dotfilesは、macOS / Linux / WSL2 で共通の開発環境を再現するための設定リポジトリです。その中の `ocw-meter` は、Claude Codeの利用量やコストを観測するツールです。

`ocw-meter-accuracy` 傘ブランチは、`ocw-meter` が出している数字と実際の観測データのズレを是正する取り組みです。その第一歩として、このプルリクエストは「観測データを保存する場所そのものの衛生状態」を直します。実際にこのマシンで使われているデータストアを調べたところ、テストが誤って本物のデータストアに書き込んでしまっていたことが判明しました。

## このプルリクエストの目的

以下の3点を実現します。

1. テストが実際のデータストア（`~/.local/state/ocw-meter`）を汚染しないようにする
2. `snapshot-quota` が「設定ミスの検出結果」をキャッシュしておくファイル（`quota-worktree-refusal.json`）から、古いエントリが消えずに残り続ける不具合を直す
3. ツール自身が残す診断用ファイルを掃除するための新しいサブコマンドを追加する

## 実装内容

### 1. テストによる実ストア汚染の停止

`bin/tests/test_ocw_meter.py` の `test_git_worktree_home_refuses_write_but_still_prints_display` というテストが、環境変数 `HOME` を差し替えずに実行されていたため、実際の開発者の `~/.local/state/ocw-meter` にテスト用のデータを書き込んでいました。実際にこのマシンのデータストアを調べたところ、テスト由来の設定ミス記録が37件、誤った診断ログが7件残っていました。

個別のテストに修正を1つ加えるだけでなく、テストヘルパー関数（`run_meter` / `run_snapshot_quota`）自体を、呼び出し側が明示的に `HOME` を指定しない限り、常にテスト専用の隔離ディレクトリを使うように変更しました。これにより、今後同じ種類のテストを書くときに `HOME` の差し替えを忘れても、実際のデータストアには影響しないようになります。隔離ディレクトリは呼び出しごとに一意な場所（`OCW_METER_HOME` 引数から一意に導出）に作られ、テストプロセス終了時にまとめて後始末されます。

この変更が正しく機能することを確認するテスト（`HomeIsolationContractTests`）と、実際に汚染を起こしていたテストへの回帰防止のアサーションを追加しました。

### 2. `quota-worktree-refusal.json` のプルーニング片手落ちの修正

設定ミスの検出結果をキャッシュするこのファイルは、24時間より古いエントリを削除する処理を持っていましたが、それが実行されるのは「新しい設定ミスを検出した瞬間」だけでした。そのため、設定ミスが起きなくなると、古いエントリが消えずにファイルに残り続けていました。

ファイルを読み込む際にも古いエントリを取り除くように変更しました。あわせて、通常時（設定ミスが1件もない、ごく普通の状態）で無駄なファイル書き込みが発生しないよう、実際に取り除くエントリがあったときだけファイルを書き戻すようにしています。**`OCW_METER_HOME` が未設定（＝既定の保存先と一致する、最も一般的な構成）でも正しくプルーニングが働くことを確認済みです。**

このファイルはマージ後、通常の `snapshot-quota` 呼び出し（次回のstatusLine描画）で自動的にプルーニングされます。人手での操作は不要です。

### 3. 診断ファイル専用の掃除サブコマンドの新設

`ocw-meter prune-diagnostics [--older-than <days>] [--apply]` というサブコマンドを新設しました。

- 対象は診断用の2つのファイル（`state/meter-errors.jsonl` と `state/quota-worktree-refusal.json`）のみです。観測データそのもの（`events/` 配下）には一切触れません
- `OCW_METER_HOME`（未設定時はその既定値）と、`$HOME` から導出される既定の保存先の両方を調べます。前者が設定ミスで使えない状態でも、後者が生きていれば処理を続けます
- 既定では何も削除せず、削除される件数だけを表示します（`--apply` を指定したときだけ実際に削除します）
- 保持期間は `--older-than` で指定でき、既定は30日です（直近数日以内の汚染はこの既定値では消えません。運用上のリテンションポリシーとして30日を選んでいるためで、直近の汚染を今すぐ消したい場合は後述の手順で `--older-than` を小さく指定してください）
- 壊れた `quota-worktree-refusal.json` があれば、その旨を報告し、`--apply` 時には空の状態に作り直します
- 失敗したときは黙って成功したふりをせず、エラーで終了します

### 実ストアの後始末について

このマシンの実ストアには、テスト汚染由来の `state/meter-errors.jsonl` 7行が残っています（`quota-worktree-refusal.json` の37件は上記の通りマージ後に自動で消えます）。修正後、dry-runで対象になることを確認済みです。

```
$ env -u OCW_METER_HOME ./bin/ocw-meter prune-diagnostics --older-than 1
prune-diagnostics: dry-run (pass --apply to actually delete), --older-than 1d
  state/meter-errors.jsonl: would remove 7, kept 0
  state/quota-worktree-refusal.json: would remove 37, kept 0 (37 of those look test-derived, heuristic only)
```

**このレビュー対応の中では `--apply` は実行していません**（実ストアへの書き込みをAIが独断で行うべきではないと判断したためです）。マージ後、実際に後始末する場合は次を実行してください。

```
ocw-meter prune-diagnostics --older-than 1 --apply
```

## レビューで見てほしいところ

- `prune-diagnostics` の既定の保持期間を30日としました。診断ログを毎月1回程度見返しても問題に気づける長さ、かつ古い一時的な設定ミスをいつまでも残さない長さ、という理由で選びましたが、妥当か確認をお願いします
- `state/meter-errors.jsonl` は「誰も書き換えないのでロック無しで追記してよい」という前提で設計されていましたが、`prune-diagnostics --apply` はこの前提の唯一の例外としてファイルを丸ごと書き換えます（ロックは取らない設計のままにしました）。並行して発生した診断1行を失う可能性があることをコメント・READMEに明記しましたが、ロックを取る設計に変更すべきか確認をお願いします

## テスト結果

`pre-commit run --all-files` / `bin/tests/lint.sh` / `python3 -m unittest discover -s bin/tests`（271件）すべて緑です。テストスイート実行後、実際の `~/.local/state/ocw-meter` が変化していないことも確認済みです。

## 今後の予定

この後、傘ブランチの他の孫（ingest自動実行、価格表の時間帯対応、費用の集計、帰属解決、文書整備）が続きます。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CJiZYagLUCiWmThCix4HTV
