### PR TITLE
ocw-meterのquota.sampleにあるsession_cost_usdをlist_price_equiv_usdとして集計・表示

### DIFF
--- a/bin/ocw-meter
+++ b/bin/ocw-meter
@@ -1823,6 +1823,82 @@ def events_for_pr(valid_events, pr_number, repo):
     ]
 
 
+def report_capacity_list_price(quota_events):
+    """孫4プロンプト §1: aggregates Claude Code's own self-reported
+    session cost (`quota.sample`'s `session_cost_usd`, statusLine's
+    `cost.total_cost_usd`) into a Claude-side "list price equivalent"
+    total. This is a completely separate signal from `cost_estimate_usd`
+    (ocw-meter's own price-table estimate, carried on `usage.message`)
+    and must never be summed with it, nor with cash cost —
+    `report_month_cash_and_capacity`'s "cash cost と capacity は never
+    summed" contract covers this metric the same way it covers cash vs
+    capacity (罠4). Callers merge this dict's keys into whichever
+    capacity-side summary they're building (`--month`'s capacity
+    section, `--pr`'s pr_detail, `--window`'s per-window row).
+
+    罠2: scoped to `provider == "anthropic"` ONLY. `deepseek`'s own
+    `session_cost_usd` (measured $93.35 across 10 sessions) is Claude
+    Code pricing an unknown-to-us rate table against a non-Anthropic
+    model — summing it in here would double-count against
+    `usage.message`'s own DeepSeek price-table estimate.
+
+    罠3: `session_cost_usd` is monotonic WITHIN one continuous session
+    but resets on `/clear`/compaction — measured 26/214 real sessions
+    with a mid-session decrease. `max()` silently drops everything
+    accumulated before a reset. Instead, sort each `session_id`'s
+    samples by `ts` and sum only the positive deltas between adjacent
+    samples (a negative delta means "a reset happened here" and
+    contributes 0, not a subtraction); the first sample in a session
+    contributes its own value as the opening term.
+
+    Samples missing `session_id` (can't be grouped into a session at
+    all) or with a null/non-numeric `session_cost_usd` are excluded
+    rather than guessed at, and counted separately so the exclusion is
+    visible in the output instead of silently dropped (plan's
+    "推測で埋めない" — 全孫共通の注意5)."""
+    sessions = {}
+    excluded_no_session_id = 0
+    excluded_null_cost = 0
+    for e in quota_events:
+        if e.get("event_type") != "quota.sample" or e.get("provider") != "anthropic":
+            continue
+        session_id = e.get("session_id")
+        if not isinstance(session_id, str) or not session_id:
+            excluded_no_session_id += 1
+            continue
+        cost = e.get("session_cost_usd")
+        if not isinstance(cost, (int, float)):
+            excluded_null_cost += 1
+            continue
+        sessions.setdefault(session_id, []).append((e.get("ts") or "", cost))
+
+    total = 0.0
+    for samples in sessions.values():
+        samples.sort(key=lambda pair: pair[0])
+        prev = None
+        for _, cost in samples:
+            total += cost if prev is None else max(0.0, cost - prev)
+            prev = cost
+
+    has_data = bool(sessions)
+    note = (
+        "Claude Code自己申告のsession_cost_usd（statusLineのcost.total_cost_usd）を "
+        "provider=anthropicのみに絞り、session_idごとに正の差分の総和として積算した下限値"
+        "（最後のstatusLine描画以降の消費は含まれない）。usage.messageのcost_estimate_usd"
+        "とは別カラムであり、cash costとは絶対に合算しない。請求書ではない。"
+    )
+    if not has_data:
+        note += " このスコープにanthropicのquota.sampleが1件も無いため null（$0.00ではない）。"
+    return {
+        "list_price_equiv_usd": total if has_data else None,
+        "list_price_equiv_is_lower_bound": True,
+        "list_price_equiv_session_count": len(sessions),
+        "list_price_equiv_excluded_no_session_id_count": excluded_no_session_id,
+        "list_price_equiv_excluded_null_cost_count": excluded_null_cost,
+        "list_price_equiv_note": note,
+    }
+
+
 def pr_review_summary(pr_events):
     """孫5 §1 --pr: review round list / human intervention count / final
     result / cash+capacity cost split / 5h枠消費 for one PR's own
@@ -1906,6 +1982,7 @@ def pr_review_summary(pr_events):
         "seven_day_used_pct_max": max(seven_day_vals) if seven_day_vals else None,
         "cash_cost_usd": cash_cost if has_cash_cost else None,
         "capacity_message_count": capacity_message_count,
+        **report_capacity_list_price(pr_events),
     }
 
 
@@ -2082,9 +2159,14 @@ def report_by_window(valid_events, repo=None):
             continue
         w = windows.setdefault(wid, {
             "samples": 0, "five_hour_used_pct_max": None, "seven_day_used_pct_max": None,
-            "first_ts": None, "last_ts": None, "prs_direct": set(),
+            "first_ts": None, "last_ts": None, "prs_direct": set(), "quota_events": [],
         })
         w["samples"] += 1
+        # 孫4プロンプト §2: list_price_equiv needs each window's own raw
+        # quota.sample events (session-level delta accounting can't be
+        # done from the running maxes above) — kept only for the
+        # `report_capacity_list_price` call below, not exposed itself.
+        w["quota_events"].append(e)
         for pct_field, out_field in (("five_hour_used_pct", "five_hour_used_pct_max"), ("seven_day_used_pct", "seven_day_used_pct_max")):
             pct = e.get(pct_field)
             if isinstance(pct, (int, float)):
@@ -2128,6 +2210,7 @@ def report_by_window(valid_events, repo=None):
             "prs_time_overlap": prs_overlap,
             "blocked_seconds": None,
             "blocked_note": "block.start/block.end are schema-defined but not emitted by any caller yet (計画書16章) — always null here",
+            **report_capacity_list_price(w["quota_events"]),
         }
     return out
 
@@ -2310,6 +2393,7 @@ def report_month_cash_and_capacity(valid_events, month):
         "five_hour_used_pct_max": max(five_hour_vals) if five_hour_vals else None,
         "seven_day_used_pct_max": max(seven_day_vals) if seven_day_vals else None,
         "distinct_five_hour_windows": len(distinct_windows),
+        **report_capacity_list_price(quota_month),
     }
 
 
@@ -2551,6 +2635,8 @@ def _print_grouped_report(title, group_label, groups, as_json, storage_root_str,
                 continue
             if field == "cost_estimate_usd":
                 value = f"${value:.4f}" if isinstance(value, (int, float)) else "null"
+            elif field == "list_price_equiv_usd":
+                value = f"${value:.2f}+ (下限 / list price相当)" if isinstance(value, (int, float)) else "null"
             print(f"    {field}: {value}")
     print_footer_text(footer_completeness, footer_cost, footer_freshness, total)
     return 0
@@ -2868,6 +2954,13 @@ def cmd_report(args):
             cash_str = f"${detail['cash_cost_usd']:.4f}" if isinstance(detail["cash_cost_usd"], (int, float)) else "null"
             print(f"cash_cost_usd: {cash_str}")
             print(f"capacity_message_count (claude subscription, no dollar figure): {detail['capacity_message_count']}")
+            list_price_str = (
+                f"${detail['list_price_equiv_usd']:.2f}+ (下限 / list price相当 / 請求書ではない / cash costと合算不可)"
+                if isinstance(detail["list_price_equiv_usd"], (int, float)) else "null"
+            )
+            print(f"list_price_equiv_usd: {list_price_str}")
+            print(f"list_price_equiv_session_count: {detail['list_price_equiv_session_count']}")
+            print(f"list_price_equiv_note: {detail['list_price_equiv_note']}")
 
     return 0
 
@@ -2914,6 +3007,24 @@ def _report_month_standalone(paths, valid_events, malformed, month, repo, as_jso
         "five_hour_used_pct_max": cash_and_capacity["five_hour_used_pct_max"],
         "seven_day_used_pct_max": cash_and_capacity["seven_day_used_pct_max"],
         "distinct_five_hour_windows": cash_and_capacity["distinct_five_hour_windows"],
+        "list_price_equiv_usd": cash_and_capacity["list_price_equiv_usd"],
+        "list_price_equiv_is_lower_bound": cash_and_capacity["list_price_equiv_is_lower_bound"],
+        "list_price_equiv_session_count": cash_and_capacity["list_price_equiv_session_count"],
+        "list_price_equiv_excluded_no_session_id_count": cash_and_capacity["list_price_equiv_excluded_no_session_id_count"],
+        "list_price_equiv_excluded_null_cost_count": cash_and_capacity["list_price_equiv_excluded_null_cost_count"],
+        # 孫4プロンプト §4: quota.sample collection itself only started
+        # 2026-08-01 — a month before that has NO Claude-side cost data
+        # to find, which is a different fact from "this particular
+        # month happened to have zero anthropic sessions" (both produce
+        # the same null above; this line is what tells them apart).
+        "list_price_equiv_note": (
+            cash_and_capacity["list_price_equiv_note"]
+            + (
+                " (quota.sampleの記録自体が2026-08-01開始のため、それより前の月は原理的に"
+                "データが無い)"
+                if month < "2026-08" else ""
+            )
+        ),
     }
 
     if as_json:
@@ -2949,6 +3060,8 @@ def _report_month_standalone(paths, valid_events, malformed, month, repo, as_jso
         print("  price_tables_applied: (none)")
     print("capacity cost (Claude subscription quota — never summed with cash cost):")
     for field, value in summary["capacity"].items():
+        if field == "list_price_equiv_usd":
+            value = f"${value:.2f}+ (下限 / list price相当 / 請求書ではない)" if isinstance(value, (int, float)) else "null"
         print(f"  {field}: {value}")
     pe = summary["process_efficiency"]
     print(f"process efficiency (approved PRs in {month}):")

--- a/bin/ocw-meter
+++ b/bin/ocw-meter
@@ -1823,6 +1823,25 @@ def events_for_pr(valid_events, pr_number, repo):
     ]
 
 
+# 孫4 round-2 review finding (新規): this explanation of what
+# `list_price_equiv_usd` is — Claude Code's own self-reported list
+# price equivalent, a lower bound, NEVER summed with cash cost, not an
+# invoice (罠4) — used to be duplicated as two independently-worded
+# ~190文字 string literals (`report_capacity_list_price`'s per-scope
+# `note` and `_print_grouped_report`'s `--window` legend). A future
+# change to this boundary's wording could silently update only one of
+# them. Both build off these two constants instead; only the
+# surrounding framing ("このスコープに" vs "値がnullの行は…") differs
+# per call site.
+LIST_PRICE_EQUIV_EXPLANATION = (
+    "Claude Code自己申告のsession_cost_usd（statusLineのcost.total_cost_usd）を "
+    "provider=anthropicのみに絞り、session_idごとに正の差分の総和として積算した下限値"
+    "（最後のstatusLine描画以降の消費は含まれない）。usage.messageのcost_estimate_usd"
+    "とは別カラムであり、cash costとは絶対に合算しない。請求書ではない。"
+)
+LIST_PRICE_EQUIV_NULL_EXPLANATION = "anthropicのquota.sampleが1件も無いため null（$0.00ではない）。"
+
+
 def _quota_session_contributions(all_quota_events):
     """孫4 round-1 review finding 1: computes each anthropic
     `quota.sample` sample's own contribution to `list_price_equiv_usd`
