### PR TITLE
ocw-meterのsession_id joinでrun_id/roleの帰属解決を大幅改善

### DIFF
--- a/bin/ocw-meter
+++ b/bin/ocw-meter
@@ -2952,15 +2952,28 @@ def backfill_run_id_and_role_via_session(usage_events, session_attrs, binds):
     それは常にdirect解決だったとみなせる)。
 
     レビュー指摘2: `pr_number`/`pr_url`も、B側の`build_usage_event`が
-    `pr_info = binds.get(run_id)`で無条件に行っているのと同じ補完を
-    ここでも行う。これをしないと「session joinでrun_idを持つように
-    なったのに、ingestより後に読まれたか先に読まれたかでpr_numberの
-    有無が変わる」という非対称が生じ、`report_by_window`の`pr_ranges`
-    （`e.get("pr_number")`が非nullのイベントだけからPRの時刻レンジを
-    作る）がingestタイミング依存になる。run_idがこの関数の対象外
-    （元から埋まっていた）イベントも含め、run_idがありpr_numberが無い
-    全usage.messageに対して行う — B側と全く同じ「run_idが決まれば
-    pr_numberも決まる」という関係を保つため。"""
+    `pr_info = binds.get(run_id)`で行っているのと同じ補完をここでも
+    行う。これをしないと「session joinでrun_idを持つようになったのに、
+    ingestより後に読まれたか先に読まれたかでpr_numberの有無が変わる」
+    という非対称が生じ、`report_by_window`の`pr_ranges`（`e.get(
+    "pr_number")`が非nullのイベントだけからPRの時刻レンジを作る）が
+    ingestタイミング依存になる。run_idがこの関数の対象外（元から埋まっ
+    ていた）イベントも含め、run_idがありpr_numberが無い全usage.message
+    に対して行う。
+
+    レビュー指摘(ラウンド2 新規1): ここで揃えているのは「run_idが決まれば
+    pr_numberも決まる」という**関係**だけであり、bindの絞り方までB側と
+    同じにするという意味ではない。渡ってくる`binds`（`pr_binds_from_
+    events()`が組む）はrepoスコープ付き — `events_for_pr()`の
+    `bound_run_ids`と同じ絞り方に揃えてある。一方B側の`load_local_pr_
+    binds_and_run_starts()`が返す`binds`にはrepoスコープが無く、この点で
+    AとBは意図的に異なる（ラウンド2 新規1: repoスコープ無しの`binds`を
+    read-timeに無条件適用すると、別リポジトリでbindされたpr_numberが
+    このrepoのusage.messageへ焼き込まれ、`events_for_pr()`の直接マッチ
+    をすり抜けて別リポジトリの費用が混入する実測済みの不具合になる）。
+    「Bと揃える」つもりでこの関数へrepoスコープ無しの`binds`を渡さない
+    こと。B側自体のrepoスコープ欠如は本PR以前から存在する別の問題であり、
+    本PRの意図的な対象外。"""
     for e in usage_events:
         if e.get("event_type") != "usage.message":
             continue

--- a/bin/ocw-meter
+++ b/bin/ocw-meter
@@ -425,6 +425,7 @@ cat >"$_ocw_meter_py" <<'PY' || die "failed to write the embedded program to $_o
 # duplicates for one message.id in memory before doing a single write
 # per calendar-day file, rather than writing-then-rewriting through this
 # CLI's per-event primitives.
+import bisect
 import contextlib
 import errno
 import fcntl
@@ -1592,6 +1593,41 @@ def _price_table_predates_message(event):
     return effective > ts[:10]
 
 
