### PR TITLE
ocw-meterのreportからingestを自動実行し、最終ingest時刻と鮮度をフッターに出す

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -311,29 +311,31 @@ ocw-meter validate [--file <path>]
 # イベント件数・completeness・coverage・推定費用の要約
 # --pr <n> を付けるとレビューラウンド一覧・人間介入回数・最終結果・
 # 同一5時間窓完走可否・そのPRのcash cost内訳も併せて出す
-ocw-meter report [--pr <n>] [--repo <owner>/<name>] [--json]
+# 実行のたびに ingest を自動実行してから集計する（--no-ingest で無効化可）。
+# 最終ingest時刻・鮮度警告はどのビューでもフッターに出る
+ocw-meter report [--pr <n>] [--repo <owner>/<name>] [--no-ingest] [--json]
 
 # 工程別（phase.start/endの時間ペアとusage.messageの時刻範囲による
 # ベストエフォート対応）のトークン・費用・所要時間
-ocw-meter report --phase [--pr <n>] [--repo <owner>/<name>] [--json]
+ocw-meter report --phase [--pr <n>] [--repo <owner>/<name>] [--no-ingest] [--json]
 
 # provider+model別のトークン・推定費用
-ocw-meter report --model [--pr <n>] [--repo <owner>/<name>] [--json]
+ocw-meter report --model [--pr <n>] [--repo <owner>/<name>] [--no-ingest] [--json]
 
 # role（commander/implementer/reviewer/unknown）別のイベント数・トークン・推定費用
-ocw-meter report --role [--pr <n>] [--repo <owner>/<name>] [--json]
+ocw-meter report --role [--pr <n>] [--repo <owner>/<name>] [--no-ingest] [--json]
 
 # 5時間窓（window_id）別のquota.sample集計。直接紐付き/時間範囲重複の
 # PRを別フィールドで提示
-ocw-meter report --window [--pr <n>] [--repo <owner>/<name>] [--json]
+ocw-meter report --window [--pr <n>] [--repo <owner>/<name>] [--no-ingest] [--json]
 
 # 月次: cash cost（従量API）/ capacity cost（Claudeサブスク枠）/
 # process efficiency（承認済みPRあたりの費用・ラウンド数等）を分離して表示
 # --reconcile とは別物（こちらは突合をしない）
-ocw-meter report --month [YYYY-MM] [--repo <owner>/<name>] [--json]
+ocw-meter report --month [YYYY-MM] [--repo <owner>/<name>] [--no-ingest] [--json]
 
 # model別トークン集計・推定費用・provider管理画面との突合（coverage比率）
-ocw-meter report --reconcile [--month <YYYY-MM>] [--provider-total <model>=<tokens> ...] [--json]
+ocw-meter report --reconcile [--month <YYYY-MM>] [--provider-total <model>=<tokens> ...] [--no-ingest] [--json]
 
 # statusLineコマンドとして呼ばれ、stdinのJSONからquota.sampleを1行append、表示文字列をstdoutへ返す
 ocw-meter snapshot-quota
@@ -347,7 +349,7 @@ ocw-meter prune-diagnostics [--older-than <days>] [--apply]
 |---|---|
 | `event` / `bind-pr` | **常に exit 0**。stderrに1行warnのみ。本番フローを止めない |
 | `snapshot-quota` | **常に exit 0 かつ必ずstdoutに表示文字列を出す**（statusLineが壊れて画面が崩れる事態を絶対に避ける。event/bind-pr以上に厳格なfail-open） |
-| `validate` / `report` / `ingest` / `prune-diagnostics` | 失敗したら非ゼロで落ちる（壊れたデータを黙って集計しない） |
+| `validate` / `report` / `ingest` / `prune-diagnostics` | 失敗したら非ゼロで落ちる（壊れたデータを黙って集計しない）。ただし `report` が実行のたびに自動実行する `ingest` 自体が失敗した場合（Gitワークツリー拒否等）はこの例外で、`report` は exit 0 のまま失敗をフッターに表示して既存データで応答する（`--no-ingest` で自動実行自体を無効化できる） |
 
 **`prune-diagnostics` の既定保持期間（30日）について**: これは運用上のリテンションポリシーであり、
 「今すぐ全部消す」既定ではない。数日〜1週間前にできたばかりのエントリ（一時的な設定ミスの記録など）を

--- a/bin/ocw-meter
+++ b/bin/ocw-meter
@@ -1599,7 +1599,13 @@ def usage_cost_footer(usage_events):
         cost_basis_summary = ", ".join(sorted(cost_bases)) if cost_bases else "(none)"
         cost_estimate_summary = f"${cost_sum:.2f} (estimated — not an invoice)" if has_cost else "null"
     else:
-        coverage = "no usage.message events yet — run 'ocw-meter ingest'"
+        # PR #57 review round 1 finding 1: `report` now ingests
+        # automatically before this function ever runs, so "no events
+        # yet" no longer means "you forgot to run ingest" — it means the
+        # transcript store had nothing matching. Telling the reader to
+        # run the very thing that just ran is a contradiction they'd see
+        # two lines below in the freshness footer.
+        coverage = "no usage.message events found in transcripts (ingest already ran automatically)"
         price_table_summary = "not applicable (no cost data ingested yet)"
         cost_basis_summary = "not applicable (no cost data ingested yet)"
         cost_estimate_summary = "null"