@@ -1946,14 +1965,9 @@ def report_capacity_list_price(scope_quota_events, contributions):
         session_ids.add(session_id)
 
     has_data = bool(session_ids)
-    note = (
-        "Claude Code自己申告のsession_cost_usd（statusLineのcost.total_cost_usd）を "
-        "provider=anthropicのみに絞り、session_idごとに正の差分の総和として積算した下限値"
-        "（最後のstatusLine描画以降の消費は含まれない）。usage.messageのcost_estimate_usd"
-        "とは別カラムであり、cash costとは絶対に合算しない。請求書ではない。"
-    )
+    note = LIST_PRICE_EQUIV_EXPLANATION
     if not has_data:
-        note += " このスコープにanthropicのquota.sampleが1件も無いため null（$0.00ではない）。"
+        note += " このスコープに" + LIST_PRICE_EQUIV_NULL_EXPLANATION
     return {
         "list_price_equiv_usd": total if has_data else None,
         # round-1 review finding 5: null と「下限」は同時に成立しない —
@@ -2212,7 +2226,7 @@ def report_by_phase(scoped_events, usage_events):
     return out
 
 
-def report_by_window(valid_events, repo=None):
+def report_by_window(valid_events, repo, quota_contributions):
     """孫5 §1 --window: `quota.sample` events grouped by `window_id`
     (plan §8.5 — the 5-hour reset boundary's identifier). `pr_number`
     on a quota.sample comes straight from the caller-supplied field
@@ -2226,14 +2240,23 @@ def report_by_window(valid_events, repo=None):
     repo does not pollute the window's PR list with identically-numbered
     PRs from a different repo in the shared ocw-meter store.
 
-    `quota_contributions` (`_quota_session_contributions()`'s return
-    value, computed from `valid_events` itself — the fullest set this
-    function ever receives, even under a combined `--pr` filter) is
-    threaded into each window's `report_capacity_list_price` call below
-    so a session spanning two windows attributes only its own delta to
-    each, not its whole running total twice (孫4 round-1 review finding
-    1)."""
-    quota_contributions = _quota_session_contributions(valid_events)
+    `valid_events` here is this call's own GROUPING scope — the caller
+    passes a PR-narrowed `filtered` when `--window` is combined with
+    `--pr` (round-2 review: `report --window --pr <n>` legitimately
+    means "only this PR's own quota.sample samples, grouped by
+    window"). `quota_contributions`, by contrast, MUST always be
+    `_quota_session_contributions()`'s output computed from the TRUE,
+    unnarrowed store — round-1 review finding 1 fixed the plain
+    `--window` and plain `--pr` cases by threading `quota_contributions`
+    in from the caller, but this function's OWN first implementation of
+    that fix still derived `quota_contributions` internally from
+    whichever `valid_events` it happened to receive, which is exactly
+    `filtered` in the combined case — round-2 review finding
+    (持ち越し) caught that the fix hadn't actually reached the one
+    combination where `valid_events` here is NOT the full store.
+    `quota_contributions` is now a required parameter for exactly this
+    reason: this function must never compute it itself from its own
+    (possibly narrowed) `valid_events` again."""
     windows = {}
     for e in valid_events:
         if e.get("event_type") != "quota.sample":
@@ -2747,12 +2770,14 @@ def _print_grouped_report(title, group_label, groups, as_json, storage_root_str,
                 value = f"${value:.2f}+ (下限 / list price相当)" if isinstance(value, (int, float)) else "null"
             print(f"    {field}: {value}")
     if has_list_price_equiv:
+        # 孫4 round-2 review finding (新規): built from the same
+        # LIST_PRICE_EQUIV_EXPLANATION / _NULL_EXPLANATION constants
+        # `report_capacity_list_price` uses for its own per-scope
+        # `note` — this used to be an independently hardcoded ~190文字
+        # string that could drift out of sync with that one.
         print(
-            "list_price_equiv_note: 各list_price_equiv_usdはClaude Code自己申告のsession_cost_usd"
-            "（statusLineのcost.total_cost_usd）を provider=anthropicのみに絞り、session_idごとに"
-            "正の差分の総和として積算した下限値。usage.messageのcost_estimate_usdとは別カラムであり、"
-            "cash costとは絶対に合算しない。請求書ではない。値がnullの行はそのスコープにanthropicの"
-            "quota.sampleが1件も無いことを意味する（$0.00ではない）。"
+            "list_price_equiv_note: 各list_price_equiv_usdは" + LIST_PRICE_EQUIV_EXPLANATION
+            + " 値がnullの行はそのスコープに" + LIST_PRICE_EQUIV_NULL_EXPLANATION
         )
     print_footer_text(footer_completeness, footer_cost, footer_freshness, total)
     return 0
@@ -3004,7 +3029,21 @@ def cmd_report(args):
         elif view == "phase":
             groups = report_by_phase(filtered, usage_events)
         elif view == "window":
-            groups = report_by_window(valid_events if filter_pr is None else filtered, repo)
+            # round-2 review finding (持ち越し): `quota_contributions` MUST
+            # come from the true full `valid_events`, never from
+            # `filtered` — even though `filtered` is also this call's
+            # OWN first argument when `--pr` is combined with
+            # `--window`. Passing `filtered` for contributions while
+            # ALSO passing it as the grouping input was exactly the
+            # bug: `report_by_window` used to derive contributions from
+            # whatever it was grouping over, so a PR-scoped call saw
+            # only that PR's own samples and mistook the PR's first
+            # sample for the session's true first sample (measured:
+            # 14/30 PRs overcounted, up to 5.5x on the real store).
+            groups = report_by_window(
+                valid_events if filter_pr is None else filtered, repo,
+                _quota_session_contributions(valid_events),
+            )
         return _print_grouped_report(
             f"by {view}", f"by_{view}", groups, as_json, str(paths.root),
             footer_completeness, footer_cost, footer_freshness, len(filtered), extra_top,

--- a/bin/ocw-meter
+++ b/bin/ocw-meter
@@ -3016,13 +3016,18 @@ def _report_month_standalone(paths, valid_events, malformed, month, repo, as_jso
         # 2026-08-01 — a month before that has NO Claude-side cost data
         # to find, which is a different fact from "this particular
         # month happened to have zero anthropic sessions" (both produce
-        # the same null above; this line is what tells them apart).
+        # the same null above; this line is what tells them apart). Only
+        # appended when the value actually IS null this scope — always
+        # true in real data for a pre-2026-08 month (quota.sample simply
+        # doesn't exist that far back), but guarding on the null itself
+        # (rather than only on the month string) keeps this from ever
+        # asserting "no data" next to a non-null figure.
         "list_price_equiv_note": (
             cash_and_capacity["list_price_equiv_note"]
             + (
                 " (quota.sampleの記録自体が2026-08-01開始のため、それより前の月は原理的に"
                 "データが無い)"
-                if month < "2026-08" else ""
+                if month < "2026-08" and cash_and_capacity["list_price_equiv_usd"] is None else ""
             )
         ),
     }

--- a/bin/ocw-meter
+++ b/bin/ocw-meter
@@ -1823,44 +1823,113 @@ def events_for_pr(valid_events, pr_number, repo):
     ]
 
 
-def report_capacity_list_price(quota_events):
+def _quota_session_contributions(all_quota_events):
+    """孫4 round-1 review finding 1: computes each anthropic
+    `quota.sample` sample's own contribution to `list_price_equiv_usd`
+    — the positive delta from the immediately preceding sample IN THE
+    SAME SESSION (or the sample's own value, if it is that session's
+    TRUE first sample across the whole store), independent of any
+    window/PR/month scope.
+
+    **MUST be called with the full relevant event set for every
+    session's entire lifetime — never with an already window/PR/month-
+    scoped subset.** Scoping the input here (the original 孫4
+    implementation's bug) breaks "is this really the session's first
+    sample" and reintroduces carryover double counting: a session that
+    spans two windows would have its ENTIRE running total re-added as
+    window 2's "opening" sample instead of just window 2's own delta —
+    measured on the real store as a 48.7% overcount on `report
+    --window`'s summed rows (57/207 anthropic sessions, 27.5%, span 2+
+    windows).
+
+    Returns `{event_id: contribution_usd}` for every event that had a
+    `session_id` and a numeric `session_cost_usd` (provider scoping —
+    罠2 — is the caller's job via `report_capacity_list_price`, but is
+    applied here too since a non-anthropic sample must never participate
+    in an anthropic session's delta sequence). A caller then sums the
+    contributions of whichever subset of these events belongs to its
+    own scope to get that scope's own `list_price_equiv_usd`, without
+    re-deriving delta order itself (which is exactly the mistake that
+    caused the overcount)."""
+    sessions = {}
+    for e in all_quota_events:
+        if e.get("event_type") != "quota.sample" or e.get("provider") != "anthropic":
+            continue
+        session_id = e.get("session_id")
+        cost = e.get("session_cost_usd")
+        event_id = e.get("event_id")
+        if not isinstance(session_id, str) or not session_id:
+            continue
+        if not isinstance(cost, (int, float)):
+            continue
+        if not event_id:
+            continue
+        sessions.setdefault(session_id, []).append((e.get("ts") or "", event_id, cost))
+
+    contributions = {}
+    for samples in sessions.values():
+        samples.sort(key=lambda item: item[0])
+        prev_cost = None
+        for _, event_id, cost in samples:
+            contributions[event_id] = cost if prev_cost is None else max(0.0, cost - prev_cost)
+            prev_cost = cost
+    return contributions
+
+
+def report_capacity_list_price(scope_quota_events, contributions):
     """孫4プロンプト §1: aggregates Claude Code's own self-reported
     session cost (`quota.sample`'s `session_cost_usd`, statusLine's
     `cost.total_cost_usd`) into a Claude-side "list price equivalent"
-    total. This is a completely separate signal from `cost_estimate_usd`
-    (ocw-meter's own price-table estimate, carried on `usage.message`)
-    and must never be summed with it, nor with cash cost —
-    `report_month_cash_and_capacity`'s "cash cost と capacity は never
-    summed" contract covers this metric the same way it covers cash vs
-    capacity (罠4). Callers merge this dict's keys into whichever
-    capacity-side summary they're building (`--month`'s capacity
-    section, `--pr`'s pr_detail, `--window`'s per-window row).
+    total, scoped to `scope_quota_events` (a window's samples, a PR's
+    samples, a month's samples). This is a completely separate signal
+    from `cost_estimate_usd` (ocw-meter's own price-table estimate,
+    carried on `usage.message`) and must never be summed with it, nor
+    with cash cost — `report_month_cash_and_capacity`'s "cash cost と
+    capacity は never summed" contract covers this metric the same way
+    it covers cash vs capacity (罠4). Callers merge this dict's keys
+    into whichever capacity-side summary they're building (`--month`'s
+    capacity section, `--pr`'s pr_detail, `--window`'s per-window row).
 
-    罠2: scoped to `provider == "anthropic"` ONLY. `deepseek`'s own
-    `session_cost_usd` (measured $93.35 across 10 sessions) is Claude
-    Code pricing an unknown-to-us rate table against a non-Anthropic
-    model — summing it in here would double-count against
-    `usage.message`'s own DeepSeek price-table estimate.
+    `contributions` is `_quota_session_contributions()`'s return value,
+    computed ONCE by the caller from the FULL (unscoped) event set —
+    see that function's docstring for why per-sample contributions must
+    be computed globally rather than from `scope_quota_events` itself.
+    This function only decides WHICH contributions belong to this scope
+    and counts exclusions; it never recomputes deltas.
 
-    罠3: `session_cost_usd` is monotonic WITHIN one continuous session
-    but resets on `/clear`/compaction — measured 26/214 real sessions
-    with a mid-session decrease. `max()` silently drops everything
-    accumulated before a reset. Instead, sort each `session_id`'s
-    samples by `ts` and sum only the positive deltas between adjacent
-    samples (a negative delta means "a reset happened here" and
-    contributes 0, not a subtraction); the first sample in a session
-    contributes its own value as the opening term.
+    罠2: non-`anthropic` samples are excluded (not just `deepseek` —
+    round-1 review finding 3: a sample whose `provider` couldn't be
+    resolved at all, e.g. no model name AND no `rate_limits`, is stored
+    as `provider: null` by `snapshot-quota`, and previously vanished
+    from every exclusion counter here too, indistinguishable from "this
+    session simply doesn't exist"). `deepseek` (measured $93.35 across
+    10 sessions) is Claude Code pricing an unknown-to-us rate table
+    against a non-Anthropic model — summing it in here would double-
+    count against `usage.message`'s own DeepSeek price-table estimate;
+    a `provider`-unresolved sample might be genuinely anthropic, so
+    losing it silently (rather than counting the exclusion) would hide
+    a real gap if statusLine's payload shape ever changes upstream.
 
     Samples missing `session_id` (can't be grouped into a session at
     all) or with a null/non-numeric `session_cost_usd` are excluded
     rather than guessed at, and counted separately so the exclusion is
     visible in the output instead of silently dropped (plan's
     "推測で埋めない" — 全孫共通の注意5)."""
-    sessions = {}
     excluded_no_session_id = 0
     excluded_null_cost = 0
-    for e in quota_events:
-        if e.get("event_type") != "quota.sample" or e.get("provider") != "anthropic":
+    excluded_deepseek = 0
+    excluded_other_provider = 0
+    total = 0.0
+    session_ids = set()
+    for e in scope_quota_events:
+        if e.get("event_type") != "quota.sample":
+            continue
+        provider = e.get("provider")
+        if provider != "anthropic":
+            if provider == "deepseek":
+                excluded_deepseek += 1
+            else:
+                excluded_other_provider += 1
             continue
         session_id = e.get("session_id")
         if not isinstance(session_id, str) or not session_id:
@@ -1870,17 +1939,13 @@ def report_capacity_list_price(quota_events):
         if not isinstance(cost, (int, float)):
             excluded_null_cost += 1
             continue
-        sessions.setdefault(session_id, []).append((e.get("ts") or "", cost))
+        contribution = contributions.get(e.get("event_id"))
+        if contribution is None:
+            continue  # defensive: shouldn't happen if contributions came from the same event set
+        total += contribution
+        session_ids.add(session_id)
 
-    total = 0.0
-    for samples in sessions.values():
-        samples.sort(key=lambda pair: pair[0])
-        prev = None
-        for _, cost in samples:
-            total += cost if prev is None else max(0.0, cost - prev)
-            prev = cost
-
-    has_data = bool(sessions)
+    has_data = bool(session_ids)
     note = (
         "Claude Code自己申告のsession_cost_usd（statusLineのcost.total_cost_usd）を "
         "provider=anthropicのみに絞り、session_idごとに正の差分の総和として積算した下限値"
@@ -1891,21 +1956,31 @@ def report_capacity_list_price(quota_events):
         note += " このスコープにanthropicのquota.sampleが1件も無いため null（$0.00ではない）。"
     return {
         "list_price_equiv_usd": total if has_data else None,
-        "list_price_equiv_is_lower_bound": True,
-        "list_price_equiv_session_count": len(sessions),
+        # round-1 review finding 5: null と「下限」は同時に成立しない —
+        # データが無いスコープでは is_lower_bound 自体も null にする。
+        "list_price_equiv_is_lower_bound": True if has_data else None,
+        "list_price_equiv_session_count": len(session_ids),
         "list_price_equiv_excluded_no_session_id_count": excluded_no_session_id,
         "list_price_equiv_excluded_null_cost_count": excluded_null_cost,
+        "list_price_equiv_excluded_deepseek_count": excluded_deepseek,
+        "list_price_equiv_excluded_other_provider_count": excluded_other_provider,
         "list_price_equiv_note": note,
     }
 
 
-def pr_review_summary(pr_events):
+def pr_review_summary(pr_events, quota_contributions):
     """孫5 §1 --pr: review round list / human intervention count / final
     result / cash+capacity cost split / 5h枠消費 for one PR's own
     (already resolved via `events_for_pr`) event set. Reads ONLY the
     events already attributed to this PR — no additional time-range
     guessing beyond what plan §7.4's PR-attribution priority already
-    resolved."""
+    resolved.
+
+    `quota_contributions` is `_quota_session_contributions()`'s return
+    value, computed by the caller from the FULL (unscoped) event set —
+    passed straight through to `report_capacity_list_price` below (孫4
+    round-1 review finding 1: a session spanning two PRs must not have
+    its whole running total re-added to the second PR)."""
     review_rounds = []
     for e in pr_events:
         if e.get("event_type") == "review.round":
@@ -1982,7 +2057,7 @@ def pr_review_summary(pr_events):
         "seven_day_used_pct_max": max(seven_day_vals) if seven_day_vals else None,
         "cash_cost_usd": cash_cost if has_cash_cost else None,
         "capacity_message_count": capacity_message_count,
-        **report_capacity_list_price(pr_events),
+        **report_capacity_list_price(pr_events, quota_contributions),
     }
 
 
@@ -2149,7 +2224,16 @@ def report_by_window(valid_events, repo=None):
 
     `repo` scopes `pr_ranges` so that `report --window` run from one
     repo does not pollute the window's PR list with identically-numbered
-    PRs from a different repo in the shared ocw-meter store."""
+    PRs from a different repo in the shared ocw-meter store.
+
+    `quota_contributions` (`_quota_session_contributions()`'s return
+    value, computed from `valid_events` itself — the fullest set this
+    function ever receives, even under a combined `--pr` filter) is
+    threaded into each window's `report_capacity_list_price` call below
+    so a session spanning two windows attributes only its own delta to
+    each, not its whole running total twice (孫4 round-1 review finding
+    1)."""
+    quota_contributions = _quota_session_contributions(valid_events)
     windows = {}
     for e in valid_events:
         if e.get("event_type") != "quota.sample":
@@ -2210,7 +2294,7 @@ def report_by_window(valid_events, repo=None):
             "prs_time_overlap": prs_overlap,
             "blocked_seconds": None,
             "blocked_note": "block.start/block.end are schema-defined but not emitted by any caller yet (計画書16章) — always null here",
-            **report_capacity_list_price(w["quota_events"]),
+            **report_capacity_list_price(w["quota_events"], quota_contributions),
         }
     return out
 
@@ -2262,11 +2346,18 @@ def report_month_process_efficiency(valid_events, month, repo):
     per-PR numbers, matching how `report --pr` already resolves one
     PR's events. `repo` scopes both "which PRs count as approved" and
     "which events belong to each one" to the invoking repo (round-1
-    review finding 1)."""
+    review finding 1).
+
+    `quota_contributions` (孫4 round-1 review finding 1) is computed
+    ONCE here from the full `valid_events` and threaded into every
+    `pr_review_summary` call below, rather than each call recomputing
+    it (or worse, deriving it from just that one PR's own events —
+    the original bug)."""
+    quota_contributions = _quota_session_contributions(valid_events)
     per_pr = []
     for pr in sorted(find_approved_pr_numbers_in_month(valid_events, month, repo)):
         pr_events = events_for_pr(valid_events, pr, repo)
-        detail = pr_review_summary(pr_events)
+        detail = pr_review_summary(pr_events, quota_contributions)
         completion, _ = pr_five_hour_window_completion(pr_events, valid_events)
         per_pr.append({"pr_number": pr, "five_hour_window_completion": completion, **detail})
 
@@ -2360,7 +2451,15 @@ def report_month_cash_and_capacity(valid_events, month):
     plan §16 / 孫5プロンプト §1 "Cash cost と Capacity cost を混ぜない"
     is a hard requirement, not a style preference: a flat-rate
     subscription has no per-message dollar figure to add to the
-    metered total."""
+    metered total.
+
+    `quota_contributions` (孫4 round-1 review finding 1) is computed
+    from `valid_events` itself — the full store, not `quota_month` —
+    so a session that straddles a month boundary (only possible from
+    September on; `quota.sample` collection itself only started
+    2026-08-01) attributes only its own delta to each month, not its
+    whole running total twice."""
+    quota_contributions = _quota_session_contributions(valid_events)
     usage_month = [
         e for e in valid_events
         if e.get("event_type") == "usage.message" and isinstance(e.get("ts"), str) and e["ts"].startswith(month)
@@ -2393,7 +2492,7 @@ def report_month_cash_and_capacity(valid_events, month):
         "five_hour_used_pct_max": max(five_hour_vals) if five_hour_vals else None,
         "seven_day_used_pct_max": max(seven_day_vals) if seven_day_vals else None,
         "distinct_five_hour_windows": len(distinct_windows),
-        **report_capacity_list_price(quota_month),
+        **report_capacity_list_price(quota_month, quota_contributions),
     }
 
 
@@ -2628,16 +2727,33 @@ def _print_grouped_report(title, group_label, groups, as_json, storage_root_str,
     print(f"{title}:")
     if not groups:
         print("  (no data)")
+    has_list_price_equiv = False
     for key, row in sorted(groups.items(), key=lambda kv: str(kv[0])):
         print(f"  {key}:")
+        has_list_price_equiv = has_list_price_equiv or "list_price_equiv_usd" in row
         for field, value in row.items():
-            if field in ("provider", "model"):
+            # round-1 review finding 6: `list_price_equiv_note` (a ~190
+            # 文字 explanation, identical for every row) used to print
+            # once PER ROW — with `report --window`'s real store
+            # currently at 26 windows, that's the same sentence 26
+            # times, burying the one thing that actually differs
+            # between rows (each window's own list_price_equiv_usd).
+            # Printed once as a shared legend after the loop instead.
+            if field in ("provider", "model", "list_price_equiv_note"):
                 continue
             if field == "cost_estimate_usd":
                 value = f"${value:.4f}" if isinstance(value, (int, float)) else "null"
             elif field == "list_price_equiv_usd":
                 value = f"${value:.2f}+ (下限 / list price相当)" if isinstance(value, (int, float)) else "null"
             print(f"    {field}: {value}")
+    if has_list_price_equiv:
+        print(
+            "list_price_equiv_note: 各list_price_equiv_usdはClaude Code自己申告のsession_cost_usd"
+            "（statusLineのcost.total_cost_usd）を provider=anthropicのみに絞り、session_idごとに"
+            "正の差分の総和として積算した下限値。usage.messageのcost_estimate_usdとは別カラムであり、"
+            "cash costとは絶対に合算しない。請求書ではない。値がnullの行はそのスコープにanthropicの"
+            "quota.sampleが1件も無いことを意味する（$0.00ではない）。"
+        )
     print_footer_text(footer_completeness, footer_cost, footer_freshness, total)
     return 0
 
@@ -2924,8 +3040,12 @@ def cmd_report(args):
         summary["five_hour_window_completion"] = five_hour_window_completion
         summary["five_hour_window_ids_seen"] = five_hour_window_ids_seen
         # 孫5 §1: round/human-intervention/final-result/cash+capacity
-        # cost detail for this one PR.
-        summary["pr_detail"] = pr_review_summary(filtered)
+        # cost detail for this one PR. quota_contributions (孫4
+        # round-1 review finding 1) is computed from `valid_events`
+        # (the full store), NOT `filtered` — a session spanning two
+        # PRs must attribute only its own delta to each, not its whole
+        # running total twice.
+        summary["pr_detail"] = pr_review_summary(filtered, _quota_session_contributions(valid_events))
 
     if as_json:
         print(json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True))
@@ -2960,6 +3080,15 @@ def cmd_report(args):
             )
             print(f"list_price_equiv_usd: {list_price_str}")
             print(f"list_price_equiv_session_count: {detail['list_price_equiv_session_count']}")