+def _attribution_source_counts(usage_events, field, source_field):
+    """孫5プロンプト §3: `field`(run_id/role)がdirect(ingest時にocw-run-id
+    ファイル/Herdr liveから直接解決)/ session_id(quota.sampleとの
+    session_id join。ingest側フォールバックB・report側joinAの両方を
+    区別せず含む)/ unresolvedのどれで埋まったかを数える。`role`は
+    non-nullable フィールドで未解決を"unknown"文字列で表す(plan §8.1)
+    ため、`run_id`(未解決はNone)と判定条件が異なる — 呼び出し側で
+    `field`ごとに揃えた「未解決値」を渡すのではなく、ここで両方を扱う。
+    `source_field`(run_id_source/role_source)が無い、または"direct"の
+    イベントはdirect扱いにする — この機能より前にingestされた
+    イベントは`*_source`フィールド自体が無いが、それらのrun_id/roleは
+    session_id joinがまだ存在しなかった頃に解決されたものなので、
+    実質directと同じ意味である。"""
+    counts = {"direct": 0, "session_id": 0, "unresolved": 0}
+    for e in usage_events:
+        value = e.get(field)
+        if value is None or value == "unknown":
+            counts["unresolved"] += 1
+        elif e.get(source_field) == "session_id":
+            counts["session_id"] += 1
+        else:
+            counts["direct"] += 1
+    return counts
+
+
+def _attribution_line(counts, total):
+    if total == 0:
+        return "n/a (no usage.message events)"
+    return (
+        f"direct {100.0 * counts['direct'] / total:.1f}% / "
+        f"via session_id {100.0 * counts['session_id'] / total:.1f}% / "
+        f"unresolved {100.0 * counts['unresolved'] / total:.1f}%"
+    )
+
+
 def usage_cost_footer(usage_events):
     """The cost/coverage/price_table portion of the required per-plan-
     §10.4 footer, shared by every `report` view (孫5 §1: "coverage 併記が
@@ -1612,6 +1648,13 @@ def usage_cost_footer(usage_events):
             cost_bases.add(e["cost_basis"])
         if _price_table_predates_message(e):
             fallback_count += 1
+    # 孫5プロンプト §3: 「run_idとroleは別々の割合になる」— 実測でも
+    # 61.6%/72.1%と異なる(計画書DOC-2608081456)ため、必ず2行に分ける。
+    total_usage = len(usage_events)
+    run_id_counts = _attribution_source_counts(usage_events, "run_id", "run_id_source")
+    role_counts = _attribution_source_counts(usage_events, "role", "role_source")
+    attribution_run_id = _attribution_line(run_id_counts, total_usage)
+    attribution_role = _attribution_line(role_counts, total_usage)
     if usage_events:
         coverage = (
             f"{len(usage_events)} usage.message event(s); run "
@@ -1652,6 +1695,10 @@ def usage_cost_footer(usage_events):
         "cost_basis": cost_basis_summary,
         "cost_estimate_usd": cost_estimate_summary,
         "price_table_fallback_count": fallback_count,
+        "attribution_run_id": attribution_run_id,
+        "attribution_role": attribution_role,
+        "attribution_run_id_counts": run_id_counts,
+        "attribution_role_counts": role_counts,
     }
 
 
@@ -1780,6 +1827,12 @@ def print_footer_text(footer_completeness, footer_cost, footer_freshness, total)
     print(f"price_table:   {footer_cost['price_table']}")
     print(f"cost_basis:    {footer_cost['cost_basis']}")
     print(f"cost_estimate: {footer_cost['cost_estimate_usd']}")
+    # `--reconcile` (孫5スコープ外の既存ビュー) はここに渡す前の
+    # `valid_events` 構築・session_id join を経由しないので
+    # attribution_run_id/roleを持たない — `.get()`で欠落を許容する
+    # （他の全ビューはusage_cost_footer()経由で必ず持つ）。
+    print(f"attribution (run_id): {footer_cost.get('attribution_run_id', 'n/a (not computed for this view)')}")
+    print(f"attribution (role):   {footer_cost.get('attribution_role', 'n/a (not computed for this view)')}")
     print(f"last_ingest_at: {footer_freshness['last_ingest_at']}")
     print(f"last_ingest_at_rfc3339: {footer_freshness['last_ingest_at_rfc3339'] or 'unknown'}")
     print(f"ingest (this run): {footer_freshness['ingest_this_run']}")
@@ -2813,6 +2866,45 @@ def auto_ingest_for_report(root, no_ingest):
     return {"status": "ran", "stats": result}
 
 
+def backfill_run_id_and_role_via_session(usage_events, session_attrs):
+    """孫5プロンプト §2 (A: report側join): session_id joinで、まだ
+    run_id/roleが解決できていない`usage.message`だけを読み取り時に補完
+    する。**保存済みイベントファイルは一切書き換えない** — mutates the
+    in-memory dicts `iter_stored_events`/`valid_events` already produced
+    for this one `report` invocation only; nothing here calls
+    `write_event`/`bulk_write_events`. 罠1と同じ理由で、ここでもrun.start
+    逆転チェックは適用しない(session_idはworktreeパスと違って再利用
+    されないため、そもそも対象外)。
+
+    既に値が入っているイベント(ingest側フォールバックで既に解決済み、
+    または旧来のdirect解決)は上書きしない — plan「補完は信頼度の低い
+    方から」の原則どおり、read-time解決はあくまで最後の手段。
+    `run_id_source`/`role_source`はingest側(B)が新規イベントに書き込む
+    のと同じキーで、`usage_cost_footer`のattribution行がingest側/
+    report側どちらのjoinで埋まったかを区別せず「via session_id」として
+    一括で数えられるようにする(古い、この機能より前にingestされた
+    イベントは両フィールドとも欠落しており、run_idが埋まっていれば
+    それは常にdirect解決だったとみなせる)。"""
+    for e in usage_events:
+        if e.get("event_type") != "usage.message":
+            continue
+        session_id = e.get("session_id")
+        if not session_id:
+            continue
+        needs_run_id = e.get("run_id") is None
+        needs_role = e.get("role") in (None, "unknown")
+        if not needs_run_id and not needs_role:
+            continue
+        ts = parse_ts(e.get("ts"))
+        session_run_id, session_role = resolve_session_attrs(session_attrs, session_id, ts)
+        if needs_run_id and session_run_id is not None:
+            e["run_id"] = session_run_id
+            e["run_id_source"] = "session_id"
+        if needs_role and session_role is not None:
+            e["role"] = session_role
+            e["role_source"] = "session_id"
+
+
 def cmd_report(args):
     filter_pr = None
     as_json = False
@@ -3007,6 +3099,16 @@ def cmd_report(args):
             malformed += 1
         else:
             valid_events.append(obj)
+
+    # 孫5プロンプト §2 (A: report側join, 計画書「【2】【3】の鍵」): built
+    # ONCE here, from the full unscoped `valid_events` (a session's
+    # quota.sample history must not be cut down to whatever subset a
+    # later --pr/--month filter happens to select — same reasoning as
+    # `_quota_session_contributions`'s own full-store requirement), and
+    # applied before ANY view-specific filtering (`events_for_pr` below
+    # included) so every view — default/--pr/--phase/--role/--model/
+    # --window/--month — sees the same backfilled run_id/role.
+    backfill_run_id_and_role_via_session(valid_events, session_attrs_from_events(valid_events))
 
     if month_flag_present and view is None:
         return _report_month_standalone(paths, valid_events, malformed, month, repo, as_json, footer_freshness)
@@ -3899,17 +4001,115 @@ def resolve_herdr_role_map():
     return role_map
 
 
+# ── session_id join: quota.sample -> usage.message run_id/role ─────────
+# 計画書 DOC-2608081456【3】/「【2】【3】の鍵」/ 孫5プロンプト: quota.sample
+# has session_id 100% and run_id/role ~78% (both captured from OCW_RUN_ID/
+# OCW_ROLE at the moment `snapshot-quota` ran — see build_envelope's
+# defaults and record_quota_sample), while usage.message's OWN run_id/role
+# resolution (resolve_run_id_via_ocw_run_id_file / resolve_herdr_role_map)
+# depends on live state that can vanish (`ocw rm` deletes the git-dir file;
+# closing a Herdr pane makes it unqueryable) before `ingest` ever runs.
+# session_id, unlike a worktree path, is never reused, so joining on it
+# lets both `ingest` (B, this file's own scan of its event store) and
+# `report` (A, read-time only, plan's "past isn't recalculated" invariant)
+# recover the answer from data that's already durably stored.
+
+
+def _accumulate_session_attr_sample(raw, event):
+    """Feeds one already-decoded event into `raw` (session_id -> {"run_id":
+    [(ts, value), ...], "role": [...]}, unsorted) if it's a quota.sample
+    carrying a session_id. Shared by the ingest-side single-pass scan
+    (`load_local_pr_binds_and_run_starts`, which decodes lines itself) and
+    the report-side scan (`session_attrs_from_events`, over already-decoded
+    `valid_events`) so the extraction rule lives in exactly one place.
+
+    run_id and role are appended independently (not as one paired sample):
+    a quota.sample can carry one without the other (OCW_RUN_ID set but
+    OCW_ROLE unset, or vice versa — see record_quota_sample), so requiring
+    both together would throw away usable half-samples."""
+    if event.get("event_type") != "quota.sample":
+        return
+    session_id = event.get("session_id")
+    if not isinstance(session_id, str) or not session_id:
+        return
+    ts = parse_ts(event.get("ts"))
+    if ts is None:
+        return
+    entry = raw.setdefault(session_id, {"run_id": [], "role": []})
+    run_id = event.get("run_id")
+    if isinstance(run_id, str) and run_id:
+        entry["run_id"].append((ts, run_id))
+    role = event.get("role")
+    if isinstance(role, str) and role and role != "unknown":
+        entry["role"].append((ts, role))
+
+
+def _finalize_session_attrs(raw):
+    for entry in raw.values():
+        entry["run_id"].sort(key=lambda item: item[0])
+        entry["role"].sort(key=lambda item: item[0])
+    return raw
+
+
+def session_attrs_from_events(events):
+    """Report側(A)用: 既にデコード済みのイベント列(`valid_events`)から
+    session_attrsを組み立てる。ingest側(B)は同じ抽出を
+    `load_local_pr_binds_and_run_starts`内の1パスで行う(全走査を二重に
+    しないため)。"""
+    raw = {}
+    for e in events:
+        _accumulate_session_attr_sample(raw, e)
+    return _finalize_session_attrs(raw)
+
+
+def _nearest_sample_value(samples, ts):
+    """`samples`: ts昇順にソート済みの [(ts, value), ...]。`ts`に時刻が
+    最も近いサンプルのvalueを返す(前後どちらでもよい — quota.sampleは
+    60秒スロットルの定期ポーリングであり、対象メッセージの前後どちらの
+    状態が「そのときのrun_id/role」かを決める根拠は無い)。同点は前方
+    (`ts`より前)のサンプルを優先する — 決定的にするためだけの選択で、
+    後方を優先すべき積極的な理由は無い。1つのsession_idに複数の
+    run_id/roleが紐づく場合(同じセッションでworktreeを移った等)も、
+    「一意でなければ解決しない」ではなくこの時刻近傍則で1つに定める
+    方針とした(計画書 DOC-2608081456 孫5プロンプト §1)。"""
+    if not samples or ts is None:
+        return None
+    times = [t for t, _ in samples]
+    idx = bisect.bisect_left(times, ts)
+    candidates = []
+    if idx < len(samples):
+        candidates.append(samples[idx])
+    if idx > 0:
+        candidates.append(samples[idx - 1])
+    best = min(candidates, key=lambda item: (abs((item[0] - ts).total_seconds()), item[0]))
+    return best[1]
+
+
+def resolve_session_attrs(session_attrs, session_id, ts):
+    """(run_id, role) resolved via session_id join, each independently
+    nearest-in-time to `ts`. Returns (None, None) when `session_id` has no
+    quota.sample history at all (not every session gets sampled — e.g.
+    claude-ds sessions, or ones where statusLine never ran)."""
+    entry = session_attrs.get(session_id) if session_id else None
+    if entry is None:
+        return None, None
+    return _nearest_sample_value(entry["run_id"], ts), _nearest_sample_value(entry["role"], ts)
+
+
 # ── run_id / PR attribution from this meter's own local event store ────
 
 def load_local_pr_binds_and_run_starts(paths):
-    """Single pass over every stored event, building two lookup tables
+    """Single pass over every stored event, building three lookup tables
     `ingest` needs: the pr.bind table (plan §7.4 PR resolution once a
-    run_id is known) and run_id -> run.start ts (PR #27 review round 2
-    finding "新規1", see resolve_run_id_via_ocw_run_id_file's caller).
-    Tolerates malformed lines by skipping them — this is advisory
-    context-building, not `validate`, so a corrupt line here just means
-    less context, not an error."""
+    run_id is known), run_id -> run.start ts (PR #27 review round 2
+    finding "新規1", see resolve_run_id_via_ocw_run_id_file's caller), and
+    session_attrs (計画書 DOC-2608081456 孫5プロンプト §1: session_id ->
+    quota.sample-derived run_id/role samples, for `build_usage_event`'s
+    session_id join fallback). Tolerates malformed lines by skipping
+    them — this is advisory context-building, not `validate`, so a
+    corrupt line here just means less context, not an error."""
     binds, run_starts = {}, {}
+    session_attrs_raw = {}
     for target in sorted(paths.events_dir.glob("*.jsonl")):
         try:
             text = target.read_text(encoding="utf-8", errors="replace")
@@ -3932,7 +4132,9 @@ def load_local_pr_binds_and_run_starts(paths):
                 ts = parse_ts(obj.get("ts"))
                 if ts is not None:
                     run_starts[run_id] = ts
-    return binds, run_starts
+            elif event_type == "quota.sample":
+                _accumulate_session_attr_sample(session_attrs_raw, obj)
+    return binds, run_starts, _finalize_session_attrs(session_attrs_raw)
 
 
 def resolve_run_id_via_ocw_run_id_file(cwd, cache):
@@ -4035,7 +4237,7 @@ def gh_pr_for_branch(branch):
 
 # ── assembling usage.message events ─────────────────────────────────────
 
-def build_usage_event(candidate, price_tables, today_str, role_map, binds, run_starts, pr_link_map, gh_cache, run_id_cache, repo_cache):
+def build_usage_event(candidate, price_tables, today_str, role_map, binds, run_starts, pr_link_map, gh_cache, run_id_cache, repo_cache, session_attrs):
     usage = candidate["usage"] or {}
     input_tokens = usage.get("input_tokens")
     cache_read = usage.get("cache_read_input_tokens")
@@ -4070,7 +4272,7 @@ def build_usage_event(candidate, price_tables, today_str, role_map, binds, run_s
     role_info = role_map.get(session_id) if session_id else None
 
     worktree = candidate["cwd"]
-    run_id = resolve_run_id_via_ocw_run_id_file(worktree, run_id_cache)
+    direct_run_id = resolve_run_id_via_ocw_run_id_file(worktree, run_id_cache)
     # PR #27 review round 2 finding "新規1": the ocw-run-id file answers
     # "which run_id does THIS PATH belong to NOW", not "...when this
     # message was generated". `ocw rm <name>` + `ocw new <name>` reuses
@@ -4081,10 +4283,31 @@ def build_usage_event(candidate, price_tables, today_str, role_map, binds, run_s
     # (null, not guessed). Unknown run.start ts (e.g. from before this
     # meter started recording, or a different machine) gives the match
     # the benefit of the doubt rather than nulling everything out.
-    if run_id is not None and ts_dt is not None:
-        run_start_ts = run_starts.get(run_id)
+    #
+    # This reversal check applies ONLY to `direct_run_id` (see below) —
+    # 計画書 DOC-2608081456 罠1: it exists to catch worktree PATH reuse,
+    # and session_id (unlike a path) is never reused, so applying it to
+    # the session_id-join fallback would null out otherwise-correct
+    # attributions instead of catching anything real.
+    if direct_run_id is not None and ts_dt is not None:
+        run_start_ts = run_starts.get(direct_run_id)
         if run_start_ts is not None and ts_dt < run_start_ts:
-            run_id = None
+            direct_run_id = None
+
+    direct_role = (role_info or {}).get("role")
+
+    # 孫5プロンプト §1 (B: ingest側フォールバック / 計画書「【2】【3】の鍵」):
+    # direct resolution (ocw-run-id file / Herdr live pane list) failed to
+    # answer, fall back to the session_id join against quota.sample before
+    # giving up. See `_nearest_sample_value`'s docstring for how a
+    # session_id with multiple distinct run_id/role samples is resolved.
+    session_run_id, session_role = (
+        resolve_session_attrs(session_attrs, session_id, ts_dt) if session_id else (None, None)
+    )
+    run_id = direct_run_id if direct_run_id is not None else session_run_id
+    run_id_source = "direct" if direct_run_id is not None else ("session_id" if session_run_id is not None else None)
+    role = direct_role or session_role
+    role_source = "direct" if direct_role else ("session_id" if session_role else None)
 
     pr_info = binds.get(run_id) if run_id else None
     if pr_info is None:
@@ -4123,13 +4346,19 @@ def build_usage_event(candidate, price_tables, today_str, role_map, binds, run_s
         "parser_version": INGEST_PARSER_VERSION,
         "completeness": completeness,
         "run_id": run_id,
+        # 孫5プロンプト §3: どの経路で解決したか(direct/session_id/未解決)
+        # を`report`のattribution行が数えられるようにする内部由来タグ。
+        # 既存の usage.message スキーマには無かった新規フィールドで、
+        # 未知フィールドは forward-compatible に保持される(plan §9.1)。
+        "run_id_source": run_id_source,
         "repo": repo_slug_for_cwd(worktree, repo_cache),
         "worktree": worktree,
         "branch": candidate["git_branch"],
         "head_sha": None,
         "workspace_id": (role_info or {}).get("workspace_id"),
         "pane_id": (role_info or {}).get("pane_id"),
-        "role": (role_info or {}).get("role") or "unknown",
+        "role": role or "unknown",
+        "role_source": role_source,
         "session_id": session_id,
         "provider": provider,
         "model": model,
@@ -4385,7 +4614,7 @@ def perform_ingest(root, since_dt=None):
         }
 
     role_map = resolve_herdr_role_map()
-    binds, run_starts = load_local_pr_binds_and_run_starts(paths)
+    binds, run_starts, session_attrs = load_local_pr_binds_and_run_starts(paths)
     price_tables = load_price_tables(price_table_dir())
     # Round-1 review finding 3: a `time_of_day_pricing` block that's
     # PRESENT but unusable must not look identical to "this table simply
@@ -4398,7 +4627,7 @@ def perform_ingest(root, since_dt=None):
     gh_cache, run_id_cache, repo_cache = {}, {}, {}
 
     events = [
-        build_usage_event(candidate, price_tables, today_str, role_map, binds, run_starts, pr_link_map, gh_cache, run_id_cache, repo_cache)
+        build_usage_event(candidate, price_tables, today_str, role_map, binds, run_starts, pr_link_map, gh_cache, run_id_cache, repo_cache, session_attrs)
         for candidate in candidates.values()
     ]
 

--- a/bin/ocw-meter
+++ b/bin/ocw-meter
@@ -1628,6 +1628,21 @@ def _attribution_line(counts, total):
     )
 
 
+# 孫5プロンプト §4「残る限界を出力または文書に書く」/ レビュー指摘1:
+# session_id joinを入れても100%解決には到達しない構造的な理由を、
+# 「直った」と誤読されないよう毎回のattribution行に添える。数値
+# （実測時点のrun_id 61.6%/role 72.1%等）はこの定数に埋め込まない —
+# 母数が変わるたびに嘘になるため、実測値は毎回のattribution行自体に
+# 出る。ここに書くのは変わらない構造的な理由のみ。
+ATTRIBUTION_KNOWN_LIMITS = (
+    "quota.sampleの記録は2026-08-01開始のため、それより前の期間はsession_id "
+    "joinによる復元ができない。以降の期間でも100%には到達しない — claude-ds "
+    "セッションやstatusLineが一度も走らなかったセッションはrun_id/roleとも "
+    "復元不能。roleのunknownの一部はHerdr外で起動したClaudeであり原理的に "
+    "取得不能(推測で埋めない方針を維持)。"
+)
+
+
 def usage_cost_footer(usage_events):
     """The cost/coverage/price_table portion of the required per-plan-
     §10.4 footer, shared by every `report` view (孫5 §1: "coverage 併記が
@@ -1699,6 +1714,7 @@ def usage_cost_footer(usage_events):
         "attribution_role": attribution_role,
         "attribution_run_id_counts": run_id_counts,
         "attribution_role_counts": role_counts,
+        "attribution_known_limits": ATTRIBUTION_KNOWN_LIMITS,
     }
 
 
@@ -1808,7 +1824,17 @@ def ingest_freshness_footer(cursor, ingest_run):
     }
 
 