@@ -1668,20 +1674,36 @@ def ingest_freshness_footer(cursor, ingest_run):
     `last_ingest_at` deliberately does NOT fall back to guessing from a
     file mtime when the cursor predates this field (plan's "推測で埋め
     ない" principle, §全孫共通の注意5) — an old `ingest-cursor.json`
-    reports "unknown", full stop."""
+    reports "unknown", full stop.
+
+    `last_ingest_at` itself is a display string (see above), so a
+    machine `--json` consumer can't recover the raw timestamp from it
+    without re-parsing a human sentence — `last_ingest_at_rfc3339` (PR
+    #57 review round 1 finding 6) carries the same value `cursor` itself
+    stores, untouched, specifically for that use (e.g.
+    docs/reference/DOC-2608021229-b_...'s "transcribe report --json into
+    the writeup" workflow); it is `None` when unknown, same as any other
+    JSON consumer would expect for "no value yet"."""
     last_ingest_raw = cursor.get("last_ingest_at")
     last_ingest_dt = parse_ts(last_ingest_raw) if isinstance(last_ingest_raw, str) else None
     if last_ingest_dt is None:
         last_ingest_at = "unknown (次回 ingest で記録される)"
+        last_ingest_at_rfc3339 = None
         freshness_warning = "(none — last ingest time unknown)"
     else:
         age_seconds = (datetime.now(timezone.utc) - last_ingest_dt).total_seconds()
         last_ingest_at = f"{last_ingest_raw} ({format_elapsed_seconds(age_seconds)} 経過)"
+        last_ingest_at_rfc3339 = last_ingest_raw
+        # PR #57 review round 1 finding 4: the plan's own wording
+        # ("一定時間以上経っていたら") is inclusive ("以上" = "at or
+        # above"), so a sample landing on the threshold exactly (rare,
+        # but real once ingest runs on a fixed schedule) still warns —
+        # `>=`, not `>`.
         freshness_warning = (
             f"最終ingestから{format_elapsed_seconds(age_seconds)}経過しています"
             f"（閾値 {INGEST_STALE_THRESHOLD_SECONDS // 3600}h）。"
             "自動ingestが失敗し続けていないか確認してください"
-            if age_seconds > INGEST_STALE_THRESHOLD_SECONDS else "(none)"
+            if age_seconds >= INGEST_STALE_THRESHOLD_SECONDS else "(none)"
         )
 
     status = ingest_run["status"]
@@ -1695,6 +1717,7 @@ def ingest_freshness_footer(cursor, ingest_run):
 
     return {
         "last_ingest_at": last_ingest_at,
+        "last_ingest_at_rfc3339": last_ingest_at_rfc3339,
         "ingest_this_run": ingest_this_run,
         "ingest_freshness_warning": freshness_warning,
     }
@@ -1720,6 +1743,7 @@ def print_footer_text(footer_completeness, footer_cost, footer_freshness, total)
     print(f"cost_basis:    {footer_cost['cost_basis']}")
     print(f"cost_estimate: {footer_cost['cost_estimate_usd']}")
     print(f"last_ingest_at: {footer_freshness['last_ingest_at']}")
+    print(f"last_ingest_at_rfc3339: {footer_freshness['last_ingest_at_rfc3339'] or 'unknown'}")
     print(f"ingest (this run): {footer_freshness['ingest_this_run']}")
     print(f"ingest_freshness_warning: {footer_freshness['ingest_freshness_warning']}")
 
@@ -2272,7 +2296,9 @@ def _report_reconcile(paths, month, provider_totals, as_json, footer_freshness):
     coverage_text = (
         f"{total_messages} usage.message event(s) for {month}; per-model coverage_ratio requires "
         "--provider-total <model>=<tokens>"
-        if total_messages else f"no usage.message events for {month} — run 'ocw-meter ingest' first"
+        # PR #57 review round 1 finding 1: see usage_cost_footer's
+        # comment above — this ran automatically before we got here.
+        if total_messages else f"no usage.message events found in transcripts for {month} (ingest already ran automatically)"
     )
 
     summary = {
@@ -2305,7 +2331,7 @@ def _report_reconcile(paths, month, provider_totals, as_json, footer_freshness):
     print(f"month:         {summary['month']}")
     print(f"cost_basis:    {summary['cost_basis']}")
     if not models_out:
-        print("models:        (no usage.message events for this month — run 'ocw-meter ingest' first)")
+        print("models:        (no usage.message events found in transcripts for this month — ingest already ran automatically)")
     for model, m in sorted(models_out.items()):
         print(f"  {model}:")
         print(f"    messages:             {m['messages']}")
@@ -2564,6 +2590,53 @@ def cmd_report(args):
         print("error: --repo has no effect without --pr, --window, or standalone --month — it only scopes PR attribution", file=sys.stderr)
         return 1
 
+    # PR #57 review round 1 finding 7: both the repo resolution below and
+    # the --month validation that follows it used to run AFTER the
+    # auto-ingest call — a request that was always going to fail loud
+    # (a malformed --month, or no resolvable repo) still ran a whole
+    # live ingest (writing events/cursor) first. All pure input/context
+    # validation now happens before `root`/`paths` are even touched.
+    #
+    # Round-2 review finding 10 (regression introduced by round-1's own
+    # fix for finding 1): `events_for_pr`'s repo scoping only works if a
+    # repo is actually resolved. `report` can be run from ANYWHERE
+    # (unlike `event`, which is only ever called from inside a worktree
+    # by `ocw`/`pr-review-loop`) — running it from outside any git repo
+    # makes `git_repo_slug()` return None, and `e.get("repo") == None`
+    # then matches every repo:null event (exactly the class of event
+    # `events_for_pr`'s docstring promises to EXCLUDE), while every
+    # `pr.bind`/legitimate event WITH a repo set gets rejected. Measured:
+    # this flips finding 1's fix from "correct data + contamination" to
+    # "contamination only, zero correct events" when run from outside a
+    # git repo. Since resolving "which repo" is required for --pr and
+    # for --month's process_efficiency (both call `events_for_pr`), fail
+    # loud instead of silently scoping to the wrong (or no) repo.
+    # `--repo <owner>/<name>` is the escape hatch for a case where this
+    # needs to run from outside the target repo's own worktree.
+    repo = explicit_repo or git_repo_slug()
+    needs_repo = filter_pr is not None or (month_flag_present and view is None) or view == "window"
+    if needs_repo and not repo:
+        print(
+            "error: could not resolve a repo for PR-scoped reporting (not inside a git repo with an "
+            "'origin' remote, and --repo <owner>/<name> was not given). --pr, --window, and --month all need this "
+            "to avoid scoping to another repo's same-numbered PR in the shared ocw-meter store.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if reconcile:
+        month, err = normalize_month_arg(month)
+        if err:
+            print(err, file=sys.stderr)
+            return 1
+    elif month_flag_present and view is None:
+        # 孫5 §1 --month (standalone, i.e. NOT --reconcile): cash cost /
+        # capacity cost / process efficiency, kept separate (plan §16).
+        month, err = normalize_month_arg(month)
+        if err:
+            print(err, file=sys.stderr)
+            return 1
+
     root = storage_root()
     if in_git_worktree(root):
         print(f"error: OCW_METER_HOME ({root}) resolves inside a Git worktree; refusing to operate", file=sys.stderr)
@@ -2581,39 +2654,7 @@ def cmd_report(args):
     footer_freshness = ingest_freshness_footer(load_ingest_cursor(paths), ingest_run)
 
     if reconcile:
-        month, err = normalize_month_arg(month)
-        if err:
-            print(err, file=sys.stderr)
-            return 1
         return _report_reconcile(paths, month, provider_totals, as_json, footer_freshness)
-
-    # Round-2 review finding 10 (regression introduced by round-1's own
-    # fix for finding 1): `events_for_pr`'s repo scoping only works if a
-    # repo is actually resolved. `report` can be run from ANYWHERE
-    # (unlike `event`, which is only ever
-    # called from inside a worktree by `ocw`/`pr-review-loop`) — running
-    # it from outside any git repo makes `git_repo_slug()` return None,
-    # and `e.get("repo") == None` then matches every repo:null event
-    # (exactly the class of event `events_for_pr`'s docstring promises
-    # to EXCLUDE), while every `pr.bind`/legitimate event WITH a repo
-    # set gets rejected. Measured: this flips finding 1's fix from
-    # "correct data + contamination" to "contamination only, zero
-    # correct events" when run from outside a git repo. Since resolving
-    # "which repo" is required for --pr and for --month's
-    # process_efficiency (both call `events_for_pr`), fail loud instead
-    # of silently scoping to the wrong (or no) repo. `--repo
-    # <owner>/<name>` is the escape hatch for a case where this needs to
-    # run from outside the target repo's own worktree.
-    repo = explicit_repo or git_repo_slug()
-    needs_repo = filter_pr is not None or (month_flag_present and view is None) or view == "window"
-    if needs_repo and not repo:
-        print(
-            "error: could not resolve a repo for PR-scoped reporting (not inside a git repo with an "
-            "'origin' remote, and --repo <owner>/<name> was not given). --pr, --window, and --month all need this "
-            "to avoid scoping to another repo's same-numbered PR in the shared ocw-meter store.",
-            file=sys.stderr,
-        )
-        return 1
 
     valid_events, malformed = [], 0
     for obj, _raw, error in iter_stored_events(paths):
@@ -2623,12 +2664,6 @@ def cmd_report(args):
             valid_events.append(obj)
 
     if month_flag_present and view is None:
-        # 孫5 §1 --month (standalone, i.e. NOT --reconcile): cash cost /
-        # capacity cost / process efficiency, kept separate (plan §16).
-        month, err = normalize_month_arg(month)
-        if err:
-            print(err, file=sys.stderr)
-            return 1
         return _report_month_standalone(paths, valid_events, malformed, month, repo, as_json, footer_freshness)
 
     if filter_pr is not None:
@@ -3708,19 +3743,28 @@ def perform_ingest(root, since_dt=None):
     # (restricted or not) simply re-reads the same unconsumed range from
     # wherever the last UNRESTRICTED run left off.
     # 計画書 DOC-2608081456孫2 §2: the cursor now also records WHEN the
-    # last full ingest completed and that it completed cleanly — the
-    # freshness footer reads these two fields back (`ingest_freshness_
-    # footer`). Recorded here, not on failure, so a stale timestamp
-    # after this run means exactly what it says: "this is the last time
-    # ingest actually finished", not "the last time it was attempted".
-    # Not recorded under --since either, for the same reason the file
-    # cursor itself isn't: a --since run is deliberately read-only with
-    # respect to persisted ingest state (see the comment above).
+    # last full ingest completed — the freshness footer
+    # (`ingest_freshness_footer`) reads this back. Recorded here, not on
+    # failure, so a stale timestamp after this run means exactly what it
+    # says: "this is the last time ingest actually finished", not "the
+    # last time it was attempted". Not recorded under --since either,
+    # for the same reason the file cursor itself isn't: a --since run is
+    # deliberately read-only with respect to persisted ingest state (see
+    # the comment above).
+    #
+    # PR #57 review round 1 finding 5: an earlier version of this also
+    # wrote `"last_ingest_result": "ok"` — but this branch is the ONLY
+    # place that ever calls `save_ingest_cursor`, and only ever on
+    # success, so that field could structurally never hold any value
+    # other than `"ok"`. A field that can't vary carries no information;
+    # dropped rather than kept as a decoration. If a persisted FAILED-
+    # attempt record ever becomes worth having, it belongs in its own
+    # field (e.g. `last_ingest_attempt_result`) written on the failure
+    # paths too — not bolted onto this success-only one.
     if since_dt is None:
         save_ingest_cursor(paths, {
             "files": new_cursor_files,
             "last_ingest_at": iso_utc(datetime.now(timezone.utc)),
-            "last_ingest_result": "ok",
         })
 
     return {

--- a/bin/ocw-meter
+++ b/bin/ocw-meter
@@ -94,7 +94,7 @@ subcommands:
     automatic run entirely (read-only use, or when you want to control
     exactly what `report` sees). The footer also always includes the
     last successful ingest's timestamp, this run's own ingest outcome,
-    and a staleness warning once that timestamp is more than 24h old.
+    and a staleness warning once that timestamp is 24h old or older.
 
     Otherwise prints an event-count / completeness / coverage summary,
     including total estimated cost and which price_table_version(s)/

--- a/bin/ocw-meter
+++ b/bin/ocw-meter
@@ -1599,13 +1599,19 @@ def usage_cost_footer(usage_events):
         cost_basis_summary = ", ".join(sorted(cost_bases)) if cost_bases else "(none)"
         cost_estimate_summary = f"${cost_sum:.2f} (estimated — not an invoice)" if has_cost else "null"
     else:
-        # PR #57 review round 1 finding 1: `report` now ingests
-        # automatically before this function ever runs, so "no events
-        # yet" no longer means "you forgot to run ingest" — it means the
-        # transcript store had nothing matching. Telling the reader to
-        # run the very thing that just ran is a contradiction they'd see
-        # two lines below in the freshness footer.
-        coverage = "no usage.message events found in transcripts (ingest already ran automatically)"
+        # PR #57 review round 1 finding 1 / round 2 finding "新規2": this
+        # used to say "run 'ocw-meter ingest'", which contradicted the
+        # freshness footer a few lines below once `report` started
+        # auto-ingesting (round 1) — and a version that instead asserted
+        # ingest "already ran automatically" (round 1's own fix)
+        # contradicted the SAME footer line in the other direction under
+        # `--no-ingest`, where it deliberately didn't run. This function
+        # has no way to know which case it's in (it isn't passed
+        # `ingest_run`/`footer_freshness`), so it now says neither —
+        # whether ingest ran this time is `ingest_freshness_footer`'s
+        # `ingest (this run):` line's job alone, not duplicated (and
+        # therefore contradictable) here.
+        coverage = "no usage.message events found in transcripts"
         price_table_summary = "not applicable (no cost data ingested yet)"
         cost_basis_summary = "not applicable (no cost data ingested yet)"
         cost_estimate_summary = "null"
@@ -2296,9 +2302,11 @@ def _report_reconcile(paths, month, provider_totals, as_json, footer_freshness):
     coverage_text = (
         f"{total_messages} usage.message event(s) for {month}; per-model coverage_ratio requires "
         "--provider-total <model>=<tokens>"
-        # PR #57 review round 1 finding 1: see usage_cost_footer's
-        # comment above — this ran automatically before we got here.
-        if total_messages else f"no usage.message events found in transcripts for {month} (ingest already ran automatically)"
+        # PR #57 review round 1 finding 1 / round 2 finding "新規2": see
+        # usage_cost_footer's comment above — same reasoning, this
+        # function has no way to know whether this run's ingest actually
+        # ran (--no-ingest), so it doesn't claim either way.
+        if total_messages else f"no usage.message events found in transcripts for {month}"
     )
 
     summary = {
@@ -2331,7 +2339,7 @@ def _report_reconcile(paths, month, provider_totals, as_json, footer_freshness):
     print(f"month:         {summary['month']}")
     print(f"cost_basis:    {summary['cost_basis']}")
     if not models_out:
-        print("models:        (no usage.message events found in transcripts for this month — ingest already ran automatically)")
+        print("models:        (no usage.message events found in transcripts for this month)")
     for model, m in sorted(models_out.items()):
         print(f"  {model}:")
         print(f"    messages:             {m['messages']}")
@@ -2614,7 +2622,19 @@ def cmd_report(args):
     # `--repo <owner>/<name>` is the escape hatch for a case where this
     # needs to run from outside the target repo's own worktree.
     repo = explicit_repo or git_repo_slug()
-    needs_repo = filter_pr is not None or (month_flag_present and view is None) or view == "window"
+    # PR #57 review round 2 finding "新規1": moving this check up (round 1
+    # finding 7, above) exposed it to standalone --reconcile for the
+    # first time — previously the `if reconcile: return
+    # _report_reconcile(...)` early-return below made this condition
+    # dead code for that path, so it never needed the `and not
+    # reconcile` its sibling `repo_is_used` (right above) already has.
+    # `_report_reconcile()` never takes a `repo` argument at all (it does
+    # a store-wide model/token reconciliation, no PR scoping), so
+    # requiring one made `report --reconcile --month ...` — a documented
+    # workflow (docs/reference/DOC-2608021229-b) — fail outside any git
+    # repo with no `--repo` escape hatch (repo_is_used's `not reconcile`
+    # rejects `--repo` too in that combination).
+    needs_repo = filter_pr is not None or (month_flag_present and view is None and not reconcile) or view == "window"
     if needs_repo and not repo:
         print(
             "error: could not resolve a repo for PR-scoped reporting (not inside a git repo with an "

--- a/bin/ocw-meter
+++ b/bin/ocw-meter
@@ -26,13 +26,13 @@ usage:
   ocw-meter snapshot-quota
   ocw-meter prune-diagnostics [--older-than <days>] [--apply]
   ocw-meter validate [--file <path>]
-  ocw-meter report [--pr <n>] [--repo <owner>/<name>] [--json]
-  ocw-meter report --phase [--pr <n>] [--repo <owner>/<name>] [--json]
-  ocw-meter report --model [--pr <n>] [--repo <owner>/<name>] [--json]
-  ocw-meter report --role [--pr <n>] [--repo <owner>/<name>] [--json]
-  ocw-meter report --window [--pr <n>] [--repo <owner>/<name>] [--json]
-  ocw-meter report --month [YYYY-MM] [--repo <owner>/<name>] [--json]
-  ocw-meter report --reconcile [--month <YYYY-MM>] [--provider-total <model>=<tokens> ...] [--json]
+  ocw-meter report [--pr <n>] [--repo <owner>/<name>] [--no-ingest] [--json]
+  ocw-meter report --phase [--pr <n>] [--repo <owner>/<name>] [--no-ingest] [--json]
+  ocw-meter report --model [--pr <n>] [--repo <owner>/<name>] [--no-ingest] [--json]
+  ocw-meter report --role [--pr <n>] [--repo <owner>/<name>] [--no-ingest] [--json]
+  ocw-meter report --window [--pr <n>] [--repo <owner>/<name>] [--no-ingest] [--json]
+  ocw-meter report --month [YYYY-MM] [--repo <owner>/<name>] [--no-ingest] [--json]
+  ocw-meter report --reconcile [--month <YYYY-MM>] [--provider-total <model>=<tokens> ...] [--no-ingest] [--json]
   ocw-meter help
 
 subcommands:
@@ -84,12 +84,24 @@ subcommands:
     non-zero on unexpected failure.
 
   report
-    Prints an event-count / completeness / coverage summary, including
-    total estimated cost and which price_table_version(s)/cost_basis
-    were applied once usage.message events exist. With `--pr <n>`, also
-    prints review-round/human-intervention/final-result/cash-cost
-    detail for that one PR and its same-5-hour-window-completion
-    verdict (孫5).
+    Runs `ingest` automatically before reading stored events (every
+    view below does this, at the very top of `report` — 計画書
+    DOC-2608081456孫2), so a `report` right after Claude Code activity
+    doesn't need a manual `ocw-meter ingest` first. An ingest failure
+    (including refusing to run inside a Git worktree) never aborts
+    `report` itself — it's shown as a footer line and `report` still
+    serves whatever was already stored. `--no-ingest` skips the
+    automatic run entirely (read-only use, or when you want to control
+    exactly what `report` sees). The footer also always includes the
+    last successful ingest's timestamp, this run's own ingest outcome,
+    and a staleness warning once that timestamp is more than 24h old.
+
+    Otherwise prints an event-count / completeness / coverage summary,
+    including total estimated cost and which price_table_version(s)/
+    cost_basis were applied once usage.message events exist. With
+    `--pr <n>`, also prints review-round/human-intervention/final-
+    result/cash-cost detail for that one PR and its same-5-hour-
+    window-completion verdict (孫5).
 
   report --phase / --model / --role / --window
     Grouped breakdowns (孫5), each combinable with `--pr <n>` to scope

--- a/bin/ocw-meter
+++ b/bin/ocw-meter
@@ -1474,7 +1474,9 @@ def cmd_validate(args):
 def iter_stored_events(paths):
     """Yield (event_or_None, raw_line, error_or_None) for every stored
     line. Malformed lines are reported here, not moved — moving them is
-    `validate`'s job, so `report` stays read-only.
+    `validate`'s job, so iterating the store never mutates it (unlike
+    `report` as a whole since 計画書 DOC-2608081456孫2, which now writes
+    via its automatic `ingest` call BEFORE this iteration ever starts).
 
     Uses `hard_line_errors` only, not `payload_shape_issues`: a payload
     shape issue is advisory (see `payload_shape_issues`'s docstring), so
@@ -1613,7 +1615,80 @@ def completeness_footer(paths, scoped_events, malformed):
     }
 
 
-def print_footer_text(footer_completeness, footer_cost, total):
+def format_elapsed_seconds(seconds):
+    """`3661` -> `"1h1m"`. Coarse on purpose — this is a freshness
+    indicator for a human glancing at a footer, not a precise duration."""
+    seconds = int(seconds)
+    if seconds < 60:
+        return f"{seconds}s"
+    minutes, seconds = divmod(seconds, 60)
+    if minutes < 60:
+        return f"{minutes}m"
+    hours, minutes = divmod(minutes, 60)
+    if hours < 24:
+        return f"{hours}h{minutes}m"
+    days, hours = divmod(hours, 24)
+    return f"{days}d{hours}h"
+
+
+# 計画書 DOC-2608081456孫2 §3: how stale is too stale before `report`
+# warns about it. 24h, not shorter — the incident this whole grandchild
+# fixes (【1】) took 4 DAYS of silence to reach an 11.4% undercount, so a
+# same-order-of-magnitude threshold (one missed day) catches drift long
+# before it compounds that far, without flagging every routine gap
+# between report runs as an emergency. Matches the existing precedent
+# for "how old is too old" in this file (QUOTA_SESSION_STATE_MAX_AGE_
+# SECONDS, also 24h).
+INGEST_STALE_THRESHOLD_SECONDS = 24 * 60 * 60
+
+
+def ingest_freshness_footer(cursor, ingest_run):
+    """The ingest-freshness portion of the plan §10.4 footer (計画書
+    DOC-2608081456孫2 §3) — see `usage_cost_footer` above for why this
+    kind of thing is factored into its own function instead of being
+    inlined per view. `cursor` is `load_ingest_cursor()`'s return value;
+    `ingest_run` is `auto_ingest_for_report()`'s. Like every other footer
+    piece in this file, the values here are pre-formatted display
+    strings shared verbatim by both the text and `--json` outputs (see
+    `usage_cost_footer`'s `cost_estimate_usd` for the same convention) —
+    not raw types for a JSON consumer to reformat.
+
+    `last_ingest_at` deliberately does NOT fall back to guessing from a
+    file mtime when the cursor predates this field (plan's "推測で埋め
+    ない" principle, §全孫共通の注意5) — an old `ingest-cursor.json`
+    reports "unknown", full stop."""
+    last_ingest_raw = cursor.get("last_ingest_at")
+    last_ingest_dt = parse_ts(last_ingest_raw) if isinstance(last_ingest_raw, str) else None
+    if last_ingest_dt is None:
+        last_ingest_at = "unknown (次回 ingest で記録される)"
+        freshness_warning = "(none — last ingest time unknown)"
+    else:
+        age_seconds = (datetime.now(timezone.utc) - last_ingest_dt).total_seconds()
+        last_ingest_at = f"{last_ingest_raw} ({format_elapsed_seconds(age_seconds)} 経過)"
+        freshness_warning = (
+            f"最終ingestから{format_elapsed_seconds(age_seconds)}経過しています"
+            f"（閾値 {INGEST_STALE_THRESHOLD_SECONDS // 3600}h）。"
+            "自動ingestが失敗し続けていないか確認してください"
+            if age_seconds > INGEST_STALE_THRESHOLD_SECONDS else "(none)"
+        )
+
+    status = ingest_run["status"]
+    if status == "ran":
+        stats = ingest_run["stats"]
+        ingest_this_run = f"ran (written={stats['written']}, replaced={stats['replaced']})"
+    elif status == "skipped":
+        ingest_this_run = "skipped (--no-ingest)"
+    else:
+        ingest_this_run = f"failed: {ingest_run['error']}"
+
+    return {
+        "last_ingest_at": last_ingest_at,
+        "ingest_this_run": ingest_this_run,
+        "ingest_freshness_warning": freshness_warning,
+    }
+
+
+def print_footer_text(footer_completeness, footer_cost, footer_freshness, total):
     def pct(n):
         return (100.0 * n / total) if total else 0.0
 
@@ -1632,6 +1707,9 @@ def print_footer_text(footer_completeness, footer_cost, total):
     print(f"price_table:   {footer_cost['price_table']}")
     print(f"cost_basis:    {footer_cost['cost_basis']}")
     print(f"cost_estimate: {footer_cost['cost_estimate_usd']}")
+    print(f"last_ingest_at: {footer_freshness['last_ingest_at']}")
+    print(f"ingest (this run): {footer_freshness['ingest_this_run']}")
+    print(f"ingest_freshness_warning: {footer_freshness['ingest_freshness_warning']}")
 
 
 def events_for_pr(valid_events, pr_number, repo):
@@ -2095,7 +2173,7 @@ def report_month_cash_and_capacity(valid_events, month):
     }
 
 
-def _report_reconcile(paths, month, provider_totals, as_json):
+def _report_reconcile(paths, month, provider_totals, as_json, footer_freshness):
     """`ocw-meter report --reconcile` (孫3 §3): model別のtranscript由来
     トークン合計・推定費用を出し、`--provider-total model=tokens` で
     人間が渡した管理画面値との coverage 比率を計算する。plan §5.10 /
@@ -2205,6 +2283,7 @@ def _report_reconcile(paths, month, provider_totals, as_json):
             "（計画書17章 R8）"
         ),
         "models": models_out,
+        **footer_freshness,
     }
 
     if as_json:
@@ -2247,6 +2326,7 @@ def _report_reconcile(paths, month, provider_totals, as_json):
                 if any(m["cost_estimate_usd"] is not None for m in models_out.values()) else "null"
             ),
         },
+        footer_freshness,
         total_messages,
     )
     print(f"known_gaps:    {summary['known_gaps']}")
@@ -2297,12 +2377,15 @@ def pr_five_hour_window_completion(pr_events, all_events):
     return ("yes" if len(distinct) == 1 else "no"), distinct
 
 
-def _print_grouped_report(title, group_label, groups, as_json, storage_root_str, footer_completeness, footer_cost, total, extra_top=None):
+def _print_grouped_report(title, group_label, groups, as_json, storage_root_str, footer_completeness, footer_cost, footer_freshness, total, extra_top=None):
     """Shared text/JSON printer for the --model/--role/--phase/--window
     grouped views (孫5 §1): each is "a dict of rows keyed by group name"
     plus the mandatory plan §10.4 footer, so one function renders all of
     them instead of four near-identical print blocks."""
-    summary = {"storage_root": storage_root_str, group_label: groups, **(extra_top or {}), **footer_completeness, **footer_cost}
+    summary = {
+        "storage_root": storage_root_str, group_label: groups, **(extra_top or {}),
+        **footer_completeness, **footer_cost, **footer_freshness,
+    }
     if as_json:
         print(json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True))
         return 0
@@ -2325,8 +2408,38 @@ def _print_grouped_report(title, group_label, groups, as_json, storage_root_str,
             if field == "cost_estimate_usd":
                 value = f"${value:.4f}" if isinstance(value, (int, float)) else "null"
             print(f"    {field}: {value}")
-    print_footer_text(footer_completeness, footer_cost, total)
+    print_footer_text(footer_completeness, footer_cost, footer_freshness, total)
     return 0
+
+
+def auto_ingest_for_report(root, no_ingest):
+    """`report`'s automatic ingest (計画書 DOC-2608081456孫2 §1):
+    DOC-2608021229-a:440 always documented `report` as auto-triggering
+    `ingest`, but `cmd_report` never actually called it, so the last 4
+    days of transcripts (11.4% of all events) silently vanished from
+    every view. Called once at the very top of `cmd_report`, before any
+    view reads stored events, so every view (default / --phase / --model
+    / --role / --window / --month / --reconcile) sees the same freshly-
+    ingested data — missing even one view here would make that one view
+    silently see stale data while the others didn't.
+
+    Never raises: an ingest failure — including the exact same git-
+    worktree refusal `ingest` itself can hit (`perform_ingest` returns
+    `ok: False` for it, not an exception) — must never stop `report`
+    from showing whatever is already in the store; both funnel through
+    the same `{"status": "failed", "error": ...}` shape here so no
+    caller needs a special case for "which kind of failure was it".
+    `--no-ingest` (read-only use, and tests that want to control what
+    `report` sees) skips the call entirely."""
+    if no_ingest:
+        return {"status": "skipped"}
+    try:
+        result = perform_ingest(root)
+    except Exception as exc:  # ingest must never crash `report` (see docstring)
+        return {"status": "failed", "error": redact_text(f"{type(exc).__name__}: {exc}")}
+    if not result["ok"]:
+        return {"status": "failed", "error": result["error"]}
+    return {"status": "ran", "stats": result}
 
 
 def cmd_report(args):
@@ -2338,6 +2451,7 @@ def cmd_report(args):
     view = None
     explicit_repo = None
     provider_totals = {}
+    no_ingest = False
     i = 0
     while i < len(args):
         token = args[i]
@@ -2372,6 +2486,9 @@ def cmd_report(args):
             i += 1
         elif token == "--reconcile":
             reconcile = True
+            i += 1
+        elif token == "--no-ingest":
+            no_ingest = True
             i += 1
         elif token in ("--phase", "--model", "--role", "--window"):
             if view is not None and view != token[2:]:
@@ -2441,17 +2558,27 @@ def cmd_report(args):
         return 1
     paths = ensure_storage(root)
 
+    # 計画書 DOC-2608081456孫2 §1: runs BEFORE any view reads stored
+    # events (`iter_stored_events` below, and the two per-view helpers'
+    # own calls to it), so every view sees the same freshly-ingested
+    # data. `auto_ingest_for_report` never raises and never signals
+    # failure through the return code — an ingest problem only ever
+    # shows up as a footer line (`ingest_freshness_footer` below), never
+    # as `report` itself failing.
+    ingest_run = auto_ingest_for_report(root, no_ingest)
+    footer_freshness = ingest_freshness_footer(load_ingest_cursor(paths), ingest_run)
+
     if reconcile:
         month, err = normalize_month_arg(month)
         if err:
             print(err, file=sys.stderr)
             return 1
-        return _report_reconcile(paths, month, provider_totals, as_json)
+        return _report_reconcile(paths, month, provider_totals, as_json, footer_freshness)
 
     # Round-2 review finding 10 (regression introduced by round-1's own
     # fix for finding 1): `events_for_pr`'s repo scoping only works if a
-    # repo is actually resolved. `report` is a read-only command that
-    # can be run from ANYWHERE (unlike `event`, which is only ever
+    # repo is actually resolved. `report` can be run from ANYWHERE
+    # (unlike `event`, which is only ever
     # called from inside a worktree by `ocw`/`pr-review-loop`) — running
     # it from outside any git repo makes `git_repo_slug()` return None,
     # and `e.get("repo") == None` then matches every repo:null event
@@ -2490,7 +2617,7 @@ def cmd_report(args):
         if err:
             print(err, file=sys.stderr)
             return 1
-        return _report_month_standalone(paths, valid_events, malformed, month, repo, as_json)
+        return _report_month_standalone(paths, valid_events, malformed, month, repo, as_json, footer_freshness)
 
     if filter_pr is not None:
         filtered = events_for_pr(valid_events, filter_pr, repo)
@@ -2513,7 +2640,7 @@ def cmd_report(args):
             groups = report_by_window(valid_events if filter_pr is None else filtered, repo)
         return _print_grouped_report(
             f"by {view}", f"by_{view}", groups, as_json, str(paths.root),
-            footer_completeness, footer_cost, len(filtered), extra_top,
+            footer_completeness, footer_cost, footer_freshness, len(filtered), extra_top,
         )
 
     five_hour_window_completion, five_hour_window_ids_seen = (
@@ -2535,6 +2662,7 @@ def cmd_report(args):
         "by_event_type": by_type,
         **footer_completeness,
         **footer_cost,
+        **footer_freshness,
     }
     if filter_pr is not None:
         # Round-2 review finding 10: which repo `--pr` scoped to must be
@@ -2558,7 +2686,7 @@ def cmd_report(args):
         for event_type, count in sorted(by_type.items(), key=lambda kv: (kv[0] or "")):
             print(f"  {event_type or '(none)'}: {count}")
 
-        print_footer_text(footer_completeness, footer_cost, total)
+        print_footer_text(footer_completeness, footer_cost, footer_freshness, total)
         if filter_pr is not None:
             ids_str = ", ".join(five_hour_window_ids_seen) if five_hour_window_ids_seen else "(none)"
             print(f"five_hour_window_completion: {five_hour_window_completion} (window_ids seen: {ids_str})")
@@ -2579,7 +2707,7 @@ def cmd_report(args):
     return 0
 
 
-def _report_month_standalone(paths, valid_events, malformed, month, repo, as_json):
+def _report_month_standalone(paths, valid_events, malformed, month, repo, as_json, footer_freshness):
     """`ocw-meter report --month [YYYY-MM]` (孫5 §1, NOT --reconcile):
     cash cost / capacity cost / process efficiency for one UTC month,
     always kept in separate top-level keys — see
@@ -2603,6 +2731,7 @@ def _report_month_standalone(paths, valid_events, malformed, month, repo, as_jso
         "quality_guardrail": "未計測 — 第一段階では収集項目が無い（計画書16章）。この行は 'report --month' の出力にのみ現れる（他の report ビューには quality_guardrail キー自体が無い）",
         **footer_completeness,
         **footer_cost,
+        **footer_freshness,
     }
     # cash_cost/capacity are both inside report_month_cash_and_capacity's
     # dict already; split them into their own top-level keys so a reader
@@ -2643,7 +2772,7 @@ def _report_month_standalone(paths, valid_events, malformed, month, repo, as_jso
     print(f"  avg_duration_seconds: {pe['avg_duration_seconds']}")
     print(f"  five_hour_window_completion_breakdown: {pe['five_hour_window_completion_breakdown']}")
     print(f"quality_guardrail: {summary['quality_guardrail']}")
-    print_footer_text(footer_completeness, footer_cost, len(month_events))
+    print_footer_text(footer_completeness, footer_cost, footer_freshness, len(month_events))
     return 0
 
 
@@ -3434,30 +3563,34 @@ def bulk_write_events(paths, events):
 
 # ── subcommand: ingest ──────────────────────────────────────────────────
 
-def cmd_ingest(args):
-    parsed = parse_flags(args, {"--since": "since"}) if args else {}
-    since_str = parsed.get("since")
-    since_dt = None
-    if since_str:
-        since_dt = parse_ts(since_str)
-        if since_dt is None:
-            print(f"error: --since is not a valid RFC3339 timestamp: {since_str!r}", file=sys.stderr)
-            return 1
+def perform_ingest(root, since_dt=None):
+    """Core of `ingest`: scans transcripts for new `usage.message`
+    candidates, writes them, and (for a full non-`--since` run) advances
+    the cursor. Shared by `cmd_ingest` and `report`'s automatic run
+    (計画書 DOC-2608081456孫2: DOC-2608021229-a:440 documented `report`
+    as auto-triggering `ingest`, but `cmd_report` never called it —
+    4 days / 11.4% of events silently missing) so both go through
+    identical logic instead of two implementations drifting apart.
 
-    root = storage_root()
+    Returns `{"ok": True, ...stats}` on success, or `{"ok": False,
+    "error": <str>}` for the one well-understood refusal this function
+    itself detects (storage root resolves inside a Git worktree) —
+    exactly like `event`/`bind-pr`/`validate` refuse the same way.
+    Any OTHER unexpected failure is left to raise so `ocw-meter ingest`
+    itself still fails loud (main()'s existing fail-loud wrapper for
+    `ingest`); a caller that must never fail loud (report's automatic
+    run) wraps this call in its own try/except instead of relying on
+    this function to swallow everything itself."""
     if in_git_worktree(root):
-        print(f"error: OCW_METER_HOME ({root}) resolves inside a Git worktree; refusing to operate", file=sys.stderr)
-        return 1
+        return {"ok": False, "error": f"OCW_METER_HOME ({root}) resolves inside a Git worktree; refusing to operate"}
     paths = ensure_storage(root)
 
     projects_dir = claude_projects_dir()
     if projects_dir is None:
-        print(
-            "error: could not determine the Claude projects directory "
-            "(HOME is not set; set OCW_METER_CLAUDE_PROJECTS_DIR explicitly)",
-            file=sys.stderr,
-        )
-        return 1
+        return {
+            "ok": False,
+            "error": "could not determine the Claude projects directory (HOME is not set; set OCW_METER_CLAUDE_PROJECTS_DIR explicitly)",
+        }
 
     transcript_files = sorted(projects_dir.glob("*/*.jsonl")) if projects_dir.is_dir() else []
 
@@ -3562,16 +3695,56 @@ def cmd_ingest(args):
     # the persisted cursor means it never loses data: the next run
     # (restricted or not) simply re-reads the same unconsumed range from
     # wherever the last UNRESTRICTED run left off.
+    # 計画書 DOC-2608081456孫2 §2: the cursor now also records WHEN the
+    # last full ingest completed and that it completed cleanly — the
+    # freshness footer reads these two fields back (`ingest_freshness_
+    # footer`). Recorded here, not on failure, so a stale timestamp
+    # after this run means exactly what it says: "this is the last time
+    # ingest actually finished", not "the last time it was attempted".
+    # Not recorded under --since either, for the same reason the file
+    # cursor itself isn't: a --since run is deliberately read-only with
+    # respect to persisted ingest state (see the comment above).
     if since_dt is None:
-        save_ingest_cursor(paths, {"files": new_cursor_files})
+        save_ingest_cursor(paths, {
+            "files": new_cursor_files,
+            "last_ingest_at": iso_utc(datetime.now(timezone.utc)),
+            "last_ingest_result": "ok",
+        })
 
-    print(f"transcript files scanned:            {files_scanned}")
-    print(f"transcript files with new data:      {files_with_new_data}")
-    print(f"distinct message.id in this run:     {len(candidates)}")
-    print(f"usage.message written (new):         {write_counts['written']}")
-    print(f"usage.message replaced (re-run/dup):  {write_counts['replaced']}")
-    if since_dt is None:
-        print(f"transcript lines quarantined:         {quarantined_count}")
+    return {
+        "ok": True,
+        "files_scanned": files_scanned,
+        "files_with_new_data": files_with_new_data,
+        "distinct_message_ids": len(candidates),
+        "written": write_counts["written"],
+        "replaced": write_counts["replaced"],
+        "quarantined": quarantined_count,
+        "since_used": since_dt is not None,
+    }
+
+
+def cmd_ingest(args):
+    parsed = parse_flags(args, {"--since": "since"}) if args else {}
+    since_str = parsed.get("since")
+    since_dt = None
+    if since_str:
+        since_dt = parse_ts(since_str)
+        if since_dt is None:
+            print(f"error: --since is not a valid RFC3339 timestamp: {since_str!r}", file=sys.stderr)
+            return 1
+
+    result = perform_ingest(storage_root(), since_dt)
+    if not result["ok"]:
+        print(f"error: {result['error']}", file=sys.stderr)
+        return 1
+
+    print(f"transcript files scanned:            {result['files_scanned']}")
+    print(f"transcript files with new data:      {result['files_with_new_data']}")
+    print(f"distinct message.id in this run:     {result['distinct_message_ids']}")
+    print(f"usage.message written (new):         {result['written']}")
+    print(f"usage.message replaced (re-run/dup):  {result['replaced']}")
+    if not result["since_used"]:
+        print(f"transcript lines quarantined:         {result['quarantined']}")
     else:
         # PR #27 review round 3 finding "新規2": under --since,
         # quarantine writes are skipped (round 2 finding "新規2"), so
@@ -3579,8 +3752,8 @@ def cmd_ingest(args):
         # run — even with the cursor note appended separately — read as
         # "this many were recorded" when zero were. Label matches what
         # actually happened: detected while reading, nothing persisted.
-        print(f"transcript lines with parse errors (detected, NOT persisted — see note below): {quarantined_count}")
-    if since_dt is not None:
+        print(f"transcript lines with parse errors (detected, NOT persisted — see note below): {result['quarantined']}")
+    if result["since_used"]:
         # PR #27 review round 4 finding "新規1": this string is printed
         # to the user's terminal — it must read on its own, not
         # reference an internal PR review round number nobody running

--- a/bin/tests/test_ocw_meter.py
+++ b/bin/tests/test_ocw_meter.py
@@ -1906,6 +1906,18 @@ class ReportAutoIngestTests(OcwMeterTestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(read_events(self.home), [])
         self.assertIn("ingest (this run): skipped (--no-ingest)", result.stdout)
+        # PR #57 review round 2 finding "新規2": the "no events yet"
+        # messages must not assert anything about whether ingest ran —
+        # round 1's own fix for finding 1 made them unconditionally claim
+        # "ingest already ran automatically", which is false right here
+        # under --no-ingest. Whether it ran is the freshness footer's
+        # `ingest (this run):` line's job alone (asserted above).
+        self.assertNotIn("ingest already ran automatically", result.stdout)
+        self.assertIn("no usage.message events found in transcripts", result.stdout)
+
+        reconcile_result = run_report(self.home, self.projects_dir, args=["--reconcile", "--no-ingest"])
+        self.assertEqual(reconcile_result.returncode, 0, reconcile_result.stderr)
+        self.assertNotIn("ingest already ran automatically", reconcile_result.stdout)
 
     def test_invalid_month_fails_before_running_the_automatic_ingest(self):
         # PR #57 review round 1 finding 7: argument validation (a
@@ -2242,6 +2254,21 @@ class ReportReconcileTests(OcwMeterTestCase):
         data = json.loads(report.stdout)
         self.assertEqual(data["transcript_lines_quarantined"], 1)
         self.assertEqual(data["quarantined_lines"], 0)
+
+    def test_reconcile_with_month_works_outside_any_git_repo(self):
+        # PR #57 review round 2 finding "新規1": moving the repo-
+        # resolution-needed check earlier (round 1 finding 7, to run
+        # before the automatic-ingest side effect) accidentally exposed
+        # `--reconcile --month` to it for the first time — previously
+        # `_report_reconcile`'s early return made the check dead code on
+        # this path. `_report_reconcile` never takes (or needs) a `repo`
+        # argument at all, so this combination must keep working from
+        # outside any git repo, exactly like it always has (this is a
+        # documented workflow — docs/reference/DOC-2608021229-b_...).
+        no_git_dir = pathlib.Path(self.tmpdir.name) / "not-a-git-repo-reconcile"
+        no_git_dir.mkdir()
+        result = run_meter(["report", "--reconcile", "--month", "2026-07"], self.home, cwd=no_git_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
 
 
 CLAUDE_STATUSLINE_SAMPLE = {

--- a/bin/tests/test_ocw_meter.py
+++ b/bin/tests/test_ocw_meter.py
@@ -1982,9 +1982,21 @@ class ReportAutoIngestTests(OcwMeterTestCase):
 
     def test_freshness_warning_only_appears_past_the_staleness_threshold(self):
         # PR #57 review round 1 finding 4: the threshold comparison is
-        # `>=` (inclusive — see ingest_freshness_footer's comment), so
-        # the boundary itself, not just comfortably-inside/outside
-        # samples, must be pinned down here.
+        # `>=` (inclusive — see ingest_freshness_footer's comment, chosen
+        # because the plan's own wording "一定時間以上経っていたら" is
+        # inclusive). This test cannot pin the literal single-instant
+        # edge (age_seconds == INGEST_STALE_THRESHOLD_SECONDS exactly):
+        # this is a black-box subprocess test built on real wall-clock
+        # `datetime.now()`, and the round trip between writing the
+        # fixture timestamp here and `ingest_freshness_footer` reading
+        # "now" always adds strictly positive latency — so any nominal
+        # age computed here always reads back slightly HIGHER once the
+        # subprocess evaluates it, which makes `>` and `>=` behave
+        # identically in practice (verified: reverting to `>` still
+        # passes every case below). Matches this file's existing
+        # precedent for other 24h-based staleness checks
+        # (WorktreeRefusalPruningTests uses a 1h/25h margin, not an
+        # exact-instant one, for the same reason).
         state_dir = self.home / "state"
         state_dir.mkdir(parents=True, exist_ok=True)
 
@@ -1999,14 +2011,14 @@ class ReportAutoIngestTests(OcwMeterTestCase):
         self.assertEqual(fresh_result.returncode, 0, fresh_result.stderr)
         self.assertIn("ingest_freshness_warning: (none)", fresh_result.stdout)
 
-        just_under_result = cursor_at_age(hours=24, seconds=-5)
+        just_under_result = cursor_at_age(hours=23, minutes=59)
         self.assertEqual(just_under_result.returncode, 0, just_under_result.stderr)
         self.assertIn("ingest_freshness_warning: (none)", just_under_result.stdout)
 
-        exactly_at_result = cursor_at_age(hours=24, seconds=1)
-        self.assertEqual(exactly_at_result.returncode, 0, exactly_at_result.stderr)
-        self.assertNotIn("ingest_freshness_warning: (none)", exactly_at_result.stdout)
-        self.assertIn("経過しています", exactly_at_result.stdout)
+        just_over_result = cursor_at_age(hours=24, minutes=1)
+        self.assertEqual(just_over_result.returncode, 0, just_over_result.stderr)
+        self.assertNotIn("ingest_freshness_warning: (none)", just_over_result.stdout)
+        self.assertIn("経過しています", just_over_result.stdout)
 
         stale_result = cursor_at_age(hours=25)
         self.assertEqual(stale_result.returncode, 0, stale_result.stderr)

--- a/bin/tests/test_ocw_meter.py
+++ b/bin/tests/test_ocw_meter.py
@@ -1907,6 +1907,17 @@ class ReportAutoIngestTests(OcwMeterTestCase):
         self.assertEqual(read_events(self.home), [])
         self.assertIn("ingest (this run): skipped (--no-ingest)", result.stdout)
 
+    def test_invalid_month_fails_before_running_the_automatic_ingest(self):
+        # PR #57 review round 1 finding 7: argument validation (a
+        # malformed --month) used to run AFTER the automatic ingest call,
+        # so a request that was always going to fail loud still wrote a
+        # live ingest-cursor.json/events first.
+        write_transcript(self.projects_dir, "proj", "sess-bad-month", [assistant_line("sess-bad-month", "m1")])
+        result = run_report(self.home, self.projects_dir, args=["--reconcile", "--month", "2026-13"])
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse((self.home / "state" / "ingest-cursor.json").exists())
+        self.assertEqual(read_events(self.home), [])
+
     def test_auto_ingest_runs_for_every_report_view(self):
         # 計画書「1つでも漏れると、そのビューだけ古いデータを見る」: each
         # view gets its OWN isolated home/projects_dir so a prior view's
@@ -1955,7 +1966,10 @@ class ReportAutoIngestTests(OcwMeterTestCase):
         self.assertNotIn("last_ingest_at: unknown", result.stdout)
         cursor = json.loads((self.home / "state" / "ingest-cursor.json").read_text(encoding="utf-8"))
         self.assertIn("last_ingest_at", cursor)
-        self.assertEqual(cursor["last_ingest_result"], "ok")
+        # The raw RFC3339 the footer's --json field (last_ingest_at_rfc3339)
+        # must carry, unmodified, for a machine consumer (PR #57 review
+        # round 1 finding 6) — round-trips through the text footer too.
+        self.assertIn(f"last_ingest_at_rfc3339: {cursor['last_ingest_at']}", result.stdout)
 
     def test_old_format_ingest_cursor_without_last_ingest_at_shows_unknown(self):
         state_dir = self.home / "state"
@@ -1964,27 +1978,63 @@ class ReportAutoIngestTests(OcwMeterTestCase):
         result = run_meter(["report", "--no-ingest"], self.home)
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("last_ingest_at: unknown", result.stdout)
+        self.assertIn("last_ingest_at_rfc3339: unknown", result.stdout)
 
     def test_freshness_warning_only_appears_past_the_staleness_threshold(self):
+        # PR #57 review round 1 finding 4: the threshold comparison is
+        # `>=` (inclusive — see ingest_freshness_footer's comment), so
+        # the boundary itself, not just comfortably-inside/outside
+        # samples, must be pinned down here.
         state_dir = self.home / "state"
         state_dir.mkdir(parents=True, exist_ok=True)
 
-        recent = (datetime.now(timezone.utc) - timedelta(minutes=5)).strftime("%Y-%m-%dT%H:%M:%S.000Z")
-        (state_dir / "ingest-cursor.json").write_text(
-            json.dumps({"files": {}, "last_ingest_at": recent, "last_ingest_result": "ok"}), encoding="utf-8",
-        )
-        fresh_result = run_meter(["report", "--no-ingest"], self.home)
+        def cursor_at_age(**age_kwargs):
+            ts = (datetime.now(timezone.utc) - timedelta(**age_kwargs)).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+            (state_dir / "ingest-cursor.json").write_text(
+                json.dumps({"files": {}, "last_ingest_at": ts}), encoding="utf-8",
+            )
+            return run_meter(["report", "--no-ingest"], self.home)
+
+        fresh_result = cursor_at_age(minutes=5)
         self.assertEqual(fresh_result.returncode, 0, fresh_result.stderr)
         self.assertIn("ingest_freshness_warning: (none)", fresh_result.stdout)
 
-        stale = (datetime.now(timezone.utc) - timedelta(hours=25)).strftime("%Y-%m-%dT%H:%M:%S.000Z")
-        (state_dir / "ingest-cursor.json").write_text(
-            json.dumps({"files": {}, "last_ingest_at": stale, "last_ingest_result": "ok"}), encoding="utf-8",
-        )
-        stale_result = run_meter(["report", "--no-ingest"], self.home)
+        just_under_result = cursor_at_age(hours=24, seconds=-5)
+        self.assertEqual(just_under_result.returncode, 0, just_under_result.stderr)
+        self.assertIn("ingest_freshness_warning: (none)", just_under_result.stdout)
+
+        exactly_at_result = cursor_at_age(hours=24, seconds=1)
+        self.assertEqual(exactly_at_result.returncode, 0, exactly_at_result.stderr)
+        self.assertNotIn("ingest_freshness_warning: (none)", exactly_at_result.stdout)
+        self.assertIn("経過しています", exactly_at_result.stdout)
+
+        stale_result = cursor_at_age(hours=25)
         self.assertEqual(stale_result.returncode, 0, stale_result.stderr)
         self.assertNotIn("ingest_freshness_warning: (none)", stale_result.stdout)
         self.assertIn("経過しています", stale_result.stdout)
+
+    def test_json_output_includes_freshness_footer_keys_for_every_view(self):
+        # PR #57 review round 1 finding 3: `footer_freshness` is `**`-
+        # expanded into 4 separate JSON summary dicts
+        # (cmd_report/_print_grouped_report/_report_month_standalone/
+        # _report_reconcile) — a dropped `**footer_freshness` in any ONE
+        # of them would otherwise go undetected, since every other
+        # existing test only checks the text footer's print lines.
+        write_transcript(self.projects_dir, "proj", "sess-json-fresh", [
+            assistant_line("sess-json-fresh", "m1", timestamp="2026-07-15T10:00:00.000Z"),
+        ])
+        freshness_keys = {"last_ingest_at", "last_ingest_at_rfc3339", "ingest_this_run", "ingest_freshness_warning"}
+        view_cases = [
+            [], ["--phase"], ["--model"], ["--role"], ["--window"],
+            ["--month", "2026-07"], ["--reconcile", "--month", "2026-07"],
+        ]
+        for view_args in view_cases:
+            with self.subTest(view=view_args):
+                result = run_report(self.home, self.projects_dir, args=[*view_args, "--json"])
+                self.assertEqual(result.returncode, 0, result.stderr)
+                summary = json.loads(result.stdout)
+                missing = freshness_keys - summary.keys()
+                self.assertFalse(missing, f"view {view_args} --json is missing freshness keys: {missing}")
 
 
 class SymlinkInvocationTests(OcwMeterTestCase):

--- a/bin/tests/test_ocw_meter.py
+++ b/bin/tests/test_ocw_meter.py
@@ -296,6 +296,21 @@ def run_ingest(home, projects_dir, args=None, price_dir=None, extra_env=None, ti
     return run_meter(["ingest", *(args or [])], home, extra_env=env, timeout=timeout)
 
 
+def run_report(home, projects_dir=None, args=None, price_dir=None, extra_env=None, timeout=60):
+    """Like `run_ingest`, but drives `report` (whose automatic ingest —
+    計画書 DOC-2608081456孫2 — is what most callers of this helper mean
+    to exercise) instead of `ingest` directly."""
+    env = {
+        "OCW_METER_PRICE_DIR": str(price_dir if price_dir is not None else REPO_PRICE_DIR),
+        "OCW_METER_INGEST_USE_GH": "0",
+    }
+    if projects_dir is not None:
+        env["OCW_METER_CLAUDE_PROJECTS_DIR"] = str(projects_dir)
+    if extra_env:
+        env.update(extra_env)
+    return run_meter(["report", *(args or [])], home, extra_env=env, timeout=timeout)
+
+
 class OcwMeterTestCase(unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.TemporaryDirectory()
@@ -1863,6 +1878,113 @@ class IngestTests(OcwMeterTestCase):
         r2 = run_ingest(self.home, self.projects_dir)
         self.assertEqual(r2.returncode, 0, r2.stderr)
         self.assertFalse(events_file.read_text(encoding="utf-8").endswith("\n"))
+
+
+class ReportAutoIngestTests(OcwMeterTestCase):
+    """計画書 DOC-2608081456孫2: `report` auto-runs `ingest` at the top of
+    every view (DOC-2608021229-a:440 documented this from the start, but
+    `cmd_report` never actually called it — 4 days / 11.4% of events
+    silently missing on the real machine)."""
+
+    def setUp(self):
+        super().setUp()
+        self.projects_dir = pathlib.Path(self.tmpdir.name) / "claude-projects"
+        self.projects_dir.mkdir(parents=True, exist_ok=True)
+
+    def test_report_auto_ingests_transcripts_without_an_explicit_ingest_call(self):
+        write_transcript(self.projects_dir, "proj", "sess-auto", [assistant_line("sess-auto", "m1")])
+        self.assertEqual(read_events(self.home), [])
+
+        result = run_report(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        usage_events = [e for e in read_events(self.home) if e["event_type"] == "usage.message"]
+        self.assertEqual(len(usage_events), 1)
+
+    def test_no_ingest_flag_skips_the_automatic_ingest(self):
+        write_transcript(self.projects_dir, "proj", "sess-skip", [assistant_line("sess-skip", "m1")])
+        result = run_report(self.home, self.projects_dir, args=["--no-ingest"])
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(read_events(self.home), [])
+        self.assertIn("ingest (this run): skipped (--no-ingest)", result.stdout)
+
+    def test_auto_ingest_runs_for_every_report_view(self):
+        # 計画書「1つでも漏れると、そのビューだけ古いデータを見る」: each
+        # view gets its OWN isolated home/projects_dir so a prior view's
+        # ingest can't accidentally satisfy this one's assertion.
+        view_cases = [
+            [], ["--phase"], ["--model"], ["--role"], ["--window"],
+            ["--month", "2026-07"], ["--reconcile", "--month", "2026-07"],
+        ]
+        for i, view_args in enumerate(view_cases):
+            with self.subTest(view=view_args):
+                home = pathlib.Path(self.tmpdir.name) / f"view-home-{i}"
+                projects_dir = pathlib.Path(self.tmpdir.name) / f"view-projects-{i}"
+                projects_dir.mkdir()
+                write_transcript(projects_dir, "proj", f"sess-view-{i}", [
+                    assistant_line(f"sess-view-{i}", "m1", timestamp="2026-07-15T10:00:00.000Z"),
+                ])
+                result = run_report(home, projects_dir, args=view_args)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                usage_events = [e for e in read_events(home) if e["event_type"] == "usage.message"]
+                self.assertEqual(len(usage_events), 1, f"view {view_args} did not auto-ingest: {result.stdout}")
+
+    def test_ingest_failure_does_not_crash_report_and_is_shown_in_the_footer(self):
+        # An empty HOME makes claude_projects_dir() unable to resolve a
+        # projects directory (and OCW_METER_CLAUDE_PROJECTS_DIR is
+        # deliberately not passed) — perform_ingest's own "could not
+        # determine" refusal, exercised without needing a git-worktree
+        # storage root (report's own top-level worktree guard would
+        # short-circuit before auto-ingest ever runs for that case).
+        run_meter(["event", "run.start", "--idempotency-key", "k1"], self.home)
+        result = run_meter(["report"], self.home, extra_env={"HOME": ""})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("total events:  1", result.stdout)
+        self.assertIn("ingest (this run): failed: could not determine the Claude projects directory", result.stdout)
+
+    def test_json_output_stays_pure_json_even_when_auto_ingest_runs(self):
+        write_transcript(self.projects_dir, "proj", "sess-json", [assistant_line("sess-json", "m1")])
+        result = run_report(self.home, self.projects_dir, args=["--json"])
+        self.assertEqual(result.returncode, 0, result.stderr)
+        summary = json.loads(result.stdout)  # raises if anything besides JSON hit stdout
+        self.assertEqual(summary["total_events"], 1)
+
+    def test_footer_shows_last_ingest_timestamp_after_a_successful_run(self):
+        write_transcript(self.projects_dir, "proj", "sess-fresh", [assistant_line("sess-fresh", "m1")])
+        result = run_report(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("last_ingest_at: unknown", result.stdout)
+        cursor = json.loads((self.home / "state" / "ingest-cursor.json").read_text(encoding="utf-8"))
+        self.assertIn("last_ingest_at", cursor)
+        self.assertEqual(cursor["last_ingest_result"], "ok")
+
+    def test_old_format_ingest_cursor_without_last_ingest_at_shows_unknown(self):
+        state_dir = self.home / "state"
+        state_dir.mkdir(parents=True, exist_ok=True)
+        (state_dir / "ingest-cursor.json").write_text(json.dumps({"files": {}}), encoding="utf-8")
+        result = run_meter(["report", "--no-ingest"], self.home)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("last_ingest_at: unknown", result.stdout)
+
+    def test_freshness_warning_only_appears_past_the_staleness_threshold(self):
+        state_dir = self.home / "state"
+        state_dir.mkdir(parents=True, exist_ok=True)
+
+        recent = (datetime.now(timezone.utc) - timedelta(minutes=5)).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+        (state_dir / "ingest-cursor.json").write_text(
+            json.dumps({"files": {}, "last_ingest_at": recent, "last_ingest_result": "ok"}), encoding="utf-8",
+        )
+        fresh_result = run_meter(["report", "--no-ingest"], self.home)
+        self.assertEqual(fresh_result.returncode, 0, fresh_result.stderr)
+        self.assertIn("ingest_freshness_warning: (none)", fresh_result.stdout)
+
+        stale = (datetime.now(timezone.utc) - timedelta(hours=25)).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+        (state_dir / "ingest-cursor.json").write_text(
+            json.dumps({"files": {}, "last_ingest_at": stale, "last_ingest_result": "ok"}), encoding="utf-8",
+        )
+        stale_result = run_meter(["report", "--no-ingest"], self.home)
+        self.assertEqual(stale_result.returncode, 0, stale_result.stderr)
+        self.assertNotIn("ingest_freshness_warning: (none)", stale_result.stdout)
+        self.assertIn("経過しています", stale_result.stdout)
 
 
 class SymlinkInvocationTests(OcwMeterTestCase):


### PR DESCRIPTION
## 背景

dotfilesはmacOS / Linux / WSL2で共通の開発環境を再現するための設定リポジトリで、`bin/ocw-meter`はLLM利用費用やClaude利用枠を観測するためのツールです。

観測基盤の設計文書（DOC-2608021229-a の440行目付近）には「`ingest`は手動、または`report`が自動実行する」と書かれていましたが、実際の`cmd_report()`には`ingest`を呼び出す処理が一つもありませんでした。この食い違いにより、実運用のストアで直近4日分・全体の11.4%にあたるイベントがtranscriptから取り込まれないまま放置されており、工程イベント（`phase.start`など）は記録されているのにトークン数だけゼロになるという歪んだ月次集計が発生していました。また、いつingestを最後に実行したかを示す情報がどこにも出力されないため、この欠測に気づく手段がありませんでした。

## このプルリクエストの目的

`report`を実行するたびに`ingest`を自動実行するようにし、あわせて最終ingest時刻と鮮度（どれくらい前の情報か）をフッターに表示することで、欠測に気づけるようにします。費用の中身・帰属の解決・価格表など、ingest以外の計測ロジックには一切手を入れていません。

## 実装内容

- `ingest`のスキャン・書き込み処理を`perform_ingest()`として切り出し、`ocw-meter ingest`コマンドと`report`の自動実行の両方から共有するようにしました
- `report`の全ビュー（既定 / `--phase` / `--model` / `--role` / `--window` / `--month` / `--reconcile`）の先頭で自動的に`ingest`を実行するようにしました。1つのビューだけ実行を忘れると、そのビューだけ古いデータを表示し続けることになるため、`cmd_report()`の入り口一箇所にまとめています
- `ingest`が失敗しても（Gitワークツリー内への書き込み拒否を含む）`report`自体は落とさず、既に保存済みのイベントで出力を続け、失敗した事実だけをフッターに表示するようにしました
- 読み取り専用で使いたい場合や、テストで自動実行を止めたい場合のために`--no-ingest`オプションを追加しました
- `ingest-cursor.json`に最終ingestの実行時刻と結果を記録するようにしました。この情報を持たない既存の（旧形式の）ファイルを読んでも落ちず、「unknown」と表示します（無い情報を推測で埋めない、というこのツール全体の方針に沿っています）
- フッターに、最終ingest時刻・経過時間・今回の実行結果（実行 / スキップ / 失敗）・鮮度警告（24時間以上経過している場合）を追加しました。既存のフッター項目の意味は変更していません
- `--json`出力時、ingestの進捗出力が混ざらず、stdoutに正しいJSON以外の文字列が出ないことを確認しています

## レビューで見てほしいところ

- 鮮度警告の閾値を24時間にハードコードしています（コード内コメントに根拠を記載: 今回の実測で4日間気づかれなかったことで11.4%の欠測に至ったため、同程度の粒度である既存の`QUOTA_SESSION_STATE_MAX_AGE_SECONDS`と揃えました）。この閾値が適切か確認をお願いします
- `report`自体がストレージルート（`OCW_METER_HOME`）がGitワークツリー内を指している場合に全体を拒否する既存のガードは変更していません。そのため`ingest`側の同種の拒否パスは`report`からは実質的に到達しませんが、`ocw-meter ingest`単体実行やコードの一貫性のために、共有関数`perform_ingest()`側にも同じ判定を残しています。この設計判断が妥当か確認をお願いします
- ingestの失敗を握りつぶす範囲（`report`の自動実行時のみ例外を捕捉し、`ocw-meter ingest`単体実行時は従来通り失敗を通知）が意図通りか確認をお願いします

## テスト結果

- `pre-commit run --all-files`: 緑
- `bin/tests/lint.sh`: 緑
- `python3 -m unittest discover -s bin/tests -v`（281件、新規8件含む）: 全件成功
- テスト実行後、実ストア（`~/.local/state/ocw-meter`）に新規の汚染が発生していないことを確認済み

## 今後の予定

このプルリクエストは傘ブランチ`ocw-meter-accuracy`向けです。マージ後、価格表の時間帯対応（孫3）に進む予定です。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ucik91wwxa6SBFQeu39LJ1

## 自己レビュー
- 正当性: 計画書「孫2用プロンプト」の全項目（自動ingest実行・--no-ingest・失敗時のフッター表示・最終ingest時刻の記録・鮮度警告）を実装済み
- エッジケース: Gitワークツリー拒否・projects_dir不明・旧形式ingest-cursor.json・鮮度警告の閾値境界を確認
- テスト: `python3 -m unittest discover -s bin/tests -v` 281件全成功（新規8件を含む）
- 無関係変更: なし（`bin/ocw-meter`と`bin/tests/test_ocw_meter.py`のみ）
- 自己レビューで、スクリプト冒頭の`usage()`ヘルプに新設した`--no-ingest`が反映されていない漏れを発見し、修正済み


## schema_versionについて

`ingest-cursor.json`への`last_ingest_at`追加にあたり、`docs/reference/DOC-2608021229-c_ocw-meterイベントスキーマ.md` §6の`schema_version`変更ルールを確認しました。同ルールは共通エンベロープを持つ「イベント」（`events/`配下に保存される`usage.message`等）を対象としたものです。`ingest-cursor.json`は`state/`配下の状態ファイルであり、`schema_version`フィールド自体を持たずイベントスキーマの対象外のため、`schema_version`の変更は不要と判断しました。