+            # round-1 review finding 2: these exclusion counts exist
+            # specifically so exclusions are never silent (plan's
+            # "黙って落とさない") — omitting them from text output
+            # (while --json still had them) defeated that purpose for
+            # anyone not passing --json.
+            print(f"list_price_equiv_excluded_no_session_id_count: {detail['list_price_equiv_excluded_no_session_id_count']}")
+            print(f"list_price_equiv_excluded_null_cost_count: {detail['list_price_equiv_excluded_null_cost_count']}")
+            print(f"list_price_equiv_excluded_deepseek_count: {detail['list_price_equiv_excluded_deepseek_count']}")
+            print(f"list_price_equiv_excluded_other_provider_count: {detail['list_price_equiv_excluded_other_provider_count']}")
             print(f"list_price_equiv_note: {detail['list_price_equiv_note']}")
 
     return 0
@@ -3012,6 +3141,8 @@ def _report_month_standalone(paths, valid_events, malformed, month, repo, as_jso
         "list_price_equiv_session_count": cash_and_capacity["list_price_equiv_session_count"],
         "list_price_equiv_excluded_no_session_id_count": cash_and_capacity["list_price_equiv_excluded_no_session_id_count"],
         "list_price_equiv_excluded_null_cost_count": cash_and_capacity["list_price_equiv_excluded_null_cost_count"],
+        "list_price_equiv_excluded_deepseek_count": cash_and_capacity["list_price_equiv_excluded_deepseek_count"],
+        "list_price_equiv_excluded_other_provider_count": cash_and_capacity["list_price_equiv_excluded_other_provider_count"],
         # 孫4プロンプト §4: quota.sample collection itself only started
         # 2026-08-01 — a month before that has NO Claude-side cost data
         # to find, which is a different fact from "this particular

--- a/bin/tests/test_ocw_meter.py
+++ b/bin/tests/test_ocw_meter.py
@@ -4056,6 +4056,30 @@ class ReportListPriceEquivTests(OcwMeterTestCase):
         self.assertAlmostEqual(data301["pr_detail"]["list_price_equiv_usd"], 20.0)
         self.assertAlmostEqual(data302["pr_detail"]["list_price_equiv_usd"], 25.0)
 
+    def test_window_and_pr_filter_combined_does_not_double_count_carryover(self):
+        # round-2レビュー持ち越し指摘: セッションS1が W1/PR#101(10->20)、
+        # W2/PR#102(30->45) とまたぐケースで、`--window` 単体・`--pr` 単体
+        # はround-1の修正で直ったが、`--window --pr <n>` の併用だけ
+        # report_by_window() が自分の受け取った引数(PRで絞られた
+        # filtered)からquota_contributionsを計算していたため、
+        # まったく同じ二重計上が残っていた。真の消費は #102=25。
+        run_meter(["event", "run.start", "--idempotency-key", "r101", "--run-id", "run-101",
+                   "--ts", "2026-08-05T09:00:00.000Z"], self.home)
+        run_meter(["bind-pr", "--run", "run-101", "--pr", "101"], self.home)
+        run_meter(["event", "run.start", "--idempotency-key", "r102", "--run-id", "run-102",
+                   "--ts", "2026-08-05T10:00:00.000Z"], self.home)
+        run_meter(["bind-pr", "--run", "run-102", "--pr", "102"], self.home)
+        self._quota_sample("q1", "sess-carry-both", 10, "2026-08-05T09:00:00.000Z",
+                            extra=["--run-id", "run-101", "--pr-number", "101", "--window-id", "winX"])
+        self._quota_sample("q2", "sess-carry-both", 20, "2026-08-05T09:01:00.000Z",
+                            extra=["--run-id", "run-101", "--pr-number", "101", "--window-id", "winX"])
+        self._quota_sample("q3", "sess-carry-both", 30, "2026-08-05T10:00:00.000Z",
+                            extra=["--run-id", "run-102", "--pr-number", "102", "--window-id", "winY"])
+        self._quota_sample("q4", "sess-carry-both", 45, "2026-08-05T10:01:00.000Z",
+                            extra=["--run-id", "run-102", "--pr-number", "102", "--window-id", "winY"])
+        data = json.loads(run_meter(["report", "--window", "--pr", "102", "--json"], self.home).stdout)
+        self.assertAlmostEqual(data["by_window"]["winY"]["list_price_equiv_usd"], 25.0)
+
     def test_month_view_still_sums_the_whole_session_across_windows(self):
         # 上のwindowテストと同じセッションでも、--monthはウィンドウを
         # またいでも変わらず正しい合計(40)を返す(こちらは元々スコープが

--- a/bin/tests/test_ocw_meter.py
+++ b/bin/tests/test_ocw_meter.py
@@ -3938,6 +3938,115 @@ class ReportMonthStandaloneTests(OcwMeterTestCase):
         self.assertNotEqual(result.returncode, 0)
 
 
+class ReportListPriceEquivTests(OcwMeterTestCase):
+    """docs/planning/DOC-2608081456_..._計画.md 孫4プロンプト:
+    `quota.sample`'s `session_cost_usd` aggregated into
+    `list_price_equiv_usd` by `report_capacity_list_price()`."""
+
+    def _quota_sample(self, idem_key, session_id, cost, ts, provider="anthropic", extra=None):
+        args = ["event", "quota.sample", "--idempotency-key", idem_key,
+                "--plan-source", "statusline", "--provider", provider, "--ts", ts]
+        if session_id is not None:
+            args += ["--session-id", session_id]
+        if cost is not None:
+            args += ["--session-cost-usd", str(cost)]
+        if extra:
+            args += extra
+        return run_meter(args, self.home)
+
+    # -- 罠3: 正の差分の総和。max() ではない --
+
+    def test_non_monotonic_session_sums_positive_deltas_not_max(self):
+        # 10 -> 20 -> 5 -> 15: max() だと20だが、正しくは
+        # 10 + (20-10) + max(0, 5-20) + (15-5) = 10+10+0+10 = 30。
+        for i, (cost, minute) in enumerate([(10, "00"), (20, "01"), (5, "02"), (15, "03")]):
+            self._quota_sample(f"q{i}", "sess-nonmono", cost, f"2026-08-05T09:{minute}:00.000Z")
+        data = json.loads(run_meter(["report", "--month", "2026-08", "--json"], self.home).stdout)
+        self.assertAlmostEqual(data["capacity"]["list_price_equiv_usd"], 30.0)
+
+    def test_monotonic_session_equals_final_value(self):
+        for i, (cost, minute) in enumerate([(5, "00"), (10, "01"), (20, "02")]):
+            self._quota_sample(f"q{i}", "sess-mono", cost, f"2026-08-05T09:{minute}:00.000Z")
+        data = json.loads(run_meter(["report", "--month", "2026-08", "--json"], self.home).stdout)
+        self.assertAlmostEqual(data["capacity"]["list_price_equiv_usd"], 20.0)
+
+    def test_single_sample_session_uses_its_value_as_is(self):
+        self._quota_sample("q1", "sess-single", 7.5, "2026-08-05T09:00:00.000Z")
+        data = json.loads(run_meter(["report", "--month", "2026-08", "--json"], self.home).stdout)
+        self.assertAlmostEqual(data["capacity"]["list_price_equiv_usd"], 7.5)
+
+    # -- 罠2: deepseek混入除外 --
+
+    def test_deepseek_session_cost_is_fully_excluded(self):
+        self._quota_sample("q1", "sess-anthropic", 12.0, "2026-08-05T09:00:00.000Z", provider="anthropic")
+        self._quota_sample("q2", "sess-deepseek", 93.35, "2026-08-05T09:01:00.000Z", provider="deepseek")
+        data = json.loads(run_meter(["report", "--month", "2026-08", "--json"], self.home).stdout)
+        # 93.35 が1セントも混じっていないことを、合計が anthropic 分の
+        # 12.0 ちょうどであることで確認する。
+        self.assertAlmostEqual(data["capacity"]["list_price_equiv_usd"], 12.0)
+
+    def test_rate_limits_less_deepseek_shaped_samples_are_excluded(self):
+        # provider が rate_limits を持たない（DeepSeek/claude-ds形状）
+        # サンプルとして "unknown" や "deepseek" になっていても、
+        # anthropic 以外は一切合算しない。
+        self._quota_sample("q1", "sess-a", 1.0, "2026-08-05T09:00:00.000Z", provider="anthropic")
+        self._quota_sample("q2", "sess-b", 999.0, "2026-08-05T09:01:00.000Z", provider="unknown")
+        data = json.loads(run_meter(["report", "--month", "2026-08", "--json"], self.home).stdout)
+        self.assertAlmostEqual(data["capacity"]["list_price_equiv_usd"], 1.0)
+
+    # -- 表示と境界 --
+
+    def test_list_price_equiv_is_a_separate_key_from_cash_cost(self):
+        self._quota_sample("q1", "sess-a", 5.0, "2026-08-05T09:00:00.000Z")
+        data = json.loads(run_meter(["report", "--month", "2026-08", "--json"], self.home).stdout)
+        self.assertNotIn("list_price_equiv_usd", data["cash_cost"])
+        self.assertIn("list_price_equiv_usd", data["capacity"])
+        self.assertAlmostEqual(data["capacity"]["list_price_equiv_usd"], 5.0)
+
+    def test_no_anthropic_quota_sample_in_scope_is_null_not_zero(self):
+        data = json.loads(run_meter(["report", "--month", "2026-08", "--json"], self.home).stdout)
+        self.assertIsNone(data["capacity"]["list_price_equiv_usd"])
+        # deepseek-onlyなquota.sampleがあっても、anthropicデータが無い
+        # 事実は変わらない — $0.00 ではなく null のまま。
+        self._quota_sample("q1", "sess-ds", 3.0, "2026-08-05T09:00:00.000Z", provider="deepseek")
+        data = json.loads(run_meter(["report", "--month", "2026-08", "--json"], self.home).stdout)
+        self.assertIsNone(data["capacity"]["list_price_equiv_usd"])
+
+    def test_list_price_equiv_appears_in_pr_report(self):
+        run_meter(["event", "run.start", "--idempotency-key", "r1", "--run-id", "run-lp1",
+                   "--ts", "2026-08-05T09:00:00.000Z"], self.home)
+        run_meter(["bind-pr", "--run", "run-lp1", "--pr", "200"], self.home)
+        self._quota_sample("q1", "sess-pr", 8.25, "2026-08-05T09:05:00.000Z",
+                            extra=["--run-id", "run-lp1", "--pr-number", "200"])
+        data = json.loads(run_meter(["report", "--pr", "200", "--json"], self.home).stdout)
+        self.assertAlmostEqual(data["pr_detail"]["list_price_equiv_usd"], 8.25)
+        self.assertTrue(data["pr_detail"]["list_price_equiv_is_lower_bound"])
+
+    def test_list_price_equiv_appears_in_window_report(self):
+        self._quota_sample("q1", "sess-win", 6.5, "2026-08-05T09:00:00.000Z",
+                            extra=["--window-id", "win-lp1"])
+        data = json.loads(run_meter(["report", "--window", "--json"], self.home).stdout)
+        self.assertAlmostEqual(data["by_window"]["win-lp1"]["list_price_equiv_usd"], 6.5)
+
+    def test_excludes_samples_without_session_id_or_with_null_cost_without_crashing(self):
+        # session_idが無いサンプル(cost自体は有り)。
+        run_meter(["event", "quota.sample", "--idempotency-key", "q1",
+                   "--plan-source", "statusline", "--provider", "anthropic",
+                   "--session-cost-usd", "50.0", "--ts", "2026-08-05T09:00:00.000Z"], self.home)
+        # session_cost_usdが無い(null)サンプル(session_idは有り)。
+        run_meter(["event", "quota.sample", "--idempotency-key", "q2",
+                   "--plan-source", "statusline", "--provider", "anthropic",
+                   "--session-id", "sess-nullcost", "--ts", "2026-08-05T09:01:00.000Z"], self.home)
+        # 有効なサンプル。
+        self._quota_sample("q3", "sess-valid", 4.0, "2026-08-05T09:02:00.000Z")
+        result = run_meter(["report", "--month", "2026-08", "--json"], self.home)
+        self.assertEqual(result.returncode, 0)
+        data = json.loads(result.stdout)
+        self.assertAlmostEqual(data["capacity"]["list_price_equiv_usd"], 4.0)
+        self.assertEqual(data["capacity"]["list_price_equiv_excluded_no_session_id_count"], 1)
+        self.assertEqual(data["capacity"]["list_price_equiv_excluded_null_cost_count"], 1)
+
+
 # ── Round 1 review regression tests ─────────────────────────────────────
 # https://github.com/manemone/dotfiles/pull/28 round-1 review findings.
 

--- a/bin/tests/test_ocw_meter.py
+++ b/bin/tests/test_ocw_meter.py
@@ -3986,13 +3986,119 @@ class ReportListPriceEquivTests(OcwMeterTestCase):
         self.assertAlmostEqual(data["capacity"]["list_price_equiv_usd"], 12.0)
 
     def test_rate_limits_less_deepseek_shaped_samples_are_excluded(self):
-        # provider が rate_limits を持たない（DeepSeek/claude-ds形状）
-        # サンプルとして "unknown" や "deepseek" になっていても、
-        # anthropic 以外は一切合算しない。
+        # 罠2は「providerフィールドが deepseek 文字列であること」ではなく
+        # 「rate_limitsを持たない実際のDeepSeek/claude-ds形状のstatusLine
+        # JSONが、その書き込み経路(snapshot-quota)を通って provider を
+        # 正しく推論され、結果として除外されること」を確認する必要がある
+        # (round-1レビュー指摘4: 直接 --provider を叩くだけのテストは
+        # rate_limits の有無がproviderに効かなくなっても緑のままだった)。
         self._quota_sample("q1", "sess-a", 1.0, "2026-08-05T09:00:00.000Z", provider="anthropic")
-        self._quota_sample("q2", "sess-b", 999.0, "2026-08-05T09:01:00.000Z", provider="unknown")
+        run_snapshot_quota(json.dumps({
+            "session_id": "sess-ds-shaped", "cwd": "/tmp",
+            "model": {"id": "deepseek-v4-pro[1m]"},
+            "cost": {"total_cost_usd": 999.0},
+        }), self.home)
         data = json.loads(run_meter(["report", "--month", "2026-08", "--json"], self.home).stdout)
         self.assertAlmostEqual(data["capacity"]["list_price_equiv_usd"], 1.0)
+        self.assertEqual(data["capacity"]["list_price_equiv_excluded_deepseek_count"], 1)
+
+    def test_provider_unresolved_samples_are_excluded_and_counted_separately(self):
+        # round-1レビュー指摘3: model名もrate_limitsも無いサンプルは
+        # provider: null で書かれる(deepseekと判定されたわけではない)。
+        # anthropicとして合算してはいけないが、除外したこと自体は
+        # deepseekの除外とは別カウンタで報告する。
+        self._quota_sample("q1", "sess-a", 1.0, "2026-08-05T09:00:00.000Z", provider="anthropic")
+        run_snapshot_quota(json.dumps({
+            "session_id": "sess-unresolved", "cwd": "/tmp",
+            "cost": {"total_cost_usd": 999.0},
+        }), self.home)
+        event = next(e for e in read_events(self.home) if e["session_id"] == "sess-unresolved")
+        self.assertIsNone(event["provider"])
+        data = json.loads(run_meter(["report", "--month", "2026-08", "--json"], self.home).stdout)
+        self.assertAlmostEqual(data["capacity"]["list_price_equiv_usd"], 1.0)
+        self.assertEqual(data["capacity"]["list_price_equiv_excluded_other_provider_count"], 1)
+        self.assertEqual(data["capacity"]["list_price_equiv_excluded_deepseek_count"], 0)
+
+    # -- round-1レビュー指摘1: セッションがスコープをまたぐと持ち越し分を
+    # 二重計上してはいけない --
+
+    def test_window_scoped_session_does_not_double_count_carryover_from_a_prior_window(self):
+        # セッションS1: W1で 10 -> 20、W2で 30 -> 40。
+        # 真の消費は W1=20, W2=20 (合計40)。バグ版はW2の初項に30を
+        # まるごと足すため W2=40 になり、合計が60に膨らむ。
+        self._quota_sample("q1", "sess-carry", 10, "2026-08-05T09:00:00.000Z", extra=["--window-id", "winA"])
+        self._quota_sample("q2", "sess-carry", 20, "2026-08-05T09:01:00.000Z", extra=["--window-id", "winA"])
+        self._quota_sample("q3", "sess-carry", 30, "2026-08-05T10:00:00.000Z", extra=["--window-id", "winB"])
+        self._quota_sample("q4", "sess-carry", 40, "2026-08-05T10:01:00.000Z", extra=["--window-id", "winB"])
+        data = json.loads(run_meter(["report", "--window", "--json"], self.home).stdout)
+        self.assertAlmostEqual(data["by_window"]["winA"]["list_price_equiv_usd"], 20.0)
+        self.assertAlmostEqual(data["by_window"]["winB"]["list_price_equiv_usd"], 20.0)
+
+    def test_pr_scoped_session_does_not_double_count_carryover_from_a_prior_pr(self):
+        # セッションS1: PR#301で 10 -> 20、PR#302で 30 -> 45。
+        # 真の消費は #301=20, #302=25。
+        run_meter(["event", "run.start", "--idempotency-key", "r301", "--run-id", "run-301",
+                   "--ts", "2026-08-05T09:00:00.000Z"], self.home)
+        run_meter(["bind-pr", "--run", "run-301", "--pr", "301"], self.home)
+        run_meter(["event", "run.start", "--idempotency-key", "r302", "--run-id", "run-302",
+                   "--ts", "2026-08-05T10:00:00.000Z"], self.home)
+        run_meter(["bind-pr", "--run", "run-302", "--pr", "302"], self.home)
+        self._quota_sample("q1", "sess-carry-pr", 10, "2026-08-05T09:00:00.000Z",
+                            extra=["--run-id", "run-301", "--pr-number", "301"])
+        self._quota_sample("q2", "sess-carry-pr", 20, "2026-08-05T09:01:00.000Z",
+                            extra=["--run-id", "run-301", "--pr-number", "301"])
+        self._quota_sample("q3", "sess-carry-pr", 30, "2026-08-05T10:00:00.000Z",
+                            extra=["--run-id", "run-302", "--pr-number", "302"])
+        self._quota_sample("q4", "sess-carry-pr", 45, "2026-08-05T10:01:00.000Z",
+                            extra=["--run-id", "run-302", "--pr-number", "302"])
+        data301 = json.loads(run_meter(["report", "--pr", "301", "--json"], self.home).stdout)
+        data302 = json.loads(run_meter(["report", "--pr", "302", "--json"], self.home).stdout)
+        self.assertAlmostEqual(data301["pr_detail"]["list_price_equiv_usd"], 20.0)
+        self.assertAlmostEqual(data302["pr_detail"]["list_price_equiv_usd"], 25.0)
+
+    def test_month_view_still_sums_the_whole_session_across_windows(self):
+        # 上のwindowテストと同じセッションでも、--monthはウィンドウを
+        # またいでも変わらず正しい合計(40)を返す(こちらは元々スコープが
+        # 月全体なのでバグの対象外だったことの回帰確認)。
+        self._quota_sample("q1", "sess-carry-month", 10, "2026-08-05T09:00:00.000Z", extra=["--window-id", "winA"])
+        self._quota_sample("q2", "sess-carry-month", 20, "2026-08-05T09:01:00.000Z", extra=["--window-id", "winA"])
+        self._quota_sample("q3", "sess-carry-month", 30, "2026-08-05T10:00:00.000Z", extra=["--window-id", "winB"])
+        self._quota_sample("q4", "sess-carry-month", 40, "2026-08-05T10:01:00.000Z", extra=["--window-id", "winB"])
+        data = json.loads(run_meter(["report", "--month", "2026-08", "--json"], self.home).stdout)
+        self.assertAlmostEqual(data["capacity"]["list_price_equiv_usd"], 40.0)
+
+    # -- round-1レビュー指摘5: null と 下限 は同時に成立しない --
+
+    def test_is_lower_bound_is_null_not_true_when_value_is_null(self):
+        data = json.loads(run_meter(["report", "--month", "2026-08", "--json"], self.home).stdout)
+        self.assertIsNone(data["capacity"]["list_price_equiv_usd"])
+        self.assertIsNone(data["capacity"]["list_price_equiv_is_lower_bound"])
+
+    # -- round-1レビュー指摘2: --prのテキスト出力でも除外件数を出す --
+
+    def test_pr_text_output_includes_exclusion_counts(self):
+        run_meter(["event", "run.start", "--idempotency-key", "r400", "--run-id", "run-400",
+                   "--ts", "2026-08-05T09:00:00.000Z"], self.home)
+        run_meter(["bind-pr", "--run", "run-400", "--pr", "400"], self.home)
+        run_meter(["event", "quota.sample", "--idempotency-key", "q1",
+                   "--plan-source", "statusline", "--provider", "anthropic",
+                   "--session-cost-usd", "5.0", "--run-id", "run-400", "--pr-number", "400",
+                   "--ts", "2026-08-05T09:05:00.000Z"], self.home)
+        result = run_meter(["report", "--pr", "400"], self.home)
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("list_price_equiv_excluded_no_session_id_count:", result.stdout)
+        self.assertIn("list_price_equiv_excluded_null_cost_count:", result.stdout)
+        self.assertIn("list_price_equiv_excluded_deepseek_count:", result.stdout)
+        self.assertIn("list_price_equiv_excluded_other_provider_count:", result.stdout)
+
+    # -- round-1レビュー指摘6: --windowのテキスト出力で説明文を行ごとに繰り返さない --
+
+    def test_window_text_output_prints_the_note_once_not_per_row(self):
+        self._quota_sample("q1", "sess-win-a", 1.0, "2026-08-05T09:00:00.000Z", extra=["--window-id", "winA"])
+        self._quota_sample("q2", "sess-win-b", 2.0, "2026-08-05T10:00:00.000Z", extra=["--window-id", "winB"])
+        result = run_meter(["report", "--window"], self.home)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout.count("list_price_equiv_note:"), 1)
 
     # -- 表示と境界 --
 