-def print_footer_text(footer_completeness, footer_cost, footer_freshness, total):
+def print_footer_text(footer_completeness, footer_cost, footer_freshness, total, attribution=True):
+    """レビュー指摘4: `attribution`はキーワード専用の明示フラグ
+    (既定True) — 以前は`footer_cost.get('attribution_run_id', 'n/a ...')`
+    で欠落を暗黙に許容していたが、これだと将来 `footer_cost` を手組みする
+    ビューが増えたとき「computed し忘れている」ことに誰も気づけないまま
+    "n/a" が出力され続ける。ここでは逆に、attribution行を出さないビュー
+    （`--reconcile`。孫5のスコープ外で、session_id joinを経由しない）だけ
+    が明示的に`attribution=False`を渡す。`attribution=True`（既定）の
+    ときは`footer_cost['attribution_run_id']`を直接インデックスし、
+    無ければKeyErrorで即座に落ちる — 呼び出し側がこの行を足し忘れたまま
+    サイレントに"n/a"を出し続けることを防ぐ。"""
     def pct(n):
         return (100.0 * n / total) if total else 0.0
 
@@ -1827,12 +1853,10 @@ def print_footer_text(footer_completeness, footer_cost, footer_freshness, total)
     print(f"price_table:   {footer_cost['price_table']}")
     print(f"cost_basis:    {footer_cost['cost_basis']}")
     print(f"cost_estimate: {footer_cost['cost_estimate_usd']}")
-    # `--reconcile` (孫5スコープ外の既存ビュー) はここに渡す前の
-    # `valid_events` 構築・session_id join を経由しないので
-    # attribution_run_id/roleを持たない — `.get()`で欠落を許容する
-    # （他の全ビューはusage_cost_footer()経由で必ず持つ）。
-    print(f"attribution (run_id): {footer_cost.get('attribution_run_id', 'n/a (not computed for this view)')}")
-    print(f"attribution (role):   {footer_cost.get('attribution_role', 'n/a (not computed for this view)')}")
+    if attribution:
+        print(f"attribution (run_id): {footer_cost['attribution_run_id']}")
+        print(f"attribution (role):   {footer_cost['attribution_role']}")
+        print(f"attribution_known_limits: {footer_cost['attribution_known_limits']}")
     print(f"last_ingest_at: {footer_freshness['last_ingest_at']}")
     print(f"last_ingest_at_rfc3339: {footer_freshness['last_ingest_at_rfc3339'] or 'unknown'}")
     print(f"ingest (this run): {footer_freshness['ingest_this_run']}")
@@ -2731,6 +2755,13 @@ def _report_reconcile(paths, month, provider_totals, as_json, footer_freshness):
         },
         footer_freshness,
         total_messages,
+        # レビュー指摘4: `--reconcile`（孫5のスコープ外の既存ビュー）は
+        # `valid_events`構築・session_id joinを一切経由しないため
+        # attributionを計算していない。「計算していないので出さない」を
+        # テキスト・--json両方で徹底する — 欠落キーに"n/a"のフォールバック
+        # 文字列を充てると、attributionを計算し忘れた将来のビューが
+        # あっても気づけないまま同じ"n/a"が出続けてしまう。
+        attribution=False,
     )
     print(f"known_gaps:    {summary['known_gaps']}")
     return 0
@@ -2866,7 +2897,25 @@ def auto_ingest_for_report(root, no_ingest):
     return {"status": "ran", "stats": result}
 
 
-def backfill_run_id_and_role_via_session(usage_events, session_attrs):
+def pr_binds_from_events(events):
+    """report側(A)用: 既にデコード済みのイベント列(`valid_events`)から
+    run_id -> pr.bind情報を組み立てる。ingest側(B)の
+    `load_local_pr_binds_and_run_starts`が返す`binds`と同じ形
+    (`{"pr_number": ..., "pr_url": ...}`) — `backfill_run_id_and_role_
+    via_session`がB側の`build_usage_event`の`pr_info = binds.get(run_id)`
+    と同じ補完をread-time側でも行うために使う(レビュー指摘2)。"""
+    binds = {}
+    for e in events:
+        if e.get("event_type") != "pr.bind":
+            continue
+        run_id = e.get("run_id")
+        pr_number = e.get("pr_number")
+        if run_id and isinstance(pr_number, int):
+            binds[run_id] = {"pr_number": pr_number, "pr_url": e.get("pr_url")}
+    return binds
+
+
+def backfill_run_id_and_role_via_session(usage_events, session_attrs, binds):
     """孫5プロンプト §2 (A: report側join): session_id joinで、まだ
     run_id/roleが解決できていない`usage.message`だけを読み取り時に補完
     する。**保存済みイベントファイルは一切書き換えない** — mutates the
@@ -2884,25 +2933,39 @@ def backfill_run_id_and_role_via_session(usage_events, session_attrs):
     report側どちらのjoinで埋まったかを区別せず「via session_id」として
     一括で数えられるようにする(古い、この機能より前にingestされた
     イベントは両フィールドとも欠落しており、run_idが埋まっていれば
-    それは常にdirect解決だったとみなせる)。"""
+    それは常にdirect解決だったとみなせる)。
+
+    レビュー指摘2: `pr_number`/`pr_url`も、B側の`build_usage_event`が
+    `pr_info = binds.get(run_id)`で無条件に行っているのと同じ補完を
+    ここでも行う。これをしないと「session joinでrun_idを持つように
+    なったのに、ingestより後に読まれたか先に読まれたかでpr_numberの
+    有無が変わる」という非対称が生じ、`report_by_window`の`pr_ranges`
+    （`e.get("pr_number")`が非nullのイベントだけからPRの時刻レンジを
+    作る）がingestタイミング依存になる。run_idがこの関数の対象外
+    （元から埋まっていた）イベントも含め、run_idがありpr_numberが無い
+    全usage.messageに対して行う — B側と全く同じ「run_idが決まれば
+    pr_numberも決まる」という関係を保つため。"""
     for e in usage_events:
         if e.get("event_type") != "usage.message":
             continue
         session_id = e.get("session_id")
-        if not session_id:
-            continue
-        needs_run_id = e.get("run_id") is None
-        needs_role = e.get("role") in (None, "unknown")
-        if not needs_run_id and not needs_role:
-            continue
-        ts = parse_ts(e.get("ts"))
-        session_run_id, session_role = resolve_session_attrs(session_attrs, session_id, ts)
-        if needs_run_id and session_run_id is not None:
-            e["run_id"] = session_run_id
-            e["run_id_source"] = "session_id"
-        if needs_role and session_role is not None:
-            e["role"] = session_role
-            e["role_source"] = "session_id"
+        if session_id:
+            needs_run_id = e.get("run_id") is None
+            needs_role = e.get("role") in (None, "unknown")
+            if needs_run_id or needs_role:
+                ts = parse_ts(e.get("ts"))
+                session_run_id, session_role = resolve_session_attrs(session_attrs, session_id, ts)
+                if needs_run_id and session_run_id is not None:
+                    e["run_id"] = session_run_id
+                    e["run_id_source"] = "session_id"
+                if needs_role and session_role is not None:
+                    e["role"] = session_role
+                    e["role_source"] = "session_id"
+        if e.get("pr_number") is None:
+            pr_info = binds.get(e.get("run_id")) if e.get("run_id") else None
+            if pr_info is not None:
+                e["pr_number"] = pr_info.get("pr_number")
+                e["pr_url"] = pr_info.get("pr_url")
 
 
 def cmd_report(args):
@@ -3107,8 +3170,10 @@ def cmd_report(args):
     # `_quota_session_contributions`'s own full-store requirement), and
     # applied before ANY view-specific filtering (`events_for_pr` below
     # included) so every view — default/--pr/--phase/--role/--model/
-    # --window/--month — sees the same backfilled run_id/role.
-    backfill_run_id_and_role_via_session(valid_events, session_attrs_from_events(valid_events))
+    # --window/--month — sees the same backfilled run_id/role/pr_number.
+    backfill_run_id_and_role_via_session(
+        valid_events, session_attrs_from_events(valid_events), pr_binds_from_events(valid_events)
+    )
 
     if month_flag_present and view is None:
         return _report_month_standalone(paths, valid_events, malformed, month, repo, as_json, footer_freshness)
@@ -4045,9 +4110,19 @@ def _accumulate_session_attr_sample(raw, event):
 
 
 def _finalize_session_attrs(raw):
+    """レビュー指摘3: `_nearest_sample_value`はbisectのため`times`列を
+    その場で作っていたが、この関数は補完対象のusage.messageごと・
+    run_id/roleで1回ずつ呼ばれる(実ストア実測で1回のreportあたり
+    877,012要素分の再構築)。ここでソート済みの(ts, value)を
+    `{"ts": [...], "values": [...]}`の2並列リストに1回だけ変換して
+    持たせ、`_nearest_sample_value`側の再構築を無くす。"""
     for entry in raw.values():
-        entry["run_id"].sort(key=lambda item: item[0])
-        entry["role"].sort(key=lambda item: item[0])
+        for field in ("run_id", "role"):
+            entry[field].sort(key=lambda item: item[0])
+            entry[field] = {
+                "ts": [item[0] for item in entry[field]],
+                "values": [item[1] for item in entry[field]],
+            }
     return raw
 
 
@@ -4062,25 +4137,27 @@ def session_attrs_from_events(events):
     return _finalize_session_attrs(raw)
 
 
-def _nearest_sample_value(samples, ts):
-    """`samples`: ts昇順にソート済みの [(ts, value), ...]。`ts`に時刻が
-    最も近いサンプルのvalueを返す(前後どちらでもよい — quota.sampleは
-    60秒スロットルの定期ポーリングであり、対象メッセージの前後どちらの
-    状態が「そのときのrun_id/role」かを決める根拠は無い)。同点は前方
-    (`ts`より前)のサンプルを優先する — 決定的にするためだけの選択で、
-    後方を優先すべき積極的な理由は無い。1つのsession_idに複数の
+def _nearest_sample_value(times_values, ts):
+    """`times_values`: `_finalize_session_attrs`が組んだ
+    `{"ts": [ts昇順...], "values": [...]}`(同じ長さの2並列リスト)。
+    `ts`に時刻が最も近いサンプルのvalueを返す(前後どちらでもよい —
+    quota.sampleは60秒スロットルの定期ポーリングであり、対象メッセージ
+    の前後どちらの状態が「そのときのrun_id/role」かを決める根拠は無い)。
+    同点は前方(`ts`より前)のサンプルを優先する — 決定的にするためだけの
+    選択で、後方を優先すべき積極的な理由は無い。1つのsession_idに複数の
     run_id/roleが紐づく場合(同じセッションでworktreeを移った等)も、
     「一意でなければ解決しない」ではなくこの時刻近傍則で1つに定める
     方針とした(計画書 DOC-2608081456 孫5プロンプト §1)。"""
-    if not samples or ts is None:
+    times = times_values["ts"]
+    if not times or ts is None:
         return None
-    times = [t for t, _ in samples]
+    values = times_values["values"]
     idx = bisect.bisect_left(times, ts)
     candidates = []
-    if idx < len(samples):
-        candidates.append(samples[idx])
+    if idx < len(times):
+        candidates.append((times[idx], values[idx]))
     if idx > 0:
-        candidates.append(samples[idx - 1])
+        candidates.append((times[idx - 1], values[idx - 1]))
     best = min(candidates, key=lambda item: (abs((item[0] - ts).total_seconds()), item[0]))
     return best[1]
 
@@ -4295,6 +4372,15 @@ def build_usage_event(candidate, price_tables, today_str, role_map, binds, run_s
             direct_run_id = None
 
     direct_role = (role_info or {}).get("role")
+    # レビュー指摘5: "unknown"はこのスキーマ全体で「未解決」を表す文字列
+    # センチネル(`_accumulate_session_attr_sample`/`_attribution_source_
+    # counts`と同じ判定基準)。`resolve_herdr_role_map()`はHerdrペインの
+    # `label`をそのまま`role`に入れる(人間が`herdr pane rename`で自由に
+    # 付けられ、"unknown"という名前も付けうる)ため、正規化せずに真偽値
+    # 判定へ渡すと"unknown"が「directで解決済み」と誤認され、本来通す
+    # べきsession joinへのフォールバックが飛ばされてしまう。
+    if direct_role == "unknown":
+        direct_role = None
 
     # 孫5プロンプト §1 (B: ingest側フォールバック / 計画書「【2】【3】の鍵」):
     # direct resolution (ocw-run-id file / Herdr live pane list) failed to

--- a/bin/ocw-meter
+++ b/bin/ocw-meter
@@ -1634,12 +1634,16 @@ def _attribution_line(counts, total):
 # （実測時点のrun_id 61.6%/role 72.1%等）はこの定数に埋め込まない —
 # 母数が変わるたびに嘘になるため、実測値は毎回のattribution行自体に
 # 出る。ここに書くのは変わらない構造的な理由のみ。
+# レビュー指摘(ラウンド2 新規2): 絶対日付(2026-08-01)を埋め込まない —
+# `bin/ocw-meter` は各マシンへ個別にデプロイされ、quota.sampleの記録
+# 開始日はマシンごとのデプロイ日でありこのマシン固有の日付ではない。
+# 断言できるのは「記録開始より前は遡れない」という構造だけ。
 ATTRIBUTION_KNOWN_LIMITS = (
-    "quota.sampleの記録は2026-08-01開始のため、それより前の期間はsession_id "
-    "joinによる復元ができない。以降の期間でも100%には到達しない — claude-ds "
-    "セッションやstatusLineが一度も走らなかったセッションはrun_id/roleとも "
-    "復元不能。roleのunknownの一部はHerdr外で起動したClaudeであり原理的に "
-    "取得不能(推測で埋めない方針を維持)。"
+    "quota.sampleの記録が始まるより前の期間は、session_id joinによる復元が"
+    "できない。以降の期間でも100%には到達しない — claude-dsセッションや"
+    "statusLineが一度も走らなかったセッションはrun_id/roleとも復元不能。"
+    "roleのunknownの一部はHerdr外で起動したClaudeであり原理的に取得不能"
+    "(推測で埋めない方針を維持)。"
 )
 
 
@@ -1824,7 +1828,7 @@ def ingest_freshness_footer(cursor, ingest_run):
     }
 
 
-def print_footer_text(footer_completeness, footer_cost, footer_freshness, total, attribution=True):
+def print_footer_text(footer_completeness, footer_cost, footer_freshness, total, *, attribution=True):
     """レビュー指摘4: `attribution`はキーワード専用の明示フラグ
     (既定True) — 以前は`footer_cost.get('attribution_run_id', 'n/a ...')`
     で欠落を暗黙に許容していたが、これだと将来 `footer_cost` を手組みする
@@ -2897,16 +2901,28 @@ def auto_ingest_for_report(root, no_ingest):
     return {"status": "ran", "stats": result}
 
 
-def pr_binds_from_events(events):
+def pr_binds_from_events(events, repo):
     """report側(A)用: 既にデコード済みのイベント列(`valid_events`)から
     run_id -> pr.bind情報を組み立てる。ingest側(B)の
     `load_local_pr_binds_and_run_starts`が返す`binds`と同じ形
     (`{"pr_number": ..., "pr_url": ...}`) — `backfill_run_id_and_role_
     via_session`がB側の`build_usage_event`の`pr_info = binds.get(run_id)`