--- a/bin/tests/test_ocw_meter.py
+++ b/bin/tests/test_ocw_meter.py
@@ -4012,6 +4012,13 @@ class ReportListPriceEquivTests(OcwMeterTestCase):
         data = json.loads(run_meter(["report", "--month", "2026-08", "--json"], self.home).stdout)
         self.assertIsNone(data["capacity"]["list_price_equiv_usd"])
 
+    def test_pre_august_month_explains_null_as_no_collection_yet(self):
+        # quota.sample の記録自体が2026-08-01開始なので、それより前の月は
+        # 「今月たまたま0件だった」ではなく「原理的にデータが無い」。
+        data = json.loads(run_meter(["report", "--month", "2026-07", "--json"], self.home).stdout)
+        self.assertIsNone(data["capacity"]["list_price_equiv_usd"])
+        self.assertIn("2026-08-01", data["capacity"]["list_price_equiv_note"])
+
     def test_list_price_equiv_appears_in_pr_report(self):
         run_meter(["event", "run.start", "--idempotency-key", "r1", "--run-id", "run-lp1",
                    "--ts", "2026-08-05T09:00:00.000Z"], self.home)


### PR DESCRIPTION
## 背景

`ocw-meter` は Claude Code の利用状況を計測するツールです。傘ブランチ `ocw-meter-accuracy` では、実際のストアを調査して見つかった6つの精度問題を順番に解消しています。このプルリクエストはそのうちの一つ、「Claude側の費用が実質見えていない」問題を扱います。

`ocw-meter` は `quota.sample` というイベントに、Claude Code自身が申告するセッション累積コスト（`session_cost_usd`）を記録しています。実測したところ4,704件中4,704件でこの値が埋まっていましたが、`report` のどの出力にもこの数字は一切出てきていませんでした。

## このプルリクエストの目的

`quota.sample` に眠っている `session_cost_usd` を集計し、Claude側のlist price相当額として `report` に表示できるようにします。

## 実装内容

- `report_capacity_list_price()` を新設し、以下の集計を行います。
  - `provider == "anthropic"` のサンプルのみを対象にします。DeepSeekのセッションにも `session_cost_usd` が入っていますが、Claude Codeがどの単価表をDeepSeekのモデル名に当てているか不明なため、`ocw-meter` 自身のDeepSeek費用推定と二重計上にならないよう除外します。
  - `session_cost_usd` は本来セッション内で単調増加するはずですが、実測で214セッション中26セッションが `/clear` やコンパクションと思われる理由で途中で減少していました。単純な最大値では減少前の分を取りこぼすため、`session_id` ごとに時刻順で正の差分だけを積算する方式にしています。
  - `session_id` が無いサンプル・`session_cost_usd` が無いサンプルは除外しつつ、除外件数自体は出力に残します（黙って捨てません）。
- 集計結果を `report --month` の capacity 節・`report --pr <n>`・`report --window` の3箇所に `list_price_equiv_usd` として追加しました。`--json` にも同じ内容が出ます。
- 表示は常に「下限値であり請求書ではない」ことを明記し、既存の `cash_cost_usd`（DeepSeekの従量課金推定）とは別のキー・別の行にして、絶対に合算しないようにしています。
- 対象期間に anthropic の `quota.sample` が1件も無い場合は `$0.00` ではなく `null` を返します（「0円だった」と「データが無い」は別の事実のため）。`quota.sample` の記録自体が2026-08-01から始まっているため、それより前の月を指定した場合はその旨を出力の説明文に含めています。
- `quota.sample` の書き込み経路（`snapshot-quota` サブコマンド・スキーマ）は一切変更していません。既存フィールドを読んで集計するだけです。

## レビューで見てほしいところ

- 「正の差分の総和」という集計方式が、`max()` よりも実態に近い下限値を出せているか（10→20→5→15という非単調な推移で30になることをテストで確認しています）。
- `provider == "anthropic"` によるスコープの絞り方が、DeepSeekセッションを漏れなく除外できているか。
- 表示・JSON双方で、`list_price_equiv_usd` が既存の `cash_cost_usd` と混同されない作りになっているか。

## テスト結果

- `pre-commit run --all-files`: 成功
- `bin/tests/lint.sh`: 成功
- `python3 -m unittest discover -s bin/tests -v`（321件）: 成功
- 実ストア（`~/.local/state/ocw-meter`）が汚染されていないことを確認済みです。

## 今後の予定

次は孫5（`session_id` joinによる `run_id`/`role` の帰属解決）に進む予定です。

## 自己レビュー

- 正当性: 計画書「孫4用プロンプト」の全項目（集計方式・除外・下限表示・null扱い・3箇所への出力）を実装済み
- エッジケース: 非単調セッション（罠3）・deepseek混入（罠2）・session_id/session_cost_usd欠落・quota.sample自体が無い期間、いずれも新規テストで確認
- テスト: `python3 -m unittest discover -s bin/tests -v` 322件全通過（新規11件を含む）
- 無関係変更: なし（`bin/ocw-meter` と `bin/tests/test_ocw_meter.py` のみ）
- 自己レビューで1点発見・修正: `report --month` capacity節の「quota.sampleは2026-08-01開始」という補足注記が、月文字列だけを条件にしていたため、値が実際にnullかどうかに関わらず表示されうる作りになっていた。値がnullのときのみ注記が付くよう修正し、テストを追加