-    と同じ補完をread-time側でも行うために使う(レビュー指摘2)。"""
+    と同じ補完をread-time側でも行うために使う(レビュー指摘2)。
+
+    レビュー指摘(ラウンド2 新規1): `repo`でスコープしないと、別repoで
+    bindされた`pr_number`がこの共有ストア（`ocw-meter`は全repo共有）で
+    `usage.message`の`pr_number`に焼き込まれ、`events_for_pr()`の直接
+    マッチ（`e.get("pr_number") == pr_number and e.get("repo") == repo`）
+    をすり抜けて別repoの費用が混入する。`find_approved_pr_numbers_in_
+    month()`の`run_to_pr`と同じ`e.get("repo") == repo`スコープを揃える。
+    `repo`が`None`（PR/window/monthビュー以外でgit repo外から実行された
+    場合）のときは、`repo`が`None`のpr.bindしかマッチしない — 「推測で
+    埋めない」の原則どおり、repoが分からない状況でscopeを緩めない。"""
     binds = {}
     for e in events:
         if e.get("event_type") != "pr.bind":
+            continue
+        if e.get("repo") != repo:
             continue
         run_id = e.get("run_id")
         pr_number = e.get("pr_number")
@@ -3172,7 +3188,7 @@ def cmd_report(args):
     # included) so every view — default/--pr/--phase/--role/--model/
     # --window/--month — sees the same backfilled run_id/role/pr_number.
     backfill_run_id_and_role_via_session(
-        valid_events, session_attrs_from_events(valid_events), pr_binds_from_events(valid_events)
+        valid_events, session_attrs_from_events(valid_events), pr_binds_from_events(valid_events, repo)
     )
 
     if month_flag_present and view is None:

--- a/bin/tests/test_ocw_meter.py
+++ b/bin/tests/test_ocw_meter.py
@@ -4807,6 +4807,36 @@ class SessionAttributionTests(OcwMeterTestCase):
         data = json.loads(run_meter(["report", "--window", "--json"], self.home).stdout)
         self.assertIn(88, data["by_window"]["win-report-pr-window"]["prs_time_overlap"])
 
+    def test_report_side_pr_number_backfill_is_scoped_to_repo(self):
+        # レビュー指摘(ラウンド2 新規1): `pr_binds_from_events()`が`repo`
+        # でスコープしないと、別リポジトリでbindされたPR番号が
+        # read-timeにこのイベントのpr_numberとして焼き込まれ、
+        # `events_for_pr()`の直接マッチ(pr_number一致 + repo一致)を
+        # すり抜けて別リポジトリの費用が混入してしまう。`run_id`は
+        # グローバルに一意な値なので、このセッションのrun_idと別
+        # リポジトリのpr.bindのrun_idを衝突させて再現する。
+        session_id = "sess-cross-repo"
+        run_meter(["event", "pr.bind", "--idempotency-key", "cross-repo-bind",
+                   "--run-id", "run-cross-repo", "--pr-number", "55",
+                   "--repo", "someone/other-repo"], self.home)
+        run_meter(["event", "quota.sample", "--idempotency-key", "cross-repo-q1", "--plan-source", "statusline",
+                   "--session-id", session_id, "--run-id", "run-cross-repo",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        # 自リポジトリ(このテストの実行cwdから自動解決される)の
+        # usage.message。session_idのみでrun_id/pr_numberは無い —
+        # session joinでrun_idを"run-cross-repo"に解決した後、修正前は
+        # そのrun_idを(repoでスコープせず)binds に引いてpr_number=55を
+        # 焼き込んでしまっていた。
+        run_meter(["event", "usage.message", "--idempotency-key", "cross-repo-u1", "--message-id", "m-cross-repo",
+                   "--session-id", session_id, "--model", "deepseek-v4-pro", "--cost-basis", "estimated",
+                   "--cost-estimate-usd", "999.0",
+                   "--ts", "2026-08-01T09:05:00.000Z"], self.home)
+        data = json.loads(run_meter(["report", "--pr", "55", "--json"], self.home).stdout)
+        # このリポジトリにはPR55への直接紐づけも無いはずなので、上の
+        # usage.message(別リポジトリのPR55にbindされたrun_id経由)は
+        # 一切拾われてはいけない。
+        self.assertIsNone(data["pr_detail"]["cash_cost_usd"])
+
     def test_report_side_join_does_not_overwrite_already_resolved_run_id(self):
         session_id = "sess-report-nooverwrite"
         run_meter(["event", "quota.sample", "--idempotency-key", "rno-q1", "--plan-source", "statusline",
@@ -4845,10 +4875,14 @@ class SessionAttributionTests(OcwMeterTestCase):
     def test_attribution_known_limits_present_in_text_and_json(self):
         # 孫5プロンプト §4「残る限界を出力または文書に書く」/ レビュー
         # 指摘1: session_id joinを入れても100%解決には到達しない構造的な
-        # 理由(quota.sampleが2026-08-01開始であること等)を、attribution行
-        # と一緒に毎回出す。
+        # 理由を、attribution行と一緒に毎回出す。
+        # レビュー指摘(ラウンド2 新規2): 絶対日付(2026-08-01)はこの
+        # マシン固有の事実であり、`bin/ocw-meter`は各マシンへ個別に
+        # デプロイされるツールの出力として断言してはいけない。ここでは
+        # マシン非依存の構造的な言い回しの一部だけを固定する。
         data = json.loads(run_meter(["report", "--json"], self.home).stdout)
-        self.assertIn("2026-08-01", data["attribution_known_limits"])
+        self.assertIn("quota.sampleの記録が始まるより前の期間は", data["attribution_known_limits"])
+        self.assertNotIn("2026-08-01", data["attribution_known_limits"])
         text = run_meter(["report"], self.home).stdout
         self.assertIn("attribution_known_limits:", text)
 

--- a/bin/tests/test_ocw_meter.py
+++ b/bin/tests/test_ocw_meter.py
@@ -4554,6 +4554,43 @@ class SessionAttributionTests(OcwMeterTestCase):
         self.assertEqual(event["role"], "implementer")
         self.assertEqual(event["role_source"], "direct")
 
+    def test_ingest_role_falls_back_to_session_join_when_herdr_label_is_the_string_unknown(self):
+        # レビュー指摘5: `"unknown"`はこのスキーマ全体で「未解決」を表す
+        # 文字列センチネル。Herdrのペインlabelは`herdr pane rename`で人間が
+        # 自由に付けられるため、labelがたまたま`"unknown"`だった場合に
+        # それを「directで解決済み」と誤認してsession joinへの
+        # フォールバックを飛ばしてはいけない。
+        session_id = "sess-join-role-unknown-label"
+        write_transcript(self.projects_dir, "proj", session_id, [assistant_line(session_id, "m1")])
+        run_meter(["event", "quota.sample", "--idempotency-key", "q5", "--plan-source", "statusline",
+                   "--session-id", session_id, "--role", "reviewer",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+
+        pane_json = json.dumps({"panes": [{
+            "pane_id": "w1:p2", "label": "unknown", "workspace_id": "w1",
+            "agent_session": {"agent": "claude", "kind": "id", "value": session_id},
+            "cwd": "/whatever",
+        }]})
+        fake_bin = pathlib.Path(self.tmpdir.name) / "fake-bin-unknown-label"
+        fake_bin.mkdir()
+        herdr_script = fake_bin / "herdr"
+        herdr_script.write_text(
+            "#!/usr/bin/env bash\n"
+            'if [ "$1" = "status" ] && [ "$2" = "server" ]; then exit 0; fi\n'
+            'if [ "$1" = "workspace" ] && [ "$2" = "list" ]; then echo \'{"workspaces":[{"workspace_id":"w1"}]}\'; exit 0; fi\n'
+            f"if [ \"$1\" = \"pane\" ] && [ \"$2\" = \"list\" ]; then echo '{pane_json}'; exit 0; fi\n"
+            "exit 1\n",
+            encoding="utf-8",
+        )
+        herdr_script.chmod(0o755)
+        path_with_fake_herdr_first = f"{fake_bin}:{os.environ.get('PATH', '')}"
+
+        result = run_ingest(self.home, self.projects_dir, extra_env={"PATH": path_with_fake_herdr_first})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = next(e for e in read_events(self.home) if e["event_type"] == "usage.message")
+        self.assertEqual(event["role"], "reviewer")
+        self.assertEqual(event["role_source"], "session_id")
+
     def test_ingest_run_id_and_role_stay_unresolved_without_any_source(self):
         session_id = "sess-none"
         write_transcript(self.projects_dir, "proj", session_id, [
@@ -4742,6 +4779,34 @@ class SessionAttributionTests(OcwMeterTestCase):
         data = json.loads(run_meter(["report", "--pr", "77", "--json"], self.home).stdout)
         self.assertAlmostEqual(data["pr_detail"]["cash_cost_usd"], 0.05)
 
+    def test_report_side_join_backfills_pr_number_symmetric_with_ingest_side(self):
+        # レビュー指摘2: B(ingest側フォールバック)はrun_idが決まると
+        # pr_number/pr_urlも一緒に埋める(build_usage_eventの
+        # `pr_info = binds.get(run_id)`)。A(report側join)がrun_idだけ
+        # 補完してpr_numberを埋めないと、report_by_windowのpr_ranges
+        # (`e.get("pr_number")`が非nullのイベントだけからPRの時刻レンジを
+        # 作る)が「session joinのrun_idを最初から持っていたか
+        # (ingest側で解決済み)、read-timeに初めて解決したか」で
+        # prs_time_overlapの中身が変わってしまう。
+        session_id = "sess-report-pr-window"
+        run_meter(["event", "quota.sample", "--idempotency-key", "rprw-q1", "--plan-source", "statusline",
+                   "--session-id", session_id, "--run-id", "run-report-pr-window",
+                   "--window-id", "win-report-pr-window",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        run_meter(["event", "quota.sample", "--idempotency-key", "rprw-q2", "--plan-source", "statusline",
+                   "--session-id", session_id, "--run-id", "run-report-pr-window",
+                   "--window-id", "win-report-pr-window",
+                   "--ts", "2026-08-01T09:10:00.000Z"], self.home)
+        run_meter(["bind-pr", "--run", "run-report-pr-window", "--pr", "88"], self.home)
+        # session_idのみ(run_id/pr_numberは無し) — Aがrun_idをsession
+        # joinで解決した後、それをbindsに引いてpr_numberも埋める必要が
+        # ある。
+        run_meter(["event", "usage.message", "--idempotency-key", "rprw-u1", "--message-id", "m-report-pr-window",
+                   "--session-id", session_id, "--model", "deepseek-v4-pro", "--cost-basis", "estimated",
+                   "--ts", "2026-08-01T09:05:00.000Z"], self.home)
+        data = json.loads(run_meter(["report", "--window", "--json"], self.home).stdout)
+        self.assertIn(88, data["by_window"]["win-report-pr-window"]["prs_time_overlap"])
+
     def test_report_side_join_does_not_overwrite_already_resolved_run_id(self):
         session_id = "sess-report-nooverwrite"
         run_meter(["event", "quota.sample", "--idempotency-key", "rno-q1", "--plan-source", "statusline",
@@ -4777,6 +4842,16 @@ class SessionAttributionTests(OcwMeterTestCase):
         self.assertEqual(data["attribution_run_id"], "n/a (no usage.message events)")
         self.assertEqual(data["attribution_role"], "n/a (no usage.message events)")
 
+    def test_attribution_known_limits_present_in_text_and_json(self):
+        # 孫5プロンプト §4「残る限界を出力または文書に書く」/ レビュー
+        # 指摘1: session_id joinを入れても100%解決には到達しない構造的な
+        # 理由(quota.sampleが2026-08-01開始であること等)を、attribution行
+        # と一緒に毎回出す。
+        data = json.loads(run_meter(["report", "--json"], self.home).stdout)
+        self.assertIn("2026-08-01", data["attribution_known_limits"])
+        text = run_meter(["report"], self.home).stdout
+        self.assertIn("attribution_known_limits:", text)
+
     def test_attribution_footer_counts_direct_session_and_unresolved_and_sums_to_total(self):
         # direct: run_idが直接設定されている(session join不要)。
         run_meter(["event", "usage.message", "--idempotency-key", "att-direct", "--message-id", "m-direct",
@@ -4811,11 +4886,19 @@ class SessionAttributionTests(OcwMeterTestCase):
         self.assertIn("attribution (run_id):", text)
         self.assertIn("attribution (role):", text)
 
-    def test_reconcile_view_omits_attribution_gracefully(self):
-        result = run_meter(["report", "--reconcile"], self.home)
-        self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("attribution (run_id): n/a", result.stdout)
-        self.assertIn("attribution (role):   n/a", result.stdout)
+    def test_reconcile_view_omits_attribution_entirely_in_text_and_json(self):
+        # レビュー指摘4: `--reconcile`はvalid_events構築・session_id join
+        # を経由しないためattributionを計算していない。「computeしていない
+        # ものは出さない」をテキスト・--json両方で徹底し、"n/a"のような
+        # フォールバック文字列で欠落をごまかさない。
+        text_result = run_meter(["report", "--reconcile"], self.home)
+        self.assertEqual(text_result.returncode, 0, text_result.stderr)
+        self.assertNotIn("attribution", text_result.stdout)
+
+        json_result = run_meter(["report", "--reconcile", "--json"], self.home)
+        self.assertEqual(json_result.returncode, 0, json_result.stderr)
+        data = json.loads(json_result.stdout)
+        self.assertFalse(any(key.startswith("attribution") for key in data))
 
 
 if __name__ == "__main__":

--- a/bin/tests/test_ocw_meter.py
+++ b/bin/tests/test_ocw_meter.py
@@ -4459,5 +4459,364 @@ class SnapshotQuotaRoundTwoReviewTests(OcwMeterTestCase):
         self.assertEqual(status.stdout.strip(), "", "suppression cache must not write inside $HOME's own git worktree")
 
 
+class SessionAttributionTests(OcwMeterTestCase):
+    """docs/planning/DOC-2608081456_..._計画.md 孫5プロンプン: session_id
+    joinによるrun_id/roleの帰属解決(B: ingest側フォールバック / A: report
+    側join)と、attribution行。
+
+    quota.sample events here are written directly via `ocw-meter event
+    quota.sample ...` (bypassing `snapshot-quota`'s statusLine-JSON
+    parsing entirely) — this phase's own scope is the session_id join
+    logic itself, not statusLine ingestion (already covered by
+    SnapshotQuotaBasicsTests etc.), and `event` is the same forward-
+    compatible primitive `_seed_full_pr` above already uses for the same
+    reason."""
+
+    def setUp(self):
+        super().setUp()
+        self.projects_dir = pathlib.Path(self.tmpdir.name) / "claude-projects"
+        self.projects_dir.mkdir(parents=True, exist_ok=True)
+
+    # -- B: ingest側フォールバック --
+
+    def test_ingest_run_id_resolved_via_session_id_join_when_ocw_run_id_file_absent(self):
+        session_id = "sess-join-1"
+        run_meter(["event", "quota.sample", "--idempotency-key", "q1", "--plan-source", "statusline",
+                   "--session-id", session_id, "--run-id", "run-from-session",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        write_transcript(self.projects_dir, "proj", session_id, [
+            assistant_line(session_id, "m1", cwd="/nonexistent/not-a-worktree", timestamp="2026-08-01T09:05:00.000Z"),
+        ])
+        result = run_ingest(self.home, self.projects_dir, extra_env={"PATH": "/usr/bin:/bin"})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = next(e for e in read_events(self.home) if e["event_type"] == "usage.message")
+        self.assertEqual(event["run_id"], "run-from-session")
+        self.assertEqual(event["run_id_source"], "session_id")
+
+    def test_ingest_run_id_prefers_ocw_run_id_file_over_session_join(self):
+        session_id = "sess-join-2"
+        worktree_dir = make_ocw_style_worktree(self.tmpdir.name, run_id="run-direct")
+        run_meter(["event", "quota.sample", "--idempotency-key", "q2", "--plan-source", "statusline",
+                   "--session-id", session_id, "--run-id", "run-from-session",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        write_transcript(self.projects_dir, "proj", session_id, [
+            assistant_line(session_id, "m1", cwd=str(worktree_dir), timestamp="2026-08-01T09:05:00.000Z"),
+        ])
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = next(e for e in read_events(self.home) if e["event_type"] == "usage.message")
+        self.assertEqual(event["run_id"], "run-direct")
+        self.assertEqual(event["run_id_source"], "direct")
+
+    def test_ingest_role_resolved_via_session_id_join_when_herdr_unavailable(self):
+        session_id = "sess-join-role"
+        run_meter(["event", "quota.sample", "--idempotency-key", "q3", "--plan-source", "statusline",
+                   "--session-id", session_id, "--role", "implementer",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        write_transcript(self.projects_dir, "proj", session_id, [
+            assistant_line(session_id, "m1", timestamp="2026-08-01T09:05:00.000Z"),
+        ])
+        result = run_ingest(self.home, self.projects_dir, extra_env={"PATH": "/usr/bin:/bin"})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = next(e for e in read_events(self.home) if e["event_type"] == "usage.message")
+        self.assertEqual(event["role"], "implementer")
+        self.assertEqual(event["role_source"], "session_id")
+
+    def test_ingest_role_prefers_herdr_live_over_session_join(self):
+        session_id = "sess-join-role-2"
+        write_transcript(self.projects_dir, "proj", session_id, [assistant_line(session_id, "m1")])
+        run_meter(["event", "quota.sample", "--idempotency-key", "q4", "--plan-source", "statusline",
+                   "--session-id", session_id, "--role", "reviewer",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+
+        pane_json = json.dumps({"panes": [{
+            "pane_id": "w1:p2", "label": "implementer", "workspace_id": "w1",
+            "agent_session": {"agent": "claude", "kind": "id", "value": session_id},
+            "cwd": "/whatever",
+        }]})
+        fake_bin = pathlib.Path(self.tmpdir.name) / "fake-bin"
+        fake_bin.mkdir()
+        herdr_script = fake_bin / "herdr"
+        herdr_script.write_text(
+            "#!/usr/bin/env bash\n"
+            'if [ "$1" = "status" ] && [ "$2" = "server" ]; then exit 0; fi\n'
+            'if [ "$1" = "workspace" ] && [ "$2" = "list" ]; then echo \'{"workspaces":[{"workspace_id":"w1"}]}\'; exit 0; fi\n'
+            f"if [ \"$1\" = \"pane\" ] && [ \"$2\" = \"list\" ]; then echo '{pane_json}'; exit 0; fi\n"
+            "exit 1\n",
+            encoding="utf-8",
+        )
+        herdr_script.chmod(0o755)
+        path_with_fake_herdr_first = f"{fake_bin}:{os.environ.get('PATH', '')}"
+
+        result = run_ingest(self.home, self.projects_dir, extra_env={"PATH": path_with_fake_herdr_first})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = next(e for e in read_events(self.home) if e["event_type"] == "usage.message")
+        self.assertEqual(event["role"], "implementer")
+        self.assertEqual(event["role_source"], "direct")
+
+    def test_ingest_run_id_and_role_stay_unresolved_without_any_source(self):
+        session_id = "sess-none"
+        write_transcript(self.projects_dir, "proj", session_id, [
+            assistant_line(session_id, "m1", timestamp="2026-08-01T09:05:00.000Z"),
+        ])
+        result = run_ingest(self.home, self.projects_dir, extra_env={"PATH": "/usr/bin:/bin"})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = next(e for e in read_events(self.home) if e["event_type"] == "usage.message")
+        self.assertIsNone(event["run_id"])
+        self.assertIsNone(event["run_id_source"])
+        self.assertEqual(event["role"], "unknown")
+        self.assertIsNone(event["role_source"])
+
+    def test_ingest_run_id_and_role_from_session_join_can_come_from_different_samples(self):
+        # quota.sampleはOCW_RUN_ID/OCW_ROLEを独立に持ちうる(片方だけ
+        # 設定されている、あるいは無い場合がある) — run_idとroleを
+        # それぞれ別サンプルの「最も時刻が近いもの」から独立に解決する。
+        session_id = "sess-split-fields"
+        run_meter(["event", "quota.sample", "--idempotency-key", "split-q1", "--plan-source", "statusline",
+                   "--session-id", session_id, "--run-id", "run-split",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        run_meter(["event", "quota.sample", "--idempotency-key", "split-q2", "--plan-source", "statusline",
+                   "--session-id", session_id, "--role", "commander",
+                   "--ts", "2026-08-01T09:01:00.000Z"], self.home)
+        write_transcript(self.projects_dir, "proj", session_id, [
+            assistant_line(session_id, "m1", timestamp="2026-08-01T09:02:00.000Z"),
+        ])
+        result = run_ingest(self.home, self.projects_dir, extra_env={"PATH": "/usr/bin:/bin"})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = next(e for e in read_events(self.home) if e["event_type"] == "usage.message")
+        self.assertEqual(event["run_id"], "run-split")
+        self.assertEqual(event["role"], "commander")
+
+    # -- 罠1: session_id由来のrun_idにrun.start逆転チェックを適用しない --
+
+    def test_session_join_run_id_not_subject_to_run_start_reversal_check(self):
+        # ocw-run-idファイル経由なら、メッセージがそのrun_idのrun.startより
+        # 前なら捨てられる(test_ingest_run_id_not_misattributed_when_
+        # worktree_path_is_reusedで確認済み)。session_id由来のrun_idは
+        # worktreeパスのように再利用されることが無いため、同じチェックを
+        # 適用してはいけない(計画書DOC-2608081456 罠1)。
+        session_id = "sess-trap1"
+        run_meter(["event", "run.start", "--idempotency-key", "trap1-start", "--run-id", "run-trap1",
+                   "--ts", "2026-08-01T12:00:00.000Z", "--base-ref", "master", "--command", "claude"],
+                  self.home)
+        run_meter(["event", "quota.sample", "--idempotency-key", "trap1-q", "--plan-source", "statusline",
+                   "--session-id", session_id, "--run-id", "run-trap1",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        # メッセージ(09:05)はrun-trap1のrun.start(12:00)より前。
+        write_transcript(self.projects_dir, "proj", session_id, [
+            assistant_line(session_id, "m1", timestamp="2026-08-01T09:05:00.000Z"),
+        ])
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = next(e for e in read_events(self.home) if e["event_type"] == "usage.message")
+        self.assertEqual(event["run_id"], "run-trap1")
+        self.assertEqual(event["run_id_source"], "session_id")
+
+    def test_direct_run_id_still_subject_to_run_start_reversal_check_regression(self):
+        # 罠1修正の対偶: ocw-run-idファイル経由の逆転チェック自体は
+        # 従来どおり効いたまま — session_id側の除外がdirect側にまで
+        # 波及していないことの回帰確認。
+        worktree_dir = make_ocw_style_worktree(self.tmpdir.name, run_id="run-trap1-direct")
+        run_meter(["event", "run.start", "--idempotency-key", "trap1d-start", "--run-id", "run-trap1-direct",
+                   "--ts", "2026-08-01T12:00:00.000Z", "--base-ref", "master", "--command", "claude"],
+                  self.home)
+        write_transcript(self.projects_dir, "proj", "sess-trap1-direct", [
+            assistant_line("sess-trap1-direct", "m1", cwd=str(worktree_dir), timestamp="2026-08-01T09:05:00.000Z"),
+        ])
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = next(e for e in read_events(self.home) if e["event_type"] == "usage.message")
+        self.assertIsNone(event["run_id"])
+
+    # -- 曖昧なケース: 1つのsession_idに複数のrun_id/roleが紐づく --
+
+    def test_ambiguous_session_run_id_resolves_to_nearest_in_time_sample(self):
+        session_id = "sess-ambiguous"
+        run_meter(["event", "quota.sample", "--idempotency-key", "amb-q1", "--plan-source", "statusline",
+                   "--session-id", session_id, "--run-id", "run-early",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        run_meter(["event", "quota.sample", "--idempotency-key", "amb-q2", "--plan-source", "statusline",
+                   "--session-id", session_id, "--run-id", "run-late",
+                   "--ts", "2026-08-01T11:00:00.000Z"], self.home)
+        run_meter(["event", "phase.start", "--idempotency-key", "amb-ps-early", "--run-id", "run-early",
+                   "--phase", "fix", "--round", "1", "--ts", "2026-08-01T08:00:00.000Z"], self.home)
+        run_meter(["event", "phase.end", "--idempotency-key", "amb-pe-early", "--run-id", "run-early",
+                   "--phase", "fix", "--round", "1", "--ts", "2026-08-01T23:59:00.000Z"], self.home)
+        run_meter(["event", "phase.start", "--idempotency-key", "amb-ps-late", "--run-id", "run-late",
+                   "--phase", "review", "--round", "1", "--ts", "2026-08-01T08:00:00.000Z"], self.home)
+        run_meter(["event", "phase.end", "--idempotency-key", "amb-pe-late", "--run-id", "run-late",
+                   "--phase", "review", "--round", "1", "--ts", "2026-08-01T23:59:00.000Z"], self.home)
+        # メッセージのtsはrun-earlyのサンプル(09:00, 差110分)よりrun-late
+        # のサンプル(11:00, 差10分)に近い — run-lateに解決されるはず。
+        write_transcript(self.projects_dir, "proj", session_id, [
+            assistant_line(session_id, "m1", timestamp="2026-08-01T10:50:00.000Z"),
+        ])
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        data = json.loads(run_meter(["report", "--phase", "--json"], self.home).stdout)
+        self.assertEqual(data["by_phase"]["review"]["messages"], 1)
+        self.assertEqual(data["by_phase"]["fix"]["messages"], 0)
+
+    def test_ambiguous_session_role_resolves_to_nearest_in_time_sample(self):
+        session_id = "sess-ambiguous-role"
+        run_meter(["event", "quota.sample", "--idempotency-key", "ambr-q1", "--plan-source", "statusline",
+                   "--session-id", session_id, "--role", "commander",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        run_meter(["event", "quota.sample", "--idempotency-key", "ambr-q2", "--plan-source", "statusline",
+                   "--session-id", session_id, "--role", "reviewer",
+                   "--ts", "2026-08-01T11:00:00.000Z"], self.home)
+        run_meter(["event", "usage.message", "--idempotency-key", "ambr-u1", "--message-id", "m-ambiguous-role",
+                   "--session-id", session_id, "--model", "deepseek-v4-pro", "--cost-basis", "estimated",
+                   "--ts", "2026-08-01T10:50:00.000Z"], self.home)
+        data = json.loads(run_meter(["report", "--role", "--json"], self.home).stdout)
+        self.assertEqual(data["by_role"]["reviewer"]["messages"], 1)
+        # "commander"バケット自体はcommanderサンプルのquota.sample自身の
+        # roleフィールドで存在する(total_events)が、usage.messageは
+        # そちら側には計上されない。
+        self.assertEqual(data["by_role"].get("commander", {}).get("messages", 0), 0)
+
+    def test_session_join_tie_break_prefers_earlier_sample(self):
+        session_id = "sess-tie"
+        run_meter(["event", "quota.sample", "--idempotency-key", "tie-q1", "--plan-source", "statusline",
+                   "--session-id", session_id, "--run-id", "run-tie-early",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        run_meter(["event", "quota.sample", "--idempotency-key", "tie-q2", "--plan-source", "statusline",
+                   "--session-id", session_id, "--run-id", "run-tie-late",
+                   "--ts", "2026-08-01T11:00:00.000Z"], self.home)
+        # メッセージは2つのサンプルのちょうど中間 -> 同点。仕様上、前方
+        # (早い方)のサンプルを優先する。
+        write_transcript(self.projects_dir, "proj", session_id, [
+            assistant_line(session_id, "m1", timestamp="2026-08-01T10:00:00.000Z"),
+        ])
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = next(e for e in read_events(self.home) if e["event_type"] == "usage.message")
+        self.assertEqual(event["run_id"], "run-tie-early")
+
+    # -- A: report側join --
+
+    def test_report_backfills_null_run_id_and_unknown_role_without_touching_stored_file(self):
+        session_id = "sess-report-join"
+        run_meter(["event", "quota.sample", "--idempotency-key", "rq1", "--plan-source", "statusline",
+                   "--session-id", session_id, "--run-id", "run-report-1", "--role", "implementer",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        run_meter(["event", "usage.message", "--idempotency-key", "ru1", "--message-id", "m-report-1",
+                   "--session-id", session_id, "--model", "deepseek-v4-pro", "--cost-basis", "estimated",
+                   "--ts", "2026-08-01T09:05:00.000Z"], self.home)
+
+        data = json.loads(run_meter(["report", "--role", "--json"], self.home).stdout)
+        self.assertEqual(data["by_role"]["implementer"]["messages"], 1)
+
+        # 保存済みイベントファイル自体は一切書き換わっていない
+        # (read-time解決のみ)。
+        stored = next(e for e in read_events(self.home) if e["event_type"] == "usage.message")
+        self.assertIsNone(stored["run_id"])
+        self.assertEqual(stored["role"], "unknown")
+
+    def test_report_side_join_feeds_phase_view(self):
+        session_id = "sess-report-phase"
+        run_meter(["event", "quota.sample", "--idempotency-key", "rp-q1", "--plan-source", "statusline",
+                   "--session-id", session_id, "--run-id", "run-report-phase",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        run_meter(["event", "phase.start", "--idempotency-key", "rp-ps", "--run-id", "run-report-phase",
+                   "--phase", "fix", "--round", "1", "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        run_meter(["event", "phase.end", "--idempotency-key", "rp-pe", "--run-id", "run-report-phase",
+                   "--phase", "fix", "--round", "1", "--ts", "2026-08-01T09:10:00.000Z"], self.home)
+        run_meter(["event", "usage.message", "--idempotency-key", "rp-u1", "--message-id", "m-report-phase",
+                   "--session-id", session_id, "--model", "deepseek-v4-pro", "--cost-basis", "estimated",
+                   "--ts", "2026-08-01T09:05:00.000Z"], self.home)
+        data = json.loads(run_meter(["report", "--phase", "--json"], self.home).stdout)
+        self.assertEqual(data["by_phase"]["fix"]["messages"], 1)
+        self.assertNotIn("(unassigned)", data["by_phase"])
+
+    def test_report_side_join_lets_events_for_pr_and_pr_review_summary_match_backfilled_run_id(self):
+        session_id = "sess-report-pr"
+        run_meter(["event", "quota.sample", "--idempotency-key", "rpr-q1", "--plan-source", "statusline",
+                   "--session-id", session_id, "--run-id", "run-report-pr",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        run_meter(["bind-pr", "--run", "run-report-pr", "--pr", "77"], self.home)
+        run_meter(["event", "usage.message", "--idempotency-key", "rpr-u1", "--message-id", "m-report-pr",
+                   "--session-id", session_id, "--model", "deepseek-v4-pro", "--cost-basis", "estimated",
+                   "--cost-estimate-usd", "0.05",
+                   "--ts", "2026-08-01T09:05:00.000Z"], self.home)
+        data = json.loads(run_meter(["report", "--pr", "77", "--json"], self.home).stdout)
+        self.assertAlmostEqual(data["pr_detail"]["cash_cost_usd"], 0.05)
+
+    def test_report_side_join_does_not_overwrite_already_resolved_run_id(self):
+        session_id = "sess-report-nooverwrite"
+        run_meter(["event", "quota.sample", "--idempotency-key", "rno-q1", "--plan-source", "statusline",
+                   "--session-id", session_id, "--run-id", "run-from-session-should-not-be-used",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        run_meter(["event", "usage.message", "--idempotency-key", "rno-u1", "--message-id", "m-noover",
+                   "--session-id", session_id, "--run-id", "run-already-direct",
+                   "--model", "deepseek-v4-pro", "--cost-basis", "estimated",
+                   "--ts", "2026-08-01T09:05:00.000Z"], self.home)
+        data = json.loads(run_meter(["report", "--json"], self.home).stdout)
+        self.assertEqual(data["attribution_run_id_counts"], {"direct": 1, "session_id": 0, "unresolved": 0})
+
+    def test_report_side_join_does_not_overwrite_already_resolved_role(self):
+        session_id = "sess-role-noover"
+        run_meter(["event", "quota.sample", "--idempotency-key", "rrn-q1", "--plan-source", "statusline",
+                   "--session-id", session_id, "--role", "reviewer",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        run_meter(["event", "usage.message", "--idempotency-key", "rrn-u1", "--message-id", "m-role-noover",
+                   "--session-id", session_id, "--role", "implementer",
+                   "--model", "deepseek-v4-pro", "--cost-basis", "estimated",
+                   "--ts", "2026-08-01T09:05:00.000Z"], self.home)
+        data = json.loads(run_meter(["report", "--role", "--json"], self.home).stdout)
+        self.assertEqual(data["by_role"]["implementer"]["messages"], 1)
+        # "reviewer"バケット自体はquota.sample自身のroleフィールドで
+        # 存在する(total_events)が、usage.messageは上書きされずimplementer
+        # のまま — そちら側には計上されない。
+        self.assertEqual(data["by_role"].get("reviewer", {}).get("messages", 0), 0)
+
+    # -- attribution行 --
+
+    def test_attribution_footer_present_on_empty_storage(self):
+        data = json.loads(run_meter(["report", "--json"], self.home).stdout)
+        self.assertEqual(data["attribution_run_id"], "n/a (no usage.message events)")
+        self.assertEqual(data["attribution_role"], "n/a (no usage.message events)")
+
+    def test_attribution_footer_counts_direct_session_and_unresolved_and_sums_to_total(self):
+        # direct: run_idが直接設定されている(session join不要)。
+        run_meter(["event", "usage.message", "--idempotency-key", "att-direct", "--message-id", "m-direct",
+                   "--run-id", "run-direct-x", "--model", "deepseek-v4-pro", "--cost-basis", "estimated",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        # via session_id: quota.sampleとのjoinで解決。
+        session_id = "sess-attribution"
+        run_meter(["event", "quota.sample", "--idempotency-key", "att-q1", "--plan-source", "statusline",
+                   "--session-id", session_id, "--run-id", "run-session-x", "--role", "reviewer",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        run_meter(["event", "usage.message", "--idempotency-key", "att-session", "--message-id", "m-session",
+                   "--session-id", session_id, "--model", "deepseek-v4-pro", "--cost-basis", "estimated",
+                   "--ts", "2026-08-01T09:05:00.000Z"], self.home)
+        # unresolved: どちらの手段でも解決できない。
+        run_meter(["event", "usage.message", "--idempotency-key", "att-unresolved", "--message-id", "m-unresolved",
+                   "--model", "deepseek-v4-pro", "--cost-basis", "estimated",
+                   "--ts", "2026-08-01T09:10:00.000Z"], self.home)
+
+        data = json.loads(run_meter(["report", "--json"], self.home).stdout)
+        run_id_counts = data["attribution_run_id_counts"]
+        self.assertEqual(run_id_counts, {"direct": 1, "session_id": 1, "unresolved": 1})
+        self.assertEqual(sum(run_id_counts.values()), 3)
+        self.assertIn("direct 33.3%", data["attribution_run_id"])
+        self.assertIn("via session_id 33.3%", data["attribution_run_id"])
+        self.assertIn("unresolved 33.3%", data["attribution_run_id"])
+
+        # role: session joinで解決したメッセージ(reviewer)のみ埋まる。
+        role_counts = data["attribution_role_counts"]
+        self.assertEqual(role_counts, {"direct": 0, "session_id": 1, "unresolved": 2})
+
+        text = run_meter(["report"], self.home).stdout
+        self.assertIn("attribution (run_id):", text)
+        self.assertIn("attribution (role):", text)
+
+    def test_reconcile_view_omits_attribution_gracefully(self):
+        result = run_meter(["report", "--reconcile"], self.home)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("attribution (run_id): n/a", result.stdout)
+        self.assertIn("attribution (role):   n/a", result.stdout)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 背景

`ocw-meter` はClaude Codeの利用状況（トークン数・費用・PRごとの作業内容）を記録する計測ツールです。傘ブランチ `ocw-meter-accuracy` では、実際のデータと突き合わせて見つかった計測精度の問題を1つずつ解消しています。このプルリクエストはそのうちの1つで、`run_id`（どの作業セッションか）と `role`（実装役・レビュー役などの立場）の紐付けを扱います。

これまでの実装では、`run_id` は「メッセージが記録された作業ディレクトリに、いま `ocw-run-id` というファイルが存在するか」を、`role` は「Herdrというツールのペイン一覧にいま該当セッションが載っているか」を、それぞれ**取り込み処理の実行時点**で確認して決めていました。しかし作業ディレクトリは片付けられれば消えますし、Herdrのペインも閉じられれば見えなくなります。しかも「過去に記録した値は再計算しない」という方針があるため、一度 `null`（不明）のまま記録されると二度と直りません。実際のデータでは、`run_id` が入っているメッセージは全体の5.3%、`role` が判明しているものは9.1%しかなく、レビューフェーズ別の集計はほぼ機能していない状態でした。

一方、Claude Codeのステータスバー（statusLine）から5秒〜60秒おきに記録している別の記録（`quota.sample`）には、セッションを一意に表す `session_id` が100%、`run_id` が78%、`role` が78%含まれています。この記録は消えることがないため、**同じ `session_id` を手がかりに突き合わせれば、消えてしまった情報を復元できます**。

## このプルリクエストの目的

`session_id` を使った突き合わせにより、`run_id` と `role` の判明率を実測で以下まで引き上げます（8月分・約17,670件で計測）。

- `run_id`: 17.2% → 61.6%
- `role`: 27.2% → 72.1%

あわせて、どの経路で判明したか（直接判明・突き合わせで判明・不明のまま）を出力に明示します。数字を「直った」ように見せず、推測で埋めた部分を隠さないためです。

## 実装内容

- **取り込み時の補完**: メッセージを記録する際、従来どおりの直接判定（作業ディレクトリのファイル・Herdrのペイン一覧）を試し、それでも決まらない場合だけ `quota.sample` との突き合わせにフォールバックします。
- **閲覧時の補完**: 過去に記録済みで `run_id`/`role` が不明のままのメッセージも、レポートを表示する瞬間に同じ突き合わせで補います。**保存されているファイル自体は一切書き換えません**（「過去は再計算しない」という方針を守るため、表示のたびに毎回その場で補うだけです）。
- **1つのセッションに複数の候補がある場合**: 作業中に別の作業ディレクトリへ移った場合など、同じセッションに複数の `run_id`/`role` が記録されていることがあります。この場合は「時刻が最も近い記録」を採用します（同時刻なら早い方を優先）。「候補が1つに決まらなければ諦める」という案も検討しましたが、それだと移動があったセッションのメッセージが軒並み不明のままになってしまうため、時刻の近さで決める方式を選びました。
- **既存の安全装置が誤って新機能に効かないようにする**: 直接判定には「作業ディレクトリのパスは使い回されることがあるので、記録より古いメッセージは無効とみなす」という安全装置が既にありますが、`session_id` は使い回されないため、この安全装置を突き合わせ結果に適用すると正しい判定まで消してしまいます。両者を明確に分けました。
- **出力への明示**: レポートの末尾に「直接判明 61.6% / 突き合わせで判明 XX% / 不明 XX%」のような行を、`run_id` 用・`role` 用それぞれ追加しました（`--json` にも同じ情報を出します）。

## レビューで見てほしいところ

- 「1つのセッションに複数の候補がある場合は時刻が最も近いものを採用する」という判断について、他に妥当な方針がないか確認をお願いします。
- 突き合わせによる補完はメッセージ単位で独立して行われ、保存ファイルには書き込まれないことをコードで確認していただきたいです。
- 実際のデータ規模（約6万件・68MB）に近い合成データで計測したところ、レポート表示にかかる時間は変更前の約0.68秒から約0.93秒に伸びました（約0.25秒増）。実用上問題ない範囲と判断していますが、確認をお願いします。

## テスト結果

- `pre-commit run --all-files`: 緑
- `python3 -m unittest discover -s bin/tests`: 349件すべて緑
- 実際の記録ストア（`~/.local/state/ocw-meter`）が変化していないことも確認済みです

## 今後の予定

この傘ブランチに残っているのは文書の整備（`bin/README.md` などへの反映）のみです。挙動が確定した後に別のプルリクエストで対応します。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JoRdny3tEt4eTkP3jeWGSf