### PR TITLE
ocw-meterの計測精度を是正する

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ for details. `bin/` changes should additionally be verified with
 ├── bin/
 │   ├── ocw                    # Git worktree manager with Herdr integration
 │   ├── claude-ds              # Claude Code via DeepSeek API wrapper
-│   ├── ocw-meter              # LLM cost / Claude quota observability (read-only, fail-open)
+│   ├── ocw-meter              # LLM cost / Claude quota observability (report auto-ingests; prune-diagnostics writes)
 │   ├── tests/                 # Python unit tests for ocw-meter etc. (bin/tests/lint.sh + unittest suite)
 │   ├── prices/                # Price tables used for cost calculation
 │   ├── deploy.sh              # bin deployment script

--- a/bin/README.md
+++ b/bin/README.md
@@ -311,29 +311,31 @@ ocw-meter validate [--file <path>]
 # イベント件数・completeness・coverage・推定費用の要約
 # --pr <n> を付けるとレビューラウンド一覧・人間介入回数・最終結果・
 # 同一5時間窓完走可否・そのPRのcash cost内訳も併せて出す
-ocw-meter report [--pr <n>] [--repo <owner>/<name>] [--json]
+# 実行のたびに ingest を自動実行してから集計する（--no-ingest で無効化可）。
+# 最終ingest時刻・鮮度警告はどのビューでもフッターに出る
+ocw-meter report [--pr <n>] [--repo <owner>/<name>] [--no-ingest] [--json]
 
 # 工程別（phase.start/endの時間ペアとusage.messageの時刻範囲による
 # ベストエフォート対応）のトークン・費用・所要時間
-ocw-meter report --phase [--pr <n>] [--repo <owner>/<name>] [--json]
+ocw-meter report --phase [--pr <n>] [--repo <owner>/<name>] [--no-ingest] [--json]
 
 # provider+model別のトークン・推定費用
-ocw-meter report --model [--pr <n>] [--repo <owner>/<name>] [--json]
+ocw-meter report --model [--pr <n>] [--repo <owner>/<name>] [--no-ingest] [--json]
 
 # role（commander/implementer/reviewer/unknown）別のイベント数・トークン・推定費用
-ocw-meter report --role [--pr <n>] [--repo <owner>/<name>] [--json]
+ocw-meter report --role [--pr <n>] [--repo <owner>/<name>] [--no-ingest] [--json]
 
 # 5時間窓（window_id）別のquota.sample集計。直接紐付き/時間範囲重複の
 # PRを別フィールドで提示
-ocw-meter report --window [--pr <n>] [--repo <owner>/<name>] [--json]
+ocw-meter report --window [--pr <n>] [--repo <owner>/<name>] [--no-ingest] [--json]
 
 # 月次: cash cost（従量API）/ capacity cost（Claudeサブスク枠）/
 # process efficiency（承認済みPRあたりの費用・ラウンド数等）を分離して表示
 # --reconcile とは別物（こちらは突合をしない）
-ocw-meter report --month [YYYY-MM] [--repo <owner>/<name>] [--json]
+ocw-meter report --month [YYYY-MM] [--repo <owner>/<name>] [--no-ingest] [--json]
 
 # model別トークン集計・推定費用・provider管理画面との突合（coverage比率）
-ocw-meter report --reconcile [--month <YYYY-MM>] [--provider-total <model>=<tokens> ...] [--json]
+ocw-meter report --reconcile [--month <YYYY-MM>] [--provider-total <model>=<tokens> ...] [--no-ingest] [--json]
 
 # statusLineコマンドとして呼ばれ、stdinのJSONからquota.sampleを1行append、表示文字列をstdoutへ返す
 ocw-meter snapshot-quota
@@ -347,7 +349,7 @@ ocw-meter prune-diagnostics [--older-than <days>] [--apply]
 |---|---|
 | `event` / `bind-pr` | **常に exit 0**。stderrに1行warnのみ。本番フローを止めない |
 | `snapshot-quota` | **常に exit 0 かつ必ずstdoutに表示文字列を出す**（statusLineが壊れて画面が崩れる事態を絶対に避ける。event/bind-pr以上に厳格なfail-open） |
-| `validate` / `report` / `ingest` / `prune-diagnostics` | 失敗したら非ゼロで落ちる（壊れたデータを黙って集計しない） |
+| `validate` / `report` / `ingest` / `prune-diagnostics` | 失敗したら非ゼロで落ちる（壊れたデータを黙って集計しない）。ただし `report` が実行のたびに自動実行する `ingest` 自体が失敗した場合（Gitワークツリー拒否等）はこの例外で、`report` は exit 0 のまま失敗をフッターに表示して既存データで応答する（`--no-ingest` で自動実行自体を無効化できる） |
 
 **`prune-diagnostics` の既定保持期間（30日）について**: これは運用上のリテンションポリシーであり、
 「今すぐ全部消す」既定ではない。数日〜1週間前にできたばかりのエントリ（一時的な設定ミスの記録など）を

--- a/bin/README.md
+++ b/bin/README.md
@@ -8,7 +8,7 @@
 |---|---|
 | `ocw` | Git worktree 作成・管理。Herdr 連携で commander/implementer/reviewer の三面体制を自動セットアップ |
 | `claude-ds` | Claude Code を DeepSeek API 経由で実行するラッパー |
-| `ocw-meter` | LLM費用・Claude利用枠の観測基盤。既存ログの事後読み取り専用。fail-open |
+| `ocw-meter` | LLM費用・Claude利用枠の観測基盤。既存ログを事後に集計する。`event` / `bind-pr` / `snapshot-quota` はfail-open、`report` / `ingest` / `validate` / `prune-diagnostics` はfail-loud（`report` は自動でingestを実行し、`prune-diagnostics --apply` は診断ファイルを削除する） |
 
 ## 1. Requirements
 
@@ -349,7 +349,7 @@ ocw-meter prune-diagnostics [--older-than <days>] [--apply]
 |---|---|
 | `event` / `bind-pr` | **常に exit 0**。stderrに1行warnのみ。本番フローを止めない |
 | `snapshot-quota` | **常に exit 0 かつ必ずstdoutに表示文字列を出す**（statusLineが壊れて画面が崩れる事態を絶対に避ける。event/bind-pr以上に厳格なfail-open） |
-| `validate` / `report` / `ingest` / `prune-diagnostics` | 失敗したら非ゼロで落ちる（壊れたデータを黙って集計しない）。ただし `report` が実行のたびに自動実行する `ingest` 自体が失敗した場合（Gitワークツリー拒否等）はこの例外で、`report` は exit 0 のまま失敗をフッターに表示して既存データで応答する（`--no-ingest` で自動実行自体を無効化できる） |
+| `validate` / `report` / `ingest` / `prune-diagnostics` | 失敗したら非ゼロで落ちる（壊れたデータを黙って集計しない）。ただし `report` が実行のたびに自動実行する `ingest` 自体が失敗した場合はこの例外で、`report` は exit 0 のまま失敗をフッターに表示して既存データで応答する（`--no-ingest` で自動実行自体を無効化できる）。**ストア自体がGitワークツリー内にある場合はこの例外に当てはまらない**。`report` は `ingest` を呼ぶ前に同じ判定を自分で行い、非ゼロで即座に終了する（何もフッターに出ない） |
 
 **`prune-diagnostics` の既定保持期間（30日）について**: これは運用上のリテンションポリシーであり、
 「今すぐ全部消す」既定ではない。数日〜1週間前にできたばかりのエントリ（一時的な設定ミスの記録など）を

--- a/bin/README.md
+++ b/bin/README.md
@@ -401,6 +401,17 @@ PR番号はリポジトリ**内**でしか一意でない。`--pr`とstandalone�
 - メッセージの費用は**そのメッセージ自身のtimestampの日付**に対応する価格表で計算する（`ingest`を
   実行した日ではない）。過去に書き込んだイベントの `cost_estimate_usd` は、価格表を追加・更新しても
   **再計算されない**
+- **価格表は時間帯（peak/off-peak）課金を表現できる**（孫3、計画書
+  [DOC-2608081456](../docs/planning/DOC-2608081456_ocw-meter-accuracy_計画.md)【5】）。
+  スキーマの詳細（`time_of_day_pricing`ブロックの書き方・タイムゾーンの扱い・境界の扱い）は
+  [`bin/prices/README.md`](prices/README.md)を参照。現時点で実際に投入されている価格表
+  （`bin/prices/deepseek-2026-08-01.json`）はこのブロックを使っていない（DeepSeekの時間帯課金は
+  発効日未定のため）
+- **該当する価格表が無い期間は黙って概算しない。** `select_price_table()`が対象日以前に有効な
+  テーブルを1枚も見つけられないと、クラッシュせず最も古いテーブルにフォールバックするが、
+  そのイベントの`price_effective_date`は実際のメッセージ日付より後になる。`report`のフッター
+  `price_table:`行の件数・`report --month`の`price_tables_applied[].is_fallback`で、このフォール
+  バックが起きたことを（イベントを書き換えずに読み取り時の突き合わせで）検出・表示する
 - `report --reconcile` の月境界は**UTC固定**。DeepSeek管理画面（北京時間 UTC+8想定）等、provider側の
   集計タイムゾーンと異なる場合、月初・月末で最大±8時間分のずれが突合結果に生じうる（計画書17章 R8）
 
@@ -425,7 +436,9 @@ PR番号はリポジトリ**内**でしか一意でない。`--pr`とstandalone�
   `null`の場合、フォールバック計算できても`ctx`セグメント自体を表示しない）
 - statusLineの`cost.total_cost_usd`（Claude Code自己申告のセッション累積コスト）を`session_cost_usd`
   として記録する。`usage.message`の`cost_estimate_usd`（ocw-meter自身の推定値）とは**別カラム**であり、
-  合算しない
+  合算しない。`ocw-meter report --month`のcapacity cost節・`report --pr`のPR単位費用内訳では、これを
+  `list_price_equiv_usd`として集計・表示する（`provider == "anthropic"`限定・下限値。詳細は後述
+  「`list_price_equiv_usd`の読み方」参照）
 - `report --pr <n>` はPRの最初と最後のイベント時刻の範囲に収まる`quota.sample`の`window_id`を集計し、
   同一5時間窓で完走できたか（`five_hour_window_completion`: `yes`/`no`/`unknown`）を出力する。
   **判定はレビュー待ち等の待機時間を含むPRの実時間レンジで行う**（＝PRが長時間openだと、
@@ -441,6 +454,77 @@ PR番号はリポジトリ**内**でしか一意でない。`--pr`とstandalone�
   `command not found` になり表示が壊れる。必ず先に `./deploy-all.sh --only bin`
   （リポジトリルートから）を実行して `~/bin/ocw-meter` を配置し、`~/bin` が PATH に
   入っていることを確認すること（本ドキュメント §5 参照）
+
+**`list_price_equiv_usd` の読み方（Claude側 list price相当額。孫4、計画書
+[DOC-2608081456](../docs/planning/DOC-2608081456_ocw-meter-accuracy_計画.md)）:**
+
+`quota.sample`に眠っている自己申告`session_cost_usd`を集計し、`report --month`のcapacity cost節・
+`report --pr`のPR単位費用内訳・`report --window`の各窓に出す。読み方の要点:
+
+- **`provider == "anthropic"`のみが対象。** DeepSeekの`session_cost_usd`は、Claude Codeが
+  DeepSeekのモデル名にどの単価を当てているか不明であり、`ocw-meter`自身の推定`cost_estimate_usd`
+  と二重計上になるため混ぜない（除外件数は`list_price_equiv_excluded_deepseek_count`等の各
+  フィールドに出る）
+- **`max()`ではなく「`session_id`ごとに、ストア全体を通じた最初のサンプルはその値そのもの・
+  それ以降は直前サンプルとの正の差分」を合計する。** `session_cost_usd`はセッション累積のはずだが、
+  `/clear`やコンパクションでリセットされる（非単調になる）ケースが実測されており、単純な`max()`
+  ではリセット前の消費分を取りこぼす。**この寄与は必ずストア全体の`quota.sample`から計算し、
+  窓/PR/月でスコープを絞った部分集合から再計算してはいけない**（絞ると、窓をまたぐセッションの
+  累計が窓2の「最初のサンプル」として丸ごと再計上され、実測で`report --window`の行合計が
+  48.7%過大になった）
+- **常に下限値であり、請求書ではない。** 最後のstatusLine描画以降の消費は含まれない
+  （値が`null`でない限り`list_price_equiv_is_lower_bound: true`がこれを機械可読にも表す。
+  対象サンプルが1件も無いスコープでは`list_price_equiv_usd`も`list_price_equiv_is_lower_bound`も
+  `null`になる）
+- **`usage.message`の`cost_estimate_usd`（cash cost）とは絶対に合算しない。** 出所も信頼レベルも
+  異なる別カラムである（この線引きの記録は
+  `docs/adr/DOC-2608021229_llm-cost-observability-collection-method.md` §10「Anthropic自己申告値の
+  採用は「換算」ではない」を参照）
+- **`quota.sample`は各マシンへのデプロイ日から記録が始まる**ため、それより前の月は`list_price_equiv_usd`
+  が`null`になる（`$0.00`ではなく「データが無い」の意味）
+
+実際の出力例（サンドボックスで実行して確認したもの。`report --month`のcapacity cost節の抜粋。
+先頭の`capacity_message_count`等は省略）:
+
+```
+  ...
+  list_price_equiv_usd: $2.00+ (下限 / list price相当 / 請求書ではない)
+  list_price_equiv_is_lower_bound: True
+  list_price_equiv_session_count: 1
+  list_price_equiv_excluded_no_session_id_count: 0
+  list_price_equiv_excluded_null_cost_count: 0
+  list_price_equiv_excluded_deepseek_count: 0
+  list_price_equiv_excluded_other_provider_count: 0
+  list_price_equiv_note: Claude Code自己申告のsession_cost_usd（statusLineのcost.total_cost_usd）を provider=anthropicのみに絞り、session_idごとに正の差分の総和として積算した下限値（最後のstatusLine描画以降の消費は含まれない）。usage.messageのcost_estimate_usdとは別カラムであり、cash costとは絶対に合算しない。請求書ではない。
+```
+
+**attribution行の読み方（`run_id`/`role`の帰属解決。孫5、計画書
+[DOC-2608081456](../docs/planning/DOC-2608081456_ocw-meter-accuracy_計画.md)）:**
+
+`usage.message`の`run_id`/`role`は、①ingest実行時点で直接解決できたもの（`ocw-run-id`ファイル /
+Herdr live pane list）に加えて、②`quota.sample`との`session_id` joinで解決したものを合算するように
+なった（ingest側フォールバックと、既存イベントを読み取り時に補完するreport側joinの両方）。
+フッターの`attribution (run_id):`/`attribution (role):`行が全ビュー（既定 / `--phase` / `--model` /
+`--role` / `--window` / `--month`）で内訳を示す:
+
+```
+attribution (run_id): direct 0.0% / via session_id 66.7% / unresolved 33.3%
+attribution (role):   direct 0.0% / via session_id 66.7% / unresolved 33.3%
+```
+
+- `direct`: `ocw-run-id`ファイル / Herdr liveから直接解決できたもの
+- `via session_id`: `quota.sample`との`session_id` joinで解決したもの（ingest側フォールバック・
+  report側joinのどちらで埋まったかは区別せず合算する）
+- `unresolved`: どちらでも解決できなかったもの
+- **`run_id`と`role`は解決手段が異なるため別々の割合になる**（一致するとは限らない。上の例は
+  たまたま同じ値になっている）
+
+**このjoinは`ocw rm`（worktree削除）に一切影響されない**（`quota.sample`は消えないイベントのため。
+`ocw-run-id`ファイルはworktreeと一緒に消えるが、`quota.sample`のsession_idはそうではない）。
+ただし限界は残る。フッターの`attribution_known_limits`行が示す通り: `quota.sample`の記録開始
+（各マシンへのデプロイ日）より前の期間は復元できない。以降の期間でも100%には到達しない
+（`claude-ds`セッションやstatusLineが一度も走らなかったセッションは`run_id`/`role`とも復元不能）。
+`role`の`unknown`の一部はHerdr外で起動したClaudeであり原理的に取得不能（推測で埋めない方針を維持）。
 
 **保存先と環境変数:**
 
@@ -468,9 +552,16 @@ PR番号はリポジトリ**内**でしか一意でない。`--pr`とstandalone�
 運用上は、`OCW_METER_QUOTA_INTERVAL`を既定の60秒より大きくする、または手動で古い
 `events/YYYY-MM-DD.jsonl`を別途アーカイブ・削除する、のいずれかを検討すること。
 
-**`prune`を実装しない決定について（孫5、計画書9.3の積み残し解消）**: 計画書9.3は
-「保存期間: 既定14日、`ocw-meter prune`で削除」と書いていたが、`prune`はどの孫の実装スコープにも
-入っておらず、計画時の書き漏れだった。孫5で以下の理由により**意図的に未実装のまま据え置く**と決定した:
+**`prune`を実装しない決定について（旧傘`ai/llm-cost-observability`の孫5、計画書
+[DOC-2608021229-a](../docs/planning/DOC-2608021229-a_ai-llm-cost-observability_計画.md)§9.3の
+積み残し解消。本傘`ocw-meter-accuracy`の孫5〈session_id join、上記「attribution行の読み方」参照〉
+とは別の孫であることに注意）**: 計画書DOC-2608021229-a §9.3は「保存期間: 既定14日、`ocw-meter prune`で削除」と
+書いていたが、`prune`はどの孫の実装スコープにも入っておらず、計画時の書き漏れだった。
+（旧傘の）孫5で以下の理由により**意図的に未実装のまま据え置く**と決定した。
+**`prune-diagnostics`（上記）とは別物である点に注意**: `prune-diagnostics`が消すのは
+`state/meter-errors.jsonl`と`state/quota-worktree-refusal.json`という自己診断・状態ファイルのみで、
+**`events/`（費用履歴そのもの）には一切触れない**。ここで未実装のまま据え置いているのは
+`events/`を消す`prune`の方であり、`prune-diagnostics`の追加によってこの決定が変わったわけではない:
 
 - `events/`（費用履歴そのもの）は数十MB/年〜数百MB/年規模（上記実測）であり、資産として残す価値が
   ディスクコストを上回る。誤って自動削除する仕組みを持ち込むリスクの方が大きい
@@ -537,16 +628,23 @@ GitHub token形式（`ghp_...` 等 / `github_pat_...`）に一致する値、キ
   （1runあたり数十件）には十分だが、**大量イベントをループでこのCLI経由で書き込む用途には向かない**。
   `ingest` はこの制約を踏まえ、Herdr/run/pr情報を1回だけ解決し、seen-key集合と書き込みロックを
   バッチ全体で保持する専用パス（`bulk_write_events`）を持つ
-- **`usage.message`の`run_id`は、`ingest`をworktree削除（`ocw rm`）より後に実行すると解決できない
-  （孫5で実データ検証して判明。実測: このマシンの実ストア44,425件の`usage.message`のうち`run_id`が
-  設定されているものは0件）。** `run_id`解決（`resolve_run_id_via_ocw_run_id_file`）は、その
-  メッセージの`cwd`（worktreeパス）配下の`<git-dir>/ocw-run-id`ファイルを**ingest実行時点**で
-  読む方式であり、`ocw rm`はそのファイルをworktreeごと削除する。一度`run_id`無しで書き込まれた
-  `usage.message`は、後から同じtranscriptを再ingestしても直らない（他のフィールドと同じ
-  「過去は再計算しない」不変条件のため）。`ocw-meter report --phase`（工程別トークン内訳。
+- **`usage.message`の`run_id`は、`ingest`をworktree削除（`ocw rm`）より後に実行すると直接解決できない。**
+  直接解決（`resolve_run_id_via_ocw_run_id_file`）は、そのメッセージの`cwd`（worktreeパス）配下の
+  `<git-dir>/ocw-run-id`ファイルを**ingest実行時点**で読む方式であり、`ocw rm`はそのファイルを
+  worktreeごと削除する。孫5より前の実測ではこの直接解決だけでは**3,043件 / 57,164件（5.3%）**しか
+  `run_id`が埋まっていなかった。
+  **孫5で`quota.sample`との`session_id` joinを追加し、直接解決に失敗した`run_id`/`role`を
+  quota.sample由来の値で補うようになった**（`quota.sample`の記録開始＝2026-08-01以降の実測では
+  `run_id` 61.6%・`role` 72.1%まで上がる。フッターの`attribution`行の読み方は上記
+  「attribution行の読み方」参照）。**ただしこのjoinは`quota.sample`の記録開始より前へは遡れない**
+  ため、100%には到達しない。direct・session_idのどちらでも解決できなかった`run_id`/`role`は、
+  後から同じtranscriptを再ingestしても直らない（他のフィールドと同じ「過去は再計算しない」不変条件
+  のため。ただしreport実行時のsession_id join（読み取り時の補完）は保存ファイル自体を書き換えず、
+  実行のたびに新しく解決できた分が反映される）。`ocw-meter report --phase`（工程別トークン内訳。
   `run_id`でphase.start/endの時間窓と対応付ける — `docs/reference/DOC-2608021229-c_...`§2.3参照）を
-  意味のある形で使うには、**PRの作業中〜マージ直後、worktreeを消す前に`ocw-meter ingest`を
-  実行する運用が必須**（`docs/reference/DOC-2608021229-b_...`§2の計測手順に反映済み）。`--model`/`--role`/
+  より確実に使うには、引き続き**PRの作業中〜マージ直後、worktreeを消す前に`ocw-meter ingest`を
+  実行する運用が望ましい**（`session_id` joinは直接解決の救済策であり、完全な代替ではない。
+  `docs/reference/DOC-2608021229-b_...`§2の計測手順に反映済み）。`--model`/`--role`/
   `--pr`はこの制約の影響を受けない（`run_id`ではなく`model`/`role`/`pr_number`を直接見るため）
 
 ## 4. Customization
@@ -625,3 +723,16 @@ chmod 600 ~/.config/deepseek/api_key
 ```bash
 OCW_NO_VSCODE=1 ocw widget-maker
 ```
+
+### `report` の `meter.error diagnostics` に見慣れない件数が並んでいる（過去のテスト汚染）
+
+`ocw-meter`本傘（計画書
+[DOC-2608081456](../docs/planning/DOC-2608081456_ocw-meter-accuracy_計画.md)）以前は、
+`bin/tests/test_ocw_meter.py`の一部テストが`HOME`を明示的に上書きせずに`snapshot-quota`相当の
+経路を叩いており、実`~/.local/state/ocw-meter`（テスト実行者本人の実ストア）へ
+`state/quota-worktree-refusal.json`のエントリと`state/meter-errors.jsonl`の
+`storage_home_inside_git_worktree`診断を書き込んでしまっていた（孫1で修正済み。テストは常に
+`HOME`をテスト専用tempdirへ上書きするようになった）。もし過去にこのリポジトリでテストを実行した
+実績があり、`report`の`meter.error diagnostics: N lines`にテスト由来と思われる古いエントリが
+残っている場合は、`ocw-meter prune-diagnostics`（既定dry-run。上記参照）で内容を確認してから
+`--apply`で掃除できる。`events/`（費用履歴そのもの）は対象外なので、費用データが失われる心配はない。

--- a/bin/README.md
+++ b/bin/README.md
@@ -337,13 +337,25 @@ ocw-meter report --reconcile [--month <YYYY-MM>] [--provider-total <model>=<toke
 
 # statusLineコマンドとして呼ばれ、stdinのJSONからquota.sampleを1行append、表示文字列をstdoutへ返す
 ocw-meter snapshot-quota
+
+# state/meter-errors.jsonl・state/quota-worktree-refusal.jsonの古いエントリを掃除する（events/には触れない）。
+# 既定はdry-run。--applyで実削除、--older-than <日数>で保持期間指定（既定30日）
+ocw-meter prune-diagnostics [--older-than <days>] [--apply]
 ```
 
 | サブコマンド | 失敗時の挙動 |
 |---|---|
 | `event` / `bind-pr` | **常に exit 0**。stderrに1行warnのみ。本番フローを止めない |
 | `snapshot-quota` | **常に exit 0 かつ必ずstdoutに表示文字列を出す**（statusLineが壊れて画面が崩れる事態を絶対に避ける。event/bind-pr以上に厳格なfail-open） |
-| `validate` / `report` / `ingest` | 失敗したら非ゼロで落ちる（壊れたデータを黙って集計しない） |
+| `validate` / `report` / `ingest` / `prune-diagnostics` | 失敗したら非ゼロで落ちる（壊れたデータを黙って集計しない） |
+
+**`prune-diagnostics` の既定保持期間（30日）について**: これは運用上のリテンションポリシーであり、
+「今すぐ全部消す」既定ではない。数日〜1週間前にできたばかりのエントリ（一時的な設定ミスの記録など）を
+今すぐ後始末したい場合は、`--older-than` に小さい値を明示する（例:
+`ocw-meter prune-diagnostics --older-than 1 --apply`）。
+`OCW_METER_HOME`（またはその既定値）と `$HOME` 由来の既定rootの両方を調べる
+（`state/quota-worktree-refusal.json` は常に既定rootにしか書かれないため。片方がGitワークツリー内で
+使えなくても、もう片方が生きていれば処理を続ける）。
 
 **`--repo <owner>/<name>`（`--pr`・standalone `--month`専用。孫5後半で追加）**:
 
@@ -489,7 +501,9 @@ rm ~/.local/state/ocw-meter/events/2026-01-*.jsonl
 `state/session-pr-links.json`（`ingest`がtranscriptの`pr-link`行から学習したsession→PRの対応。
 増分実行をまたいで保持される）/
 `state/meter-errors.jsonl`（`meter.error`自己診断専用。
-`events/`とは別ファイルにすることで、後勝ちdedupによるイベントファイル書き換えと競合せずlock無しで追記できる）/
+`events/`とは別ファイルにすることで、後勝ちdedupによるイベントファイル書き換えと競合せずlock無しで追記できる。
+ただし `ocw-meter prune-diagnostics --apply` はこのファイルを丸ごと書き換える唯一の例外で、
+書き換えの瞬間と重なった追記1行を失う可能性がある）/
 `state/quota-last-sample.json`（`snapshot-quota`のサンプリング間隔自制・同一window内の異常値検知に使う
 直近サンプルの状態）/
 `raw/YYYY-MM-DD/*.json`（`OCW_METER_RAW=1`のときのみ。`snapshot-quota`が保存するredaction済みの

--- a/bin/ocw-meter
+++ b/bin/ocw-meter
@@ -425,6 +425,7 @@ cat >"$_ocw_meter_py" <<'PY' || die "failed to write the embedded program to $_o
 # duplicates for one message.id in memory before doing a single write
 # per calendar-day file, rather than writing-then-rewriting through this
 # CLI's per-event primitives.
+import bisect
 import contextlib
 import errno
 import fcntl
@@ -1592,6 +1593,60 @@ def _price_table_predates_message(event):
     return effective > ts[:10]
 
 
+def _attribution_source_counts(usage_events, field, source_field):
+    """孫5プロンプト §3: `field`(run_id/role)がdirect(ingest時にocw-run-id
+    ファイル/Herdr liveから直接解決)/ session_id(quota.sampleとの
+    session_id join。ingest側フォールバックB・report側joinAの両方を
+    区別せず含む)/ unresolvedのどれで埋まったかを数える。`role`は
+    non-nullable フィールドで未解決を"unknown"文字列で表す(plan §8.1)
+    ため、`run_id`(未解決はNone)と判定条件が異なる — 呼び出し側で
+    `field`ごとに揃えた「未解決値」を渡すのではなく、ここで両方を扱う。
+    `source_field`(run_id_source/role_source)が無い、または"direct"の
+    イベントはdirect扱いにする — この機能より前にingestされた
+    イベントは`*_source`フィールド自体が無いが、それらのrun_id/roleは
+    session_id joinがまだ存在しなかった頃に解決されたものなので、
+    実質directと同じ意味である。"""
+    counts = {"direct": 0, "session_id": 0, "unresolved": 0}
+    for e in usage_events:
+        value = e.get(field)
+        if value is None or value == "unknown":
+            counts["unresolved"] += 1
+        elif e.get(source_field) == "session_id":
+            counts["session_id"] += 1
+        else:
+            counts["direct"] += 1
+    return counts
+
+
+def _attribution_line(counts, total):
+    if total == 0:
+        return "n/a (no usage.message events)"
+    return (
+        f"direct {100.0 * counts['direct'] / total:.1f}% / "
+        f"via session_id {100.0 * counts['session_id'] / total:.1f}% / "
+        f"unresolved {100.0 * counts['unresolved'] / total:.1f}%"
+    )
+
+
+# 孫5プロンプト §4「残る限界を出力または文書に書く」/ レビュー指摘1:
+# session_id joinを入れても100%解決には到達しない構造的な理由を、
+# 「直った」と誤読されないよう毎回のattribution行に添える。数値
+# （実測時点のrun_id 61.6%/role 72.1%等）はこの定数に埋め込まない —
+# 母数が変わるたびに嘘になるため、実測値は毎回のattribution行自体に
+# 出る。ここに書くのは変わらない構造的な理由のみ。
+# レビュー指摘(ラウンド2 新規2): 絶対日付(2026-08-01)を埋め込まない —
+# `bin/ocw-meter` は各マシンへ個別にデプロイされ、quota.sampleの記録
+# 開始日はマシンごとのデプロイ日でありこのマシン固有の日付ではない。
+# 断言できるのは「記録開始より前は遡れない」という構造だけ。
+ATTRIBUTION_KNOWN_LIMITS = (
+    "quota.sampleの記録が始まるより前の期間は、session_id joinによる復元が"
+    "できない。以降の期間でも100%には到達しない — claude-dsセッションや"
+    "statusLineが一度も走らなかったセッションはrun_id/roleとも復元不能。"
+    "roleのunknownの一部はHerdr外で起動したClaudeであり原理的に取得不能"
+    "(推測で埋めない方針を維持)。"
+)
+
+
 def usage_cost_footer(usage_events):
     """The cost/coverage/price_table portion of the required per-plan-
     §10.4 footer, shared by every `report` view (孫5 §1: "coverage 併記が
@@ -1612,6 +1667,13 @@ def usage_cost_footer(usage_events):
             cost_bases.add(e["cost_basis"])
         if _price_table_predates_message(e):
             fallback_count += 1
+    # 孫5プロンプト §3: 「run_idとroleは別々の割合になる」— 実測でも
+    # 61.6%/72.1%と異なる(計画書DOC-2608081456)ため、必ず2行に分ける。
+    total_usage = len(usage_events)
+    run_id_counts = _attribution_source_counts(usage_events, "run_id", "run_id_source")
+    role_counts = _attribution_source_counts(usage_events, "role", "role_source")
+    attribution_run_id = _attribution_line(run_id_counts, total_usage)
+    attribution_role = _attribution_line(role_counts, total_usage)
     if usage_events:
         coverage = (
             f"{len(usage_events)} usage.message event(s); run "
@@ -1652,6 +1714,11 @@ def usage_cost_footer(usage_events):
         "cost_basis": cost_basis_summary,
         "cost_estimate_usd": cost_estimate_summary,
         "price_table_fallback_count": fallback_count,
+        "attribution_run_id": attribution_run_id,
+        "attribution_role": attribution_role,
+        "attribution_run_id_counts": run_id_counts,
+        "attribution_role_counts": role_counts,
+        "attribution_known_limits": ATTRIBUTION_KNOWN_LIMITS,
     }
 
 
@@ -1761,7 +1828,17 @@ def ingest_freshness_footer(cursor, ingest_run):
     }
 
 
-def print_footer_text(footer_completeness, footer_cost, footer_freshness, total):
+def print_footer_text(footer_completeness, footer_cost, footer_freshness, total, *, attribution=True):
+    """レビュー指摘4: `attribution`はキーワード専用の明示フラグ
+    (既定True) — 以前は`footer_cost.get('attribution_run_id', 'n/a ...')`
+    で欠落を暗黙に許容していたが、これだと将来 `footer_cost` を手組みする
+    ビューが増えたとき「computed し忘れている」ことに誰も気づけないまま
+    "n/a" が出力され続ける。ここでは逆に、attribution行を出さないビュー
+    （`--reconcile`。孫5のスコープ外で、session_id joinを経由しない）だけ
+    が明示的に`attribution=False`を渡す。`attribution=True`（既定）の
+    ときは`footer_cost['attribution_run_id']`を直接インデックスし、
+    無ければKeyErrorで即座に落ちる — 呼び出し側がこの行を足し忘れたまま
+    サイレントに"n/a"を出し続けることを防ぐ。"""
     def pct(n):
         return (100.0 * n / total) if total else 0.0
 
@@ -1780,6 +1857,10 @@ def print_footer_text(footer_completeness, footer_cost, footer_freshness, total)
     print(f"price_table:   {footer_cost['price_table']}")
     print(f"cost_basis:    {footer_cost['cost_basis']}")
     print(f"cost_estimate: {footer_cost['cost_estimate_usd']}")
+    if attribution:
+        print(f"attribution (run_id): {footer_cost['attribution_run_id']}")
+        print(f"attribution (role):   {footer_cost['attribution_role']}")
+        print(f"attribution_known_limits: {footer_cost['attribution_known_limits']}")
     print(f"last_ingest_at: {footer_freshness['last_ingest_at']}")
     print(f"last_ingest_at_rfc3339: {footer_freshness['last_ingest_at_rfc3339'] or 'unknown'}")
     print(f"ingest (this run): {footer_freshness['ingest_this_run']}")
@@ -2678,6 +2759,13 @@ def _report_reconcile(paths, month, provider_totals, as_json, footer_freshness):
         },
         footer_freshness,
         total_messages,
+        # レビュー指摘4: `--reconcile`（孫5のスコープ外の既存ビュー）は
+        # `valid_events`構築・session_id joinを一切経由しないため
+        # attributionを計算していない。「計算していないので出さない」を
+        # テキスト・--json両方で徹底する — 欠落キーに"n/a"のフォールバック
+        # 文字列を充てると、attributionを計算し忘れた将来のビューが
+        # あっても気づけないまま同じ"n/a"が出続けてしまう。
+        attribution=False,
     )
     print(f"known_gaps:    {summary['known_gaps']}")
     return 0
@@ -2811,6 +2899,102 @@ def auto_ingest_for_report(root, no_ingest):
     if not result["ok"]:
         return {"status": "failed", "error": result["error"]}
     return {"status": "ran", "stats": result}
+
+
+def pr_binds_from_events(events, repo):
+    """report側(A)用: 既にデコード済みのイベント列(`valid_events`)から
+    run_id -> pr.bind情報を組み立てる。ingest側(B)の
+    `load_local_pr_binds_and_run_starts`が返す`binds`と同じ形
+    (`{"pr_number": ..., "pr_url": ...}`) — `backfill_run_id_and_role_
+    via_session`がB側の`build_usage_event`の`pr_info = binds.get(run_id)`
+    と同じ補完をread-time側でも行うために使う(レビュー指摘2)。
+
+    レビュー指摘(ラウンド2 新規1): `repo`でスコープしないと、別repoで
+    bindされた`pr_number`がこの共有ストア（`ocw-meter`は全repo共有）で
+    `usage.message`の`pr_number`に焼き込まれ、`events_for_pr()`の直接
+    マッチ（`e.get("pr_number") == pr_number and e.get("repo") == repo`）
+    をすり抜けて別repoの費用が混入する。`find_approved_pr_numbers_in_
+    month()`の`run_to_pr`と同じ`e.get("repo") == repo`スコープを揃える。
+    `repo`が`None`（PR/window/monthビュー以外でgit repo外から実行された
+    場合）のときは、`repo`が`None`のpr.bindしかマッチしない — 「推測で
+    埋めない」の原則どおり、repoが分からない状況でscopeを緩めない。"""
+    binds = {}
+    for e in events:
+        if e.get("event_type") != "pr.bind":
+            continue
+        if e.get("repo") != repo:
+            continue
+        run_id = e.get("run_id")
+        pr_number = e.get("pr_number")
+        if run_id and isinstance(pr_number, int):
+            binds[run_id] = {"pr_number": pr_number, "pr_url": e.get("pr_url")}
+    return binds
+
+
+def backfill_run_id_and_role_via_session(usage_events, session_attrs, binds):
+    """孫5プロンプト §2 (A: report側join): session_id joinで、まだ
+    run_id/roleが解決できていない`usage.message`だけを読み取り時に補完
+    する。**保存済みイベントファイルは一切書き換えない** — mutates the
+    in-memory dicts `iter_stored_events`/`valid_events` already produced
+    for this one `report` invocation only; nothing here calls
+    `write_event`/`bulk_write_events`. 罠1と同じ理由で、ここでもrun.start
+    逆転チェックは適用しない(session_idはworktreeパスと違って再利用
+    されないため、そもそも対象外)。
+
+    既に値が入っているイベント(ingest側フォールバックで既に解決済み、
+    または旧来のdirect解決)は上書きしない — plan「補完は信頼度の低い
+    方から」の原則どおり、read-time解決はあくまで最後の手段。
+    `run_id_source`/`role_source`はingest側(B)が新規イベントに書き込む
+    のと同じキーで、`usage_cost_footer`のattribution行がingest側/
+    report側どちらのjoinで埋まったかを区別せず「via session_id」として
+    一括で数えられるようにする(古い、この機能より前にingestされた
+    イベントは両フィールドとも欠落しており、run_idが埋まっていれば
+    それは常にdirect解決だったとみなせる)。
+
+    レビュー指摘2: `pr_number`/`pr_url`も、B側の`build_usage_event`が
+    `pr_info = binds.get(run_id)`で行っているのと同じ補完をここでも
+    行う。これをしないと「session joinでrun_idを持つようになったのに、
+    ingestより後に読まれたか先に読まれたかでpr_numberの有無が変わる」
+    という非対称が生じ、`report_by_window`の`pr_ranges`（`e.get(
+    "pr_number")`が非nullのイベントだけからPRの時刻レンジを作る）が
+    ingestタイミング依存になる。run_idがこの関数の対象外（元から埋まっ
+    ていた）イベントも含め、run_idがありpr_numberが無い全usage.message
+    に対して行う。
+
+    レビュー指摘(ラウンド2 新規1): ここで揃えているのは「run_idが決まれば
+    pr_numberも決まる」という**関係**だけであり、bindの絞り方までB側と
+    同じにするという意味ではない。渡ってくる`binds`（`pr_binds_from_
+    events()`が組む）はrepoスコープ付き — `events_for_pr()`の
+    `bound_run_ids`と同じ絞り方に揃えてある。一方B側の`load_local_pr_
+    binds_and_run_starts()`が返す`binds`にはrepoスコープが無く、この点で
+    AとBは意図的に異なる（ラウンド2 新規1: repoスコープ無しの`binds`を
+    read-timeに無条件適用すると、別リポジトリでbindされたpr_numberが
+    このrepoのusage.messageへ焼き込まれ、`events_for_pr()`の直接マッチ
+    をすり抜けて別リポジトリの費用が混入する実測済みの不具合になる）。
+    「Bと揃える」つもりでこの関数へrepoスコープ無しの`binds`を渡さない
+    こと。B側自体のrepoスコープ欠如は本PR以前から存在する別の問題であり、
+    本PRの意図的な対象外。"""
+    for e in usage_events:
+        if e.get("event_type") != "usage.message":
+            continue
+        session_id = e.get("session_id")
+        if session_id:
+            needs_run_id = e.get("run_id") is None
+            needs_role = e.get("role") in (None, "unknown")
+            if needs_run_id or needs_role:
+                ts = parse_ts(e.get("ts"))
+                session_run_id, session_role = resolve_session_attrs(session_attrs, session_id, ts)
+                if needs_run_id and session_run_id is not None:
+                    e["run_id"] = session_run_id
+                    e["run_id_source"] = "session_id"
+                if needs_role and session_role is not None:
+                    e["role"] = session_role
+                    e["role_source"] = "session_id"
+        if e.get("pr_number") is None:
+            pr_info = binds.get(e.get("run_id")) if e.get("run_id") else None
+            if pr_info is not None:
+                e["pr_number"] = pr_info.get("pr_number")
+                e["pr_url"] = pr_info.get("pr_url")
 
 
 def cmd_report(args):
@@ -3007,6 +3191,18 @@ def cmd_report(args):
             malformed += 1
         else:
             valid_events.append(obj)
+
+    # 孫5プロンプト §2 (A: report側join, 計画書「【2】【3】の鍵」): built
+    # ONCE here, from the full unscoped `valid_events` (a session's
+    # quota.sample history must not be cut down to whatever subset a
+    # later --pr/--month filter happens to select — same reasoning as
+    # `_quota_session_contributions`'s own full-store requirement), and
+    # applied before ANY view-specific filtering (`events_for_pr` below
+    # included) so every view — default/--pr/--phase/--role/--model/
+    # --window/--month — sees the same backfilled run_id/role/pr_number.
+    backfill_run_id_and_role_via_session(
+        valid_events, session_attrs_from_events(valid_events), pr_binds_from_events(valid_events, repo)
+    )
 
     if month_flag_present and view is None:
         return _report_month_standalone(paths, valid_events, malformed, month, repo, as_json, footer_freshness)
@@ -3899,17 +4095,127 @@ def resolve_herdr_role_map():
     return role_map
 
 
+# ── session_id join: quota.sample -> usage.message run_id/role ─────────
+# 計画書 DOC-2608081456【3】/「【2】【3】の鍵」/ 孫5プロンプト: quota.sample
+# has session_id 100% and run_id/role ~78% (both captured from OCW_RUN_ID/
+# OCW_ROLE at the moment `snapshot-quota` ran — see build_envelope's
+# defaults and record_quota_sample), while usage.message's OWN run_id/role
+# resolution (resolve_run_id_via_ocw_run_id_file / resolve_herdr_role_map)
+# depends on live state that can vanish (`ocw rm` deletes the git-dir file;
+# closing a Herdr pane makes it unqueryable) before `ingest` ever runs.
+# session_id, unlike a worktree path, is never reused, so joining on it
+# lets both `ingest` (B, this file's own scan of its event store) and
+# `report` (A, read-time only, plan's "past isn't recalculated" invariant)
+# recover the answer from data that's already durably stored.
+
+
+def _accumulate_session_attr_sample(raw, event):
+    """Feeds one already-decoded event into `raw` (session_id -> {"run_id":
+    [(ts, value), ...], "role": [...]}, unsorted) if it's a quota.sample
+    carrying a session_id. Shared by the ingest-side single-pass scan
+    (`load_local_pr_binds_and_run_starts`, which decodes lines itself) and
+    the report-side scan (`session_attrs_from_events`, over already-decoded
+    `valid_events`) so the extraction rule lives in exactly one place.
+
+    run_id and role are appended independently (not as one paired sample):
+    a quota.sample can carry one without the other (OCW_RUN_ID set but
+    OCW_ROLE unset, or vice versa — see record_quota_sample), so requiring
+    both together would throw away usable half-samples."""
+    if event.get("event_type") != "quota.sample":
+        return
+    session_id = event.get("session_id")
+    if not isinstance(session_id, str) or not session_id:
+        return
+    ts = parse_ts(event.get("ts"))
+    if ts is None:
+        return
+    entry = raw.setdefault(session_id, {"run_id": [], "role": []})
+    run_id = event.get("run_id")
+    if isinstance(run_id, str) and run_id:
+        entry["run_id"].append((ts, run_id))
+    role = event.get("role")
+    if isinstance(role, str) and role and role != "unknown":
+        entry["role"].append((ts, role))
+
+
+def _finalize_session_attrs(raw):
+    """レビュー指摘3: `_nearest_sample_value`はbisectのため`times`列を
+    その場で作っていたが、この関数は補完対象のusage.messageごと・
+    run_id/roleで1回ずつ呼ばれる(実ストア実測で1回のreportあたり
+    877,012要素分の再構築)。ここでソート済みの(ts, value)を
+    `{"ts": [...], "values": [...]}`の2並列リストに1回だけ変換して
+    持たせ、`_nearest_sample_value`側の再構築を無くす。"""
+    for entry in raw.values():
+        for field in ("run_id", "role"):
+            entry[field].sort(key=lambda item: item[0])
+            entry[field] = {
+                "ts": [item[0] for item in entry[field]],
+                "values": [item[1] for item in entry[field]],
+            }
+    return raw
+
+
+def session_attrs_from_events(events):
+    """Report側(A)用: 既にデコード済みのイベント列(`valid_events`)から
+    session_attrsを組み立てる。ingest側(B)は同じ抽出を
+    `load_local_pr_binds_and_run_starts`内の1パスで行う(全走査を二重に
+    しないため)。"""
+    raw = {}
+    for e in events:
+        _accumulate_session_attr_sample(raw, e)
+    return _finalize_session_attrs(raw)
+
+
+def _nearest_sample_value(times_values, ts):
+    """`times_values`: `_finalize_session_attrs`が組んだ
+    `{"ts": [ts昇順...], "values": [...]}`(同じ長さの2並列リスト)。
+    `ts`に時刻が最も近いサンプルのvalueを返す(前後どちらでもよい —
+    quota.sampleは60秒スロットルの定期ポーリングであり、対象メッセージ
+    の前後どちらの状態が「そのときのrun_id/role」かを決める根拠は無い)。
+    同点は前方(`ts`より前)のサンプルを優先する — 決定的にするためだけの
+    選択で、後方を優先すべき積極的な理由は無い。1つのsession_idに複数の
+    run_id/roleが紐づく場合(同じセッションでworktreeを移った等)も、
+    「一意でなければ解決しない」ではなくこの時刻近傍則で1つに定める
+    方針とした(計画書 DOC-2608081456 孫5プロンプト §1)。"""
+    times = times_values["ts"]
+    if not times or ts is None:
+        return None
+    values = times_values["values"]
+    idx = bisect.bisect_left(times, ts)
+    candidates = []
+    if idx < len(times):
+        candidates.append((times[idx], values[idx]))
+    if idx > 0:
+        candidates.append((times[idx - 1], values[idx - 1]))
+    best = min(candidates, key=lambda item: (abs((item[0] - ts).total_seconds()), item[0]))
+    return best[1]
+
+
+def resolve_session_attrs(session_attrs, session_id, ts):
+    """(run_id, role) resolved via session_id join, each independently
+    nearest-in-time to `ts`. Returns (None, None) when `session_id` has no
+    quota.sample history at all (not every session gets sampled — e.g.
+    claude-ds sessions, or ones where statusLine never ran)."""
+    entry = session_attrs.get(session_id) if session_id else None
+    if entry is None:
+        return None, None
+    return _nearest_sample_value(entry["run_id"], ts), _nearest_sample_value(entry["role"], ts)
+
+
 # ── run_id / PR attribution from this meter's own local event store ────
 
 def load_local_pr_binds_and_run_starts(paths):
-    """Single pass over every stored event, building two lookup tables
+    """Single pass over every stored event, building three lookup tables
     `ingest` needs: the pr.bind table (plan §7.4 PR resolution once a
-    run_id is known) and run_id -> run.start ts (PR #27 review round 2
-    finding "新規1", see resolve_run_id_via_ocw_run_id_file's caller).
-    Tolerates malformed lines by skipping them — this is advisory
-    context-building, not `validate`, so a corrupt line here just means
-    less context, not an error."""
+    run_id is known), run_id -> run.start ts (PR #27 review round 2
+    finding "新規1", see resolve_run_id_via_ocw_run_id_file's caller), and
+    session_attrs (計画書 DOC-2608081456 孫5プロンプト §1: session_id ->
+    quota.sample-derived run_id/role samples, for `build_usage_event`'s
+    session_id join fallback). Tolerates malformed lines by skipping
+    them — this is advisory context-building, not `validate`, so a
+    corrupt line here just means less context, not an error."""
     binds, run_starts = {}, {}
+    session_attrs_raw = {}
     for target in sorted(paths.events_dir.glob("*.jsonl")):
         try:
             text = target.read_text(encoding="utf-8", errors="replace")
@@ -3932,7 +4238,9 @@ def load_local_pr_binds_and_run_starts(paths):
                 ts = parse_ts(obj.get("ts"))
                 if ts is not None:
                     run_starts[run_id] = ts
-    return binds, run_starts
+            elif event_type == "quota.sample":
+                _accumulate_session_attr_sample(session_attrs_raw, obj)
+    return binds, run_starts, _finalize_session_attrs(session_attrs_raw)
 
 
 def resolve_run_id_via_ocw_run_id_file(cwd, cache):
@@ -4035,7 +4343,7 @@ def gh_pr_for_branch(branch):
 
 # ── assembling usage.message events ─────────────────────────────────────
 
-def build_usage_event(candidate, price_tables, today_str, role_map, binds, run_starts, pr_link_map, gh_cache, run_id_cache, repo_cache):
+def build_usage_event(candidate, price_tables, today_str, role_map, binds, run_starts, pr_link_map, gh_cache, run_id_cache, repo_cache, session_attrs):
     usage = candidate["usage"] or {}
     input_tokens = usage.get("input_tokens")
     cache_read = usage.get("cache_read_input_tokens")
@@ -4070,7 +4378,7 @@ def build_usage_event(candidate, price_tables, today_str, role_map, binds, run_s
     role_info = role_map.get(session_id) if session_id else None
 
     worktree = candidate["cwd"]
-    run_id = resolve_run_id_via_ocw_run_id_file(worktree, run_id_cache)
+    direct_run_id = resolve_run_id_via_ocw_run_id_file(worktree, run_id_cache)
     # PR #27 review round 2 finding "新規1": the ocw-run-id file answers
     # "which run_id does THIS PATH belong to NOW", not "...when this
     # message was generated". `ocw rm <name>` + `ocw new <name>` reuses
@@ -4081,10 +4389,40 @@ def build_usage_event(candidate, price_tables, today_str, role_map, binds, run_s
     # (null, not guessed). Unknown run.start ts (e.g. from before this
     # meter started recording, or a different machine) gives the match
     # the benefit of the doubt rather than nulling everything out.
-    if run_id is not None and ts_dt is not None:
-        run_start_ts = run_starts.get(run_id)
+    #
+    # This reversal check applies ONLY to `direct_run_id` (see below) —
+    # 計画書 DOC-2608081456 罠1: it exists to catch worktree PATH reuse,
+    # and session_id (unlike a path) is never reused, so applying it to
+    # the session_id-join fallback would null out otherwise-correct
+    # attributions instead of catching anything real.
+    if direct_run_id is not None and ts_dt is not None:
+        run_start_ts = run_starts.get(direct_run_id)
         if run_start_ts is not None and ts_dt < run_start_ts:
-            run_id = None
+            direct_run_id = None
+
+    direct_role = (role_info or {}).get("role")
+    # レビュー指摘5: "unknown"はこのスキーマ全体で「未解決」を表す文字列
+    # センチネル(`_accumulate_session_attr_sample`/`_attribution_source_
+    # counts`と同じ判定基準)。`resolve_herdr_role_map()`はHerdrペインの
+    # `label`をそのまま`role`に入れる(人間が`herdr pane rename`で自由に
+    # 付けられ、"unknown"という名前も付けうる)ため、正規化せずに真偽値
+    # 判定へ渡すと"unknown"が「directで解決済み」と誤認され、本来通す
+    # べきsession joinへのフォールバックが飛ばされてしまう。
+    if direct_role == "unknown":
+        direct_role = None
+
+    # 孫5プロンプト §1 (B: ingest側フォールバック / 計画書「【2】【3】の鍵」):
+    # direct resolution (ocw-run-id file / Herdr live pane list) failed to
+    # answer, fall back to the session_id join against quota.sample before
+    # giving up. See `_nearest_sample_value`'s docstring for how a
+    # session_id with multiple distinct run_id/role samples is resolved.
+    session_run_id, session_role = (
+        resolve_session_attrs(session_attrs, session_id, ts_dt) if session_id else (None, None)
+    )
+    run_id = direct_run_id if direct_run_id is not None else session_run_id
+    run_id_source = "direct" if direct_run_id is not None else ("session_id" if session_run_id is not None else None)
+    role = direct_role or session_role
+    role_source = "direct" if direct_role else ("session_id" if session_role else None)
 
     pr_info = binds.get(run_id) if run_id else None
     if pr_info is None:
@@ -4123,13 +4461,19 @@ def build_usage_event(candidate, price_tables, today_str, role_map, binds, run_s
         "parser_version": INGEST_PARSER_VERSION,
         "completeness": completeness,
         "run_id": run_id,
+        # 孫5プロンプト §3: どの経路で解決したか(direct/session_id/未解決)
+        # を`report`のattribution行が数えられるようにする内部由来タグ。
+        # 既存の usage.message スキーマには無かった新規フィールドで、
+        # 未知フィールドは forward-compatible に保持される(plan §9.1)。
+        "run_id_source": run_id_source,
         "repo": repo_slug_for_cwd(worktree, repo_cache),
         "worktree": worktree,
         "branch": candidate["git_branch"],
         "head_sha": None,
         "workspace_id": (role_info or {}).get("workspace_id"),
         "pane_id": (role_info or {}).get("pane_id"),
-        "role": (role_info or {}).get("role") or "unknown",
+        "role": role or "unknown",
+        "role_source": role_source,
         "session_id": session_id,
         "provider": provider,
         "model": model,
@@ -4385,7 +4729,7 @@ def perform_ingest(root, since_dt=None):
         }
 
     role_map = resolve_herdr_role_map()
-    binds, run_starts = load_local_pr_binds_and_run_starts(paths)
+    binds, run_starts, session_attrs = load_local_pr_binds_and_run_starts(paths)
     price_tables = load_price_tables(price_table_dir())
     # Round-1 review finding 3: a `time_of_day_pricing` block that's
     # PRESENT but unusable must not look identical to "this table simply
@@ -4398,7 +4742,7 @@ def perform_ingest(root, since_dt=None):
     gh_cache, run_id_cache, repo_cache = {}, {}, {}
 
     events = [
-        build_usage_event(candidate, price_tables, today_str, role_map, binds, run_starts, pr_link_map, gh_cache, run_id_cache, repo_cache)
+        build_usage_event(candidate, price_tables, today_str, role_map, binds, run_starts, pr_link_map, gh_cache, run_id_cache, repo_cache, session_attrs)
         for candidate in candidates.values()
     ]
 

--- a/bin/ocw-meter
+++ b/bin/ocw-meter
@@ -88,11 +88,14 @@ subcommands:
     view below does this, at the very top of `report` — 計画書
     DOC-2608081456孫2), so a `report` right after Claude Code activity
     doesn't need a manual `ocw-meter ingest` first. An ingest failure
-    (including refusing to run inside a Git worktree) never aborts
-    `report` itself — it's shown as a footer line and `report` still
-    serves whatever was already stored. `--no-ingest` skips the
-    automatic run entirely (read-only use, or when you want to control
-    exactly what `report` sees). The footer also always includes the
+    never aborts `report` itself — it's shown as a footer line and
+    `report` still serves whatever was already stored. `--no-ingest`
+    skips the automatic run entirely (read-only use, or when you want
+    to control what `report` sees). If the store itself resolves
+    inside a Git worktree, `report` refuses to run at all and exits
+    non-zero before printing anything — this is a `report`-level guard
+    that runs before the automatic ingest, not an ingest failure that
+    shows up as a footer line. The footer also always includes the
     last successful ingest's timestamp, this run's own ingest outcome,
     and a staleness warning once that timestamp is 24h old or older.
 
@@ -2882,14 +2885,19 @@ def auto_ingest_for_report(root, no_ingest):
     ingested data — missing even one view here would make that one view
     silently see stale data while the others didn't.
 
-    Never raises: an ingest failure — including the exact same git-
-    worktree refusal `ingest` itself can hit (`perform_ingest` returns
-    `ok: False` for it, not an exception) — must never stop `report`
-    from showing whatever is already in the store; both funnel through
-    the same `{"status": "failed", "error": ...}` shape here so no
-    caller needs a special case for "which kind of failure was it".
-    `--no-ingest` (read-only use, and tests that want to control what
-    `report` sees) skips the call entirely."""
+    Never raises: any failure `perform_ingest` reports through its
+    `ok: False` return (not an exception) must never stop `report` from
+    showing whatever is already in the store; it funnels through the
+    same `{"status": "failed", "error": ...}` shape here so no caller
+    needs a special case for "which kind of failure was it". This does
+    NOT cover the git-worktree-refusal case: `cmd_report` checks
+    `in_git_worktree(root)` on this same `root` itself, before this
+    function is ever called, and returns non-zero immediately if the
+    store resolves inside a Git worktree — so the identical check
+    inside `perform_ingest` can never actually fire from this call site
+    (it exists there for `ingest`'s own direct invocation). `--no-ingest`
+    (read-only use, and tests that want to control what `report` sees)
+    skips the call entirely."""
     if no_ingest:
         return {"status": "skipped"}
     try:
@@ -3378,22 +3386,24 @@ def _report_month_standalone(paths, valid_events, malformed, month, repo, as_jso
         "list_price_equiv_excluded_null_cost_count": cash_and_capacity["list_price_equiv_excluded_null_cost_count"],
         "list_price_equiv_excluded_deepseek_count": cash_and_capacity["list_price_equiv_excluded_deepseek_count"],
         "list_price_equiv_excluded_other_provider_count": cash_and_capacity["list_price_equiv_excluded_other_provider_count"],
-        # 孫4プロンプト §4: quota.sample collection itself only started
-        # 2026-08-01 — a month before that has NO Claude-side cost data
-        # to find, which is a different fact from "this particular
-        # month happened to have zero anthropic sessions" (both produce
-        # the same null above; this line is what tells them apart). Only
-        # appended when the value actually IS null this scope — always
-        # true in real data for a pre-2026-08 month (quota.sample simply
-        # doesn't exist that far back), but guarding on the null itself
-        # (rather than only on the month string) keeps this from ever
-        # asserting "no data" next to a non-null figure.
+        # 孫4プロンプト §4: quota.sample collection only started when this
+        # machine deployed it, not on a fixed calendar date (`bin/ocw-meter`
+        # is deployed to different machines on different days — レビュー指摘
+        # 最終PRラウンド1 finding 3, same reasoning as
+        # `ATTRIBUTION_KNOWN_LIMITS` above). A null `list_price_equiv_usd`
+        # here can mean either "this scope predates quota.sample on this
+        # machine" or "quota.sample was running but no anthropic sessions
+        # happened to land in this scope" — the two are indistinguishable
+        # from the stored data alone, so the note names both possibilities
+        # rather than asserting one. Guarding on the null itself (not a
+        # month string) keeps this from ever appending next to a non-null
+        # figure.
         "list_price_equiv_note": (
             cash_and_capacity["list_price_equiv_note"]
             + (
-                " (quota.sampleの記録自体が2026-08-01開始のため、それより前の月は原理的に"
-                "データが無い)"
-                if month < "2026-08" and cash_and_capacity["list_price_equiv_usd"] is None else ""
+                " (quota.sampleの記録が始まる前の期間か、このスコープに該当する"
+                "anthropicセッションが無かったため、データが無い)"
+                if cash_and_capacity["list_price_equiv_usd"] is None else ""
             )
         ),
     }

--- a/bin/ocw-meter
+++ b/bin/ocw-meter
@@ -1823,13 +1823,178 @@ def events_for_pr(valid_events, pr_number, repo):
     ]
 
 
-def pr_review_summary(pr_events):
+# 孫4 round-2 review finding (新規): this explanation of what
+# `list_price_equiv_usd` is — Claude Code's own self-reported list
+# price equivalent, a lower bound, NEVER summed with cash cost, not an
+# invoice (罠4) — used to be duplicated as two independently-worded
+# ~190文字 string literals (`report_capacity_list_price`'s per-scope
+# `note` and `_print_grouped_report`'s `--window` legend). A future
+# change to this boundary's wording could silently update only one of
+# them. Both build off these two constants instead; only the
+# surrounding framing ("このスコープに" vs "値がnullの行は…") differs
+# per call site.
+LIST_PRICE_EQUIV_EXPLANATION = (
+    "Claude Code自己申告のsession_cost_usd（statusLineのcost.total_cost_usd）を "
+    "provider=anthropicのみに絞り、session_idごとに正の差分の総和として積算した下限値"
+    "（最後のstatusLine描画以降の消費は含まれない）。usage.messageのcost_estimate_usd"
+    "とは別カラムであり、cash costとは絶対に合算しない。請求書ではない。"
+)
+LIST_PRICE_EQUIV_NULL_EXPLANATION = "anthropicのquota.sampleが1件も無いため null（$0.00ではない）。"
+
+
+def _quota_session_contributions(all_quota_events):
+    """孫4 round-1 review finding 1: computes each anthropic
+    `quota.sample` sample's own contribution to `list_price_equiv_usd`
+    — the positive delta from the immediately preceding sample IN THE
+    SAME SESSION (or the sample's own value, if it is that session's
+    TRUE first sample across the whole store), independent of any
+    window/PR/month scope.
+
+    **MUST be called with the full relevant event set for every
+    session's entire lifetime — never with an already window/PR/month-
+    scoped subset.** Scoping the input here (the original 孫4
+    implementation's bug) breaks "is this really the session's first
+    sample" and reintroduces carryover double counting: a session that
+    spans two windows would have its ENTIRE running total re-added as
+    window 2's "opening" sample instead of just window 2's own delta —
+    measured on the real store as a 48.7% overcount on `report
+    --window`'s summed rows (57/207 anthropic sessions, 27.5%, span 2+
+    windows).
+
+    Returns `{event_id: contribution_usd}` for every event that had a
+    `session_id` and a numeric `session_cost_usd` (provider scoping —
+    罠2 — is the caller's job via `report_capacity_list_price`, but is
+    applied here too since a non-anthropic sample must never participate
+    in an anthropic session's delta sequence). A caller then sums the
+    contributions of whichever subset of these events belongs to its
+    own scope to get that scope's own `list_price_equiv_usd`, without
+    re-deriving delta order itself (which is exactly the mistake that
+    caused the overcount)."""
+    sessions = {}
+    for e in all_quota_events:
+        if e.get("event_type") != "quota.sample" or e.get("provider") != "anthropic":
+            continue
+        session_id = e.get("session_id")
+        cost = e.get("session_cost_usd")
+        event_id = e.get("event_id")
+        if not isinstance(session_id, str) or not session_id:
+            continue
+        if not isinstance(cost, (int, float)):
+            continue
+        if not event_id:
+            continue
+        sessions.setdefault(session_id, []).append((e.get("ts") or "", event_id, cost))
+
+    contributions = {}
+    for samples in sessions.values():
+        samples.sort(key=lambda item: item[0])
+        prev_cost = None
+        for _, event_id, cost in samples:
+            contributions[event_id] = cost if prev_cost is None else max(0.0, cost - prev_cost)
+            prev_cost = cost
+    return contributions
+
+
+def report_capacity_list_price(scope_quota_events, contributions):
+    """孫4プロンプト §1: aggregates Claude Code's own self-reported
+    session cost (`quota.sample`'s `session_cost_usd`, statusLine's
+    `cost.total_cost_usd`) into a Claude-side "list price equivalent"
+    total, scoped to `scope_quota_events` (a window's samples, a PR's
+    samples, a month's samples). This is a completely separate signal
+    from `cost_estimate_usd` (ocw-meter's own price-table estimate,
+    carried on `usage.message`) and must never be summed with it, nor
+    with cash cost — `report_month_cash_and_capacity`'s "cash cost と
+    capacity は never summed" contract covers this metric the same way
+    it covers cash vs capacity (罠4). Callers merge this dict's keys
+    into whichever capacity-side summary they're building (`--month`'s
+    capacity section, `--pr`'s pr_detail, `--window`'s per-window row).
+
+    `contributions` is `_quota_session_contributions()`'s return value,
+    computed ONCE by the caller from the FULL (unscoped) event set —
+    see that function's docstring for why per-sample contributions must
+    be computed globally rather than from `scope_quota_events` itself.
+    This function only decides WHICH contributions belong to this scope
+    and counts exclusions; it never recomputes deltas.
+
+    罠2: non-`anthropic` samples are excluded (not just `deepseek` —
+    round-1 review finding 3: a sample whose `provider` couldn't be
+    resolved at all, e.g. no model name AND no `rate_limits`, is stored
+    as `provider: null` by `snapshot-quota`, and previously vanished
+    from every exclusion counter here too, indistinguishable from "this
+    session simply doesn't exist"). `deepseek` (measured $93.35 across
+    10 sessions) is Claude Code pricing an unknown-to-us rate table
+    against a non-Anthropic model — summing it in here would double-
+    count against `usage.message`'s own DeepSeek price-table estimate;
+    a `provider`-unresolved sample might be genuinely anthropic, so
+    losing it silently (rather than counting the exclusion) would hide
+    a real gap if statusLine's payload shape ever changes upstream.
+
+    Samples missing `session_id` (can't be grouped into a session at
+    all) or with a null/non-numeric `session_cost_usd` are excluded
+    rather than guessed at, and counted separately so the exclusion is
+    visible in the output instead of silently dropped (plan's
+    "推測で埋めない" — 全孫共通の注意5)."""
+    excluded_no_session_id = 0
+    excluded_null_cost = 0
+    excluded_deepseek = 0
+    excluded_other_provider = 0
+    total = 0.0
+    session_ids = set()
+    for e in scope_quota_events:
+        if e.get("event_type") != "quota.sample":
+            continue
+        provider = e.get("provider")
+        if provider != "anthropic":
+            if provider == "deepseek":
+                excluded_deepseek += 1
+            else:
+                excluded_other_provider += 1
+            continue
+        session_id = e.get("session_id")
+        if not isinstance(session_id, str) or not session_id:
+            excluded_no_session_id += 1
+            continue
+        cost = e.get("session_cost_usd")
+        if not isinstance(cost, (int, float)):
+            excluded_null_cost += 1
+            continue
+        contribution = contributions.get(e.get("event_id"))
+        if contribution is None:
+            continue  # defensive: shouldn't happen if contributions came from the same event set
+        total += contribution
+        session_ids.add(session_id)
+
+    has_data = bool(session_ids)
+    note = LIST_PRICE_EQUIV_EXPLANATION
+    if not has_data:
+        note += " このスコープに" + LIST_PRICE_EQUIV_NULL_EXPLANATION
+    return {
+        "list_price_equiv_usd": total if has_data else None,
+        # round-1 review finding 5: null と「下限」は同時に成立しない —
+        # データが無いスコープでは is_lower_bound 自体も null にする。
+        "list_price_equiv_is_lower_bound": True if has_data else None,
+        "list_price_equiv_session_count": len(session_ids),
+        "list_price_equiv_excluded_no_session_id_count": excluded_no_session_id,
+        "list_price_equiv_excluded_null_cost_count": excluded_null_cost,
+        "list_price_equiv_excluded_deepseek_count": excluded_deepseek,
+        "list_price_equiv_excluded_other_provider_count": excluded_other_provider,
+        "list_price_equiv_note": note,
+    }
+
+
+def pr_review_summary(pr_events, quota_contributions):
     """孫5 §1 --pr: review round list / human intervention count / final
     result / cash+capacity cost split / 5h枠消費 for one PR's own
     (already resolved via `events_for_pr`) event set. Reads ONLY the
     events already attributed to this PR — no additional time-range
     guessing beyond what plan §7.4's PR-attribution priority already
-    resolved."""
+    resolved.
+
+    `quota_contributions` is `_quota_session_contributions()`'s return
+    value, computed by the caller from the FULL (unscoped) event set —
+    passed straight through to `report_capacity_list_price` below (孫4
+    round-1 review finding 1: a session spanning two PRs must not have
+    its whole running total re-added to the second PR)."""
     review_rounds = []
     for e in pr_events:
         if e.get("event_type") == "review.round":
@@ -1906,6 +2071,7 @@ def pr_review_summary(pr_events):
         "seven_day_used_pct_max": max(seven_day_vals) if seven_day_vals else None,
         "cash_cost_usd": cash_cost if has_cash_cost else None,
         "capacity_message_count": capacity_message_count,
+        **report_capacity_list_price(pr_events, quota_contributions),
     }
 
 
@@ -2060,7 +2226,7 @@ def report_by_phase(scoped_events, usage_events):
     return out
 
 
-def report_by_window(valid_events, repo=None):
+def report_by_window(valid_events, repo, quota_contributions):
     """孫5 §1 --window: `quota.sample` events grouped by `window_id`
     (plan §8.5 — the 5-hour reset boundary's identifier). `pr_number`
     on a quota.sample comes straight from the caller-supplied field
@@ -2072,7 +2238,25 @@ def report_by_window(valid_events, repo=None):
 
     `repo` scopes `pr_ranges` so that `report --window` run from one
     repo does not pollute the window's PR list with identically-numbered
-    PRs from a different repo in the shared ocw-meter store."""
+    PRs from a different repo in the shared ocw-meter store.
+
+    `valid_events` here is this call's own GROUPING scope — the caller
+    passes a PR-narrowed `filtered` when `--window` is combined with
+    `--pr` (round-2 review: `report --window --pr <n>` legitimately
+    means "only this PR's own quota.sample samples, grouped by
+    window"). `quota_contributions`, by contrast, MUST always be
+    `_quota_session_contributions()`'s output computed from the TRUE,
+    unnarrowed store — round-1 review finding 1 fixed the plain
+    `--window` and plain `--pr` cases by threading `quota_contributions`
+    in from the caller, but this function's OWN first implementation of
+    that fix still derived `quota_contributions` internally from
+    whichever `valid_events` it happened to receive, which is exactly
+    `filtered` in the combined case — round-2 review finding
+    (持ち越し) caught that the fix hadn't actually reached the one
+    combination where `valid_events` here is NOT the full store.
+    `quota_contributions` is now a required parameter for exactly this
+    reason: this function must never compute it itself from its own
+    (possibly narrowed) `valid_events` again."""
     windows = {}
     for e in valid_events:
         if e.get("event_type") != "quota.sample":
@@ -2082,9 +2266,14 @@ def report_by_window(valid_events, repo=None):
             continue
         w = windows.setdefault(wid, {
             "samples": 0, "five_hour_used_pct_max": None, "seven_day_used_pct_max": None,
-            "first_ts": None, "last_ts": None, "prs_direct": set(),
+            "first_ts": None, "last_ts": None, "prs_direct": set(), "quota_events": [],
         })
         w["samples"] += 1
+        # 孫4プロンプト §2: list_price_equiv needs each window's own raw
+        # quota.sample events (session-level delta accounting can't be
+        # done from the running maxes above) — kept only for the
+        # `report_capacity_list_price` call below, not exposed itself.
+        w["quota_events"].append(e)
         for pct_field, out_field in (("five_hour_used_pct", "five_hour_used_pct_max"), ("seven_day_used_pct", "seven_day_used_pct_max")):
             pct = e.get(pct_field)
             if isinstance(pct, (int, float)):
@@ -2128,6 +2317,7 @@ def report_by_window(valid_events, repo=None):
             "prs_time_overlap": prs_overlap,
             "blocked_seconds": None,
             "blocked_note": "block.start/block.end are schema-defined but not emitted by any caller yet (計画書16章) — always null here",
+            **report_capacity_list_price(w["quota_events"], quota_contributions),
         }
     return out
 
@@ -2179,11 +2369,18 @@ def report_month_process_efficiency(valid_events, month, repo):
     per-PR numbers, matching how `report --pr` already resolves one
     PR's events. `repo` scopes both "which PRs count as approved" and
     "which events belong to each one" to the invoking repo (round-1
-    review finding 1)."""
+    review finding 1).
+
+    `quota_contributions` (孫4 round-1 review finding 1) is computed
+    ONCE here from the full `valid_events` and threaded into every
+    `pr_review_summary` call below, rather than each call recomputing
+    it (or worse, deriving it from just that one PR's own events —
+    the original bug)."""
+    quota_contributions = _quota_session_contributions(valid_events)
     per_pr = []
     for pr in sorted(find_approved_pr_numbers_in_month(valid_events, month, repo)):
         pr_events = events_for_pr(valid_events, pr, repo)
-        detail = pr_review_summary(pr_events)
+        detail = pr_review_summary(pr_events, quota_contributions)
         completion, _ = pr_five_hour_window_completion(pr_events, valid_events)
         per_pr.append({"pr_number": pr, "five_hour_window_completion": completion, **detail})
 
@@ -2277,7 +2474,15 @@ def report_month_cash_and_capacity(valid_events, month):
     plan §16 / 孫5プロンプト §1 "Cash cost と Capacity cost を混ぜない"
     is a hard requirement, not a style preference: a flat-rate
     subscription has no per-message dollar figure to add to the
-    metered total."""
+    metered total.
+
+    `quota_contributions` (孫4 round-1 review finding 1) is computed
+    from `valid_events` itself — the full store, not `quota_month` —
+    so a session that straddles a month boundary (only possible from
+    September on; `quota.sample` collection itself only started
+    2026-08-01) attributes only its own delta to each month, not its
+    whole running total twice."""
+    quota_contributions = _quota_session_contributions(valid_events)
     usage_month = [
         e for e in valid_events
         if e.get("event_type") == "usage.message" and isinstance(e.get("ts"), str) and e["ts"].startswith(month)
@@ -2310,6 +2515,7 @@ def report_month_cash_and_capacity(valid_events, month):
         "five_hour_used_pct_max": max(five_hour_vals) if five_hour_vals else None,
         "seven_day_used_pct_max": max(seven_day_vals) if seven_day_vals else None,
         "distinct_five_hour_windows": len(distinct_windows),
+        **report_capacity_list_price(quota_month, quota_contributions),
     }
 
 
@@ -2544,14 +2750,35 @@ def _print_grouped_report(title, group_label, groups, as_json, storage_root_str,
     print(f"{title}:")
     if not groups:
         print("  (no data)")
+    has_list_price_equiv = False
     for key, row in sorted(groups.items(), key=lambda kv: str(kv[0])):
         print(f"  {key}:")
+        has_list_price_equiv = has_list_price_equiv or "list_price_equiv_usd" in row
         for field, value in row.items():
-            if field in ("provider", "model"):
+            # round-1 review finding 6: `list_price_equiv_note` (a ~190
+            # 文字 explanation, identical for every row) used to print
+            # once PER ROW — with `report --window`'s real store
+            # currently at 26 windows, that's the same sentence 26
+            # times, burying the one thing that actually differs
+            # between rows (each window's own list_price_equiv_usd).
+            # Printed once as a shared legend after the loop instead.
+            if field in ("provider", "model", "list_price_equiv_note"):
                 continue
             if field == "cost_estimate_usd":
                 value = f"${value:.4f}" if isinstance(value, (int, float)) else "null"
+            elif field == "list_price_equiv_usd":
+                value = f"${value:.2f}+ (下限 / list price相当)" if isinstance(value, (int, float)) else "null"
             print(f"    {field}: {value}")
+    if has_list_price_equiv:
+        # 孫4 round-2 review finding (新規): built from the same
+        # LIST_PRICE_EQUIV_EXPLANATION / _NULL_EXPLANATION constants
+        # `report_capacity_list_price` uses for its own per-scope
+        # `note` — this used to be an independently hardcoded ~190文字
+        # string that could drift out of sync with that one.
+        print(
+            "list_price_equiv_note: 各list_price_equiv_usdは" + LIST_PRICE_EQUIV_EXPLANATION
+            + " 値がnullの行はそのスコープに" + LIST_PRICE_EQUIV_NULL_EXPLANATION
+        )
     print_footer_text(footer_completeness, footer_cost, footer_freshness, total)
     return 0
 
@@ -2802,7 +3029,21 @@ def cmd_report(args):
         elif view == "phase":
             groups = report_by_phase(filtered, usage_events)
         elif view == "window":
-            groups = report_by_window(valid_events if filter_pr is None else filtered, repo)
+            # round-2 review finding (持ち越し): `quota_contributions` MUST
+            # come from the true full `valid_events`, never from
+            # `filtered` — even though `filtered` is also this call's
+            # OWN first argument when `--pr` is combined with
+            # `--window`. Passing `filtered` for contributions while
+            # ALSO passing it as the grouping input was exactly the
+            # bug: `report_by_window` used to derive contributions from
+            # whatever it was grouping over, so a PR-scoped call saw
+            # only that PR's own samples and mistook the PR's first
+            # sample for the session's true first sample (measured:
+            # 14/30 PRs overcounted, up to 5.5x on the real store).
+            groups = report_by_window(
+                valid_events if filter_pr is None else filtered, repo,
+                _quota_session_contributions(valid_events),
+            )
         return _print_grouped_report(
             f"by {view}", f"by_{view}", groups, as_json, str(paths.root),
             footer_completeness, footer_cost, footer_freshness, len(filtered), extra_top,
@@ -2838,8 +3079,12 @@ def cmd_report(args):
         summary["five_hour_window_completion"] = five_hour_window_completion
         summary["five_hour_window_ids_seen"] = five_hour_window_ids_seen
         # 孫5 §1: round/human-intervention/final-result/cash+capacity
-        # cost detail for this one PR.
-        summary["pr_detail"] = pr_review_summary(filtered)
+        # cost detail for this one PR. quota_contributions (孫4
+        # round-1 review finding 1) is computed from `valid_events`
+        # (the full store), NOT `filtered` — a session spanning two
+        # PRs must attribute only its own delta to each, not its whole
+        # running total twice.
+        summary["pr_detail"] = pr_review_summary(filtered, _quota_session_contributions(valid_events))
 
     if as_json:
         print(json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True))
@@ -2868,6 +3113,22 @@ def cmd_report(args):
             cash_str = f"${detail['cash_cost_usd']:.4f}" if isinstance(detail["cash_cost_usd"], (int, float)) else "null"
             print(f"cash_cost_usd: {cash_str}")
             print(f"capacity_message_count (claude subscription, no dollar figure): {detail['capacity_message_count']}")
+            list_price_str = (
+                f"${detail['list_price_equiv_usd']:.2f}+ (下限 / list price相当 / 請求書ではない / cash costと合算不可)"
+                if isinstance(detail["list_price_equiv_usd"], (int, float)) else "null"
+            )
+            print(f"list_price_equiv_usd: {list_price_str}")
+            print(f"list_price_equiv_session_count: {detail['list_price_equiv_session_count']}")
+            # round-1 review finding 2: these exclusion counts exist
+            # specifically so exclusions are never silent (plan's
+            # "黙って落とさない") — omitting them from text output
+            # (while --json still had them) defeated that purpose for
+            # anyone not passing --json.
+            print(f"list_price_equiv_excluded_no_session_id_count: {detail['list_price_equiv_excluded_no_session_id_count']}")
+            print(f"list_price_equiv_excluded_null_cost_count: {detail['list_price_equiv_excluded_null_cost_count']}")
+            print(f"list_price_equiv_excluded_deepseek_count: {detail['list_price_equiv_excluded_deepseek_count']}")
+            print(f"list_price_equiv_excluded_other_provider_count: {detail['list_price_equiv_excluded_other_provider_count']}")
+            print(f"list_price_equiv_note: {detail['list_price_equiv_note']}")
 
     return 0
 
@@ -2914,6 +3175,31 @@ def _report_month_standalone(paths, valid_events, malformed, month, repo, as_jso
         "five_hour_used_pct_max": cash_and_capacity["five_hour_used_pct_max"],
         "seven_day_used_pct_max": cash_and_capacity["seven_day_used_pct_max"],
         "distinct_five_hour_windows": cash_and_capacity["distinct_five_hour_windows"],
+        "list_price_equiv_usd": cash_and_capacity["list_price_equiv_usd"],
+        "list_price_equiv_is_lower_bound": cash_and_capacity["list_price_equiv_is_lower_bound"],
+        "list_price_equiv_session_count": cash_and_capacity["list_price_equiv_session_count"],
+        "list_price_equiv_excluded_no_session_id_count": cash_and_capacity["list_price_equiv_excluded_no_session_id_count"],
+        "list_price_equiv_excluded_null_cost_count": cash_and_capacity["list_price_equiv_excluded_null_cost_count"],
+        "list_price_equiv_excluded_deepseek_count": cash_and_capacity["list_price_equiv_excluded_deepseek_count"],
+        "list_price_equiv_excluded_other_provider_count": cash_and_capacity["list_price_equiv_excluded_other_provider_count"],
+        # 孫4プロンプト §4: quota.sample collection itself only started
+        # 2026-08-01 — a month before that has NO Claude-side cost data
+        # to find, which is a different fact from "this particular
+        # month happened to have zero anthropic sessions" (both produce
+        # the same null above; this line is what tells them apart). Only
+        # appended when the value actually IS null this scope — always
+        # true in real data for a pre-2026-08 month (quota.sample simply
+        # doesn't exist that far back), but guarding on the null itself
+        # (rather than only on the month string) keeps this from ever
+        # asserting "no data" next to a non-null figure.
+        "list_price_equiv_note": (
+            cash_and_capacity["list_price_equiv_note"]
+            + (
+                " (quota.sampleの記録自体が2026-08-01開始のため、それより前の月は原理的に"
+                "データが無い)"
+                if month < "2026-08" and cash_and_capacity["list_price_equiv_usd"] is None else ""
+            )
+        ),
     }
 
     if as_json:
@@ -2949,6 +3235,8 @@ def _report_month_standalone(paths, valid_events, malformed, month, repo, as_jso
         print("  price_tables_applied: (none)")
     print("capacity cost (Claude subscription quota — never summed with cash cost):")
     for field, value in summary["capacity"].items():
+        if field == "list_price_equiv_usd":
+            value = f"${value:.2f}+ (下限 / list price相当 / 請求書ではない)" if isinstance(value, (int, float)) else "null"
         print(f"  {field}: {value}")
     pe = summary["process_efficiency"]
     print(f"process efficiency (approved PRs in {month}):")

--- a/bin/ocw-meter
+++ b/bin/ocw-meter
@@ -24,6 +24,7 @@ usage:
   ocw-meter bind-pr --run <run_id> --pr <n> [--url <url>]
   ocw-meter ingest [--since <rfc3339-ts>]
   ocw-meter snapshot-quota
+  ocw-meter prune-diagnostics [--older-than <days>] [--apply]
   ocw-meter validate [--file <path>]
   ocw-meter report [--pr <n>] [--repo <owner>/<name>] [--json]
   ocw-meter report --phase [--pr <n>] [--repo <owner>/<name>] [--json]
@@ -169,6 +170,41 @@ subcommands:
     samples sharing the same `window_id` is flagged (completeness:
     "partial", stderr warning) rather than silently trusted.
 
+  prune-diagnostics [--older-than <days>] [--apply]
+    Cleans up ocw-meter's OWN diagnostic/state sidecar files —
+    state/meter-errors.jsonl and state/quota-worktree-refusal.json —
+    ONLY. Never touches events/*.jsonl (deleting events is `prune`'s
+    territory, and `prune` remains deliberately unimplemented — see
+    notes below). Default is dry-run: reports how many entries in each
+    file are older than --older-than days (default 30) without
+    modifying either file; pass --apply to actually rewrite them. A
+    SMALLER --older-than is usually needed to clean up entries left
+    over from a recent one-off misconfiguration (they will not be that
+    old yet) — this is a retention policy for ongoing hygiene, not a
+    "clean everything now" default.
+
+    Checks BOTH OCW_METER_HOME (or its own default when unset) and the
+    $HOME-derived default root: quota-worktree-refusal.json is ALWAYS
+    written under the latter regardless of OCW_METER_HOME, and
+    meter-errors.jsonl can end up under either (emit_meter_error falls
+    back to the default root whenever OCW_METER_HOME itself is refused
+    for resolving inside a Git worktree). A root that itself resolves
+    inside a Git worktree is skipped, not fatal, as long as the other
+    one is reachable. The two roots are compared by RESOLVED path, so a
+    trailing slash or a symlink does not make the same real directory
+    look like two roots and get double-counted. The roots actually
+    checked are always printed, and meter-errors.jsonl gets a per-root
+    breakdown whenever more than one contributed to the total. A
+    corrupt (unparseable, or not a JSON object) quota-worktree-
+    refusal.json is reported as such, not silently treated as empty;
+    --apply replaces it with a fresh empty state.
+
+    Always reports both a removed count and a kept count, plus (as
+    informational-only text, never as a deletion criterion) how many of
+    the removed entries look test-derived by path shape. Fail-loud
+    (non-zero exit) on unexpected failure, like validate/report/ingest
+    — unlike event/bind-pr/snapshot-quota's fail-open contract.
+
 environment:
   OCW_METER_HOME
     default: $HOME/.local/state/ocw-meter
@@ -275,7 +311,7 @@ case "$cmd" in
     usage
     exit 0
     ;;
-  event | bind-pr | validate | report | ingest | snapshot-quota)
+  event | bind-pr | validate | report | ingest | snapshot-quota | prune-diagnostics)
     ;;
   *)
     usage >&2
@@ -392,7 +428,7 @@ import sys
 import tempfile
 import time
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 SCHEMA_VERSION = 1
 # Bumped whenever `ingest`'s transcript-line -> usage.message extraction
@@ -688,6 +724,18 @@ class Paths:
         # the main lock made the write_event_lock_timeout diagnostic
         # self-defeating: it would need the very lock it's reporting as
         # unavailable).
+        #
+        # ONE exception (孫1, 計画書 DOC-2608081456【4】後始末, round-1
+        # review finding 4): `cmd_prune_diagnostics --apply` rewrites
+        # this file wholesale (mkstemp + os.replace) to drop aged-out
+        # lines. That is a deliberate, human-invoked, infrequent hygiene
+        # operation, not a background writer — `emit_meter_error` itself
+        # still never touches the main lock for this file. The narrow
+        # accepted risk: an `emit_meter_error` append landing in the
+        # exact instant between prune-diagnostics reading the old inode
+        # and replacing it is lost (one low-value diagnostic line, not
+        # silently corrupted data — os.replace is atomic, so readers
+        # never see a half-written file).
         self.meter_errors_file = self.state_dir / "meter-errors.jsonl"
 
 
@@ -3813,8 +3861,44 @@ def save_quota_state(paths, state):
     save_json_state_file(paths, QUOTA_STATE_FILENAME, state)
 
 
-def load_worktree_refusal_state(paths):
-    return load_json_state_file(paths, QUOTA_WORKTREE_REFUSAL_FILENAME)
+def load_and_prune_worktree_refusal_state(paths, now=None):
+    """Reads quota-worktree-refusal.json and prunes entries older than
+    QUOTA_SESSION_STATE_MAX_AGE_SECONDS on every read, not only when a
+    NEW refusal is about to be recorded (孫1, 計画書 DOC-2608081456【6】:
+    previously the only pruning happened inside the write-a-new-refusal
+    branch below, so once a misconfiguration stopped happening the last
+    stale entries sat in the file forever — 37 of them, all >24h old, on
+    this machine's real store).
+
+    Named `load_and_prune_*`, not `load_*`, on purpose (孫1 round-1
+    review finding 9): every other `load_*` function in this file
+    (`load_json_state_file` / `load_quota_state` / `load_ingest_cursor` /
+    `load_session_pr_links`) is a pure read, and this one is not — it
+    can write. `cmd_prune_diagnostics` deliberately calls
+    `load_json_state_file` directly instead of this function, precisely
+    to avoid that write side effect; the name difference is what makes
+    that choice legible at the call site.
+
+    If pruning actually dropped something, the pruned result is written
+    straight back so the file shrinks on the very next call after the
+    misconfiguration stops (no NEW refusal is needed to trigger cleanup
+    anymore). The overwhelmingly common case — nothing has ever been
+    refused, or nothing here has expired yet — stays a pure read with no
+    write I/O: `snapshot-quota` calls this on essentially every
+    statusLine tick (~60s throttle), so paying for a write on every call
+    would be wasteful for machines that never hit this path at all."""
+    raw = load_json_state_file(paths, QUOTA_WORKTREE_REFUSAL_FILENAME)
+    if now is None:
+        now = datetime.now(timezone.utc)
+    pruned = {}
+    for bad_root, checked_at in raw.items():
+        checked_ts = parse_ts(checked_at) if isinstance(checked_at, str) else None
+        if checked_ts is not None and (now - checked_ts).total_seconds() <= QUOTA_SESSION_STATE_MAX_AGE_SECONDS:
+            pruned[bad_root] = checked_at
+    if len(pruned) != len(raw):
+        with contextlib.suppress(Exception):
+            save_worktree_refusal_state(paths, pruned)
+    return pruned
 
 
 def save_worktree_refusal_state(paths, state):
@@ -3974,20 +4058,50 @@ def record_quota_sample(obj):
     # worktree, there is nowhere left to cache the refusal — `root`
     # simply gets re-checked every call in that (rare, doubly-
     # misconfigured) case, same as before this suppression existed.
+    #
+    # 孫1 round-1 review finding 1: this used to additionally require
+    # `default_root != root` before even LOADING (and therefore
+    # pruning) the file — which meant the read-time pruning added
+    # above never ran in the single most common configuration of all:
+    # OCW_METER_HOME unset, so `storage_root()` and
+    # `default_storage_root()` resolve to the identical path. That is
+    # exactly the "misconfiguration has stopped" state 計画書
+    # DOC-2608081456【6】 is about, so the 37 stale entries found on
+    # this machine's real store would never have actually been pruned.
+    # Dropping that equality check is safe: the only reason it existed
+    # was to avoid writing the cache INTO the very root being refused,
+    # and that is already fully handled by the `not
+    # in_git_worktree(default_root)` check alone — if `default_root ==
+    # root` and `root` is refused, `default_root` is refused too (same
+    # path), so `refusal_paths` still ends up None via that check, no
+    # new paradox introduced.
     default_root = default_storage_root()
-    refusal_paths = (
-        Paths(default_root)
-        if (default_root and default_root != root and not in_git_worktree(default_root))
-        else None
-    )
+    # 孫1 round-2 review finding 1: `default_root == root` is exactly the
+    # common case the round-1 fix above stopped short-circuiting on
+    # (OCW_METER_HOME unset) — so `in_git_worktree(default_root)` below
+    # and `in_git_worktree(root)` a few lines down were now hitting the
+    # SAME path with two separate `git rev-parse --is-inside-work-tree`
+    # subprocess calls per `snapshot-quota` invocation, exactly the
+    # doubled cost this function's own docstring and the comment on the
+    # per-session throttle check above both say to avoid. Evaluate it
+    # ONCE here and reuse the result for `root` whenever the two paths
+    # are identical.
+    default_root_is_worktree = bool(default_root) and in_git_worktree(default_root)
+    refusal_paths = Paths(default_root) if (default_root and not default_root_is_worktree) else None
+    refusal_state = {}
     if refusal_paths is not None:
-        refusal_state = load_worktree_refusal_state(refusal_paths)
+        # Already pruned of anything >24h old (see load_and_prune_
+        # worktree_refusal_state's own docstring) — reused below instead
+        # of re-loading, so a refusal doesn't pay for reading+pruning the
+        # file twice.
+        refusal_state = load_and_prune_worktree_refusal_state(refusal_paths, now)
         last_refused_at = refusal_state.get(root)
         last_refused_at = parse_ts(last_refused_at) if isinstance(last_refused_at, str) else None
         if last_refused_at is not None and (now - last_refused_at).total_seconds() < interval:
             return  # still within the suppression window from a previous refusal
 
-    if in_git_worktree(root):
+    root_is_worktree = default_root_is_worktree if (default_root and default_root == root) else in_git_worktree(root)
+    if root_is_worktree:
         print(
             f"warning: OCW_METER_HOME ({root}) resolves inside a Git worktree; "
             "refusing to write there (no quota.sample recorded)",
@@ -3996,11 +4110,7 @@ def record_quota_sample(obj):
         emit_meter_error(root, "storage_home_inside_git_worktree", None)
         if refusal_paths is not None:
             with contextlib.suppress(Exception):
-                updated = {}
-                for bad_root, checked_at in load_worktree_refusal_state(refusal_paths).items():
-                    checked_ts = parse_ts(checked_at) if isinstance(checked_at, str) else None
-                    if checked_ts is not None and (now - checked_ts).total_seconds() <= QUOTA_SESSION_STATE_MAX_AGE_SECONDS:
-                        updated[bad_root] = checked_at
+                updated = dict(refusal_state)
                 updated[root] = iso_utc(now)
                 save_worktree_refusal_state(refusal_paths, updated)
         return
@@ -4190,6 +4300,314 @@ def cmd_snapshot_quota(args):
     return 0
 
 
+# ── subcommand: prune-diagnostics (孫1, 計画書 DOC-2608081456【4】【6】) ──
+
+PRUNE_DIAGNOSTICS_DEFAULT_OLDER_THAN_DAYS = 30
+
+# Best-effort heuristic ONLY — see _looks_test_derived below. Never used
+# to decide what actually gets deleted (age is the only deletion
+# criterion); shown in dry-run/apply output purely as extra context.
+_TEST_ARTIFACT_PATH_HINT = "ocw-meter-home"
+
+
+def _looks_test_derived(text):
+    """Real test fixtures across bin/tests/test_ocw_meter.py always name
+    their throwaway storage root literally "...ocw-meter-home" (see
+    OcwMeterTestCase.home and every `bad_home = <repo>/ocw-meter-home`
+    variant used to exercise the worktree-refusal path) — a name a real
+    misconfiguration is very unlikely to coincidentally share. False
+    negatives (a differently-named test fixture) are expected and fine:
+    this is informational only, never a deletion criterion (計画書
+    DOC-2608081456 孫1プロンプト: 「削除条件にはしない」)."""
+    return isinstance(text, str) and _TEST_ARTIFACT_PATH_HINT in text
+
+
+def _parse_prune_diagnostics_args(args):
+    apply_changes = False
+    older_than_days = PRUNE_DIAGNOSTICS_DEFAULT_OLDER_THAN_DAYS
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg == "--apply":
+            apply_changes = True
+            i += 1
+        elif arg == "--older-than":
+            if i + 1 >= len(args):
+                raise ValueError("--older-than requires a value")
+            raw = args[i + 1]
+            try:
+                older_than_days = int(raw)
+            except ValueError:
+                raise ValueError(f"--older-than expects an integer number of days, got: {raw}") from None
+            if older_than_days < 0:
+                raise ValueError("--older-than must not be negative")
+            i += 2
+        else:
+            raise ValueError(f"unrecognized argument: {arg}")
+    return apply_changes, older_than_days
+
+
+def _resolve_path_str(path):
+    """Same normalization `in_git_worktree` applies internally (resolve,
+    falling back to the original on OSError) — used here so dedup
+    compares REAL locations, not surface path spelling."""
+    p = pathlib.Path(path)
+    try:
+        return str(p.resolve())
+    except OSError:
+        return str(p)
+
+
+def _diagnostic_target_roots():
+    """The distinct, reachable storage roots ocw-meter's OWN diagnostics
+    can actually live under (孫1 round-1 review finding 2):
+    `storage_root()` (OCW_METER_HOME, or its own default when unset) is
+    where `emit_meter_error` normally appends state/meter-errors.jsonl,
+    and `default_storage_root()` ($HOME-derived) is BOTH where
+    `emit_meter_error` falls back to whenever `storage_root()` itself is
+    refused for resolving inside a Git worktree, AND the ONLY place
+    state/quota-worktree-refusal.json is ever written (see
+    load_and_prune_worktree_refusal_state's docstring) — never under a
+    custom OCW_METER_HOME. A root that itself resolves inside a Git
+    worktree is skipped, not fatal for the whole subcommand: the other
+    root may still be reachable and worth cleaning.
+
+    Dedup compares RESOLVED paths (孫1 round-2 review finding 2): a bare
+    string comparison let a trailing slash or a symlink hop make
+    `storage_root()` and `default_storage_root()` look like two
+    different roots when they were the same real directory, so
+    `state/meter-errors.jsonl` got read (and counted) twice — dry-run
+    and `--apply` then disagreed on how many lines would be removed.
+    The RESOLVED path is also what gets returned and used to build
+    `Paths(...)` downstream, so every consumer sees the same
+    canonicalized root `in_git_worktree` itself already compares
+    against."""
+    roots = []
+    seen = set()
+    for candidate in (storage_root(), default_storage_root()):
+        if not candidate:
+            continue
+        resolved = _resolve_path_str(candidate)
+        if resolved in seen:
+            continue
+        if in_git_worktree(resolved):
+            continue
+        seen.add(resolved)
+        roots.append(resolved)
+    return roots
+
+
+def _split_meter_errors_by_age(raw_text, now, max_age):
+    kept = []
+    dropped = 0
+    dropped_test_like = 0
+    for line in raw_text.splitlines():
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            # Not this subcommand's job to quarantine malformed lines —
+            # that is `validate`'s contract, and it only applies to
+            # events/*.jsonl. Keep anything unparseable rather than
+            # guess whether it is stale.
+            kept.append(line)
+            continue
+        ts = parse_ts(event.get("ts")) if isinstance(event, dict) else None
+        if ts is not None and (now - ts) > max_age:
+            dropped += 1
+            if _looks_test_derived(line):
+                dropped_test_like += 1
+        else:
+            kept.append(line)
+    return kept, dropped, dropped_test_like
+
+
+def _rewrite_meter_errors_file(paths, kept_lines):
+    if kept_lines:
+        ensure_dir(paths.state_dir, 0o700)
+        tmp_fd, tmp_path = tempfile.mkstemp(dir=str(paths.state_dir), prefix=".tmp-", suffix=".jsonl")
+        try:
+            with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
+                fh.write("\n".join(kept_lines) + "\n")
+            os.chmod(tmp_path, 0o600)
+            os.replace(tmp_path, paths.meter_errors_file)
+        except Exception:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_path)
+            raise
+    else:
+        paths.meter_errors_file.unlink()
+
+
+def _read_worktree_refusal_state_raw(paths):
+    """Like load_json_state_file, but distinguishes "absent/empty" from
+    "present but unparseable" (孫1 round-1 review finding 8) — silently
+    treating a corrupt file as `{}` (load_json_state_file's own
+    contract, correct for every OTHER caller) let prune-diagnostics
+    report "kept 0" for a file that, in fact, was still sitting there
+    corrupt and untouched. Returns (data, was_corrupt)."""
+    path = paths.state_dir / QUOTA_WORKTREE_REFUSAL_FILENAME
+    if not path.exists():
+        return {}, False
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return {}, True
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return {}, True
+    return (data, False) if isinstance(data, dict) else ({}, True)
+
+
+def cmd_prune_diagnostics(args):
+    """Cleans up ocw-meter's OWN diagnostic/state sidecar files —
+    state/meter-errors.jsonl and state/quota-worktree-refusal.json —
+    and ONLY those two. Deliberately never touches events/*.jsonl:
+    deleting observation events is `prune`'s territory, and `prune`
+    stays intentionally unimplemented (bin/README.md) — this subcommand
+    does not revisit that decision (計画書 DOC-2608081456【6】).
+
+    Checks BOTH `storage_root()` (OCW_METER_HOME, or its default) and
+    `default_storage_root()` ($HOME-derived) — see
+    _diagnostic_target_roots — since ocw-meter's own diagnostics can
+    legitimately end up at either, and quota-worktree-refusal.json is
+    ALWAYS at the default root regardless of OCW_METER_HOME. A root
+    that resolves inside a Git worktree is skipped, not fatal: the
+    other root may still be reachable. The two are compared by
+    RESOLVED path, so a trailing slash or a symlink hop never makes the
+    same real directory look like two different roots (which would
+    otherwise double-count state/meter-errors.jsonl). The roots
+    actually selected are always printed, and state/meter-errors.jsonl
+    gets a per-root breakdown whenever more than one of them
+    contributed to the total.
+
+    Default is dry-run: reports counts without writing anything. Only
+    --apply rewrites the files, and only entries older than
+    --older-than days (default 30 — long enough that a human skimming
+    `report`'s "meter.error diagnostics: N lines" footer roughly once a
+    month still sees a genuine problem before it becomes eligible for
+    cleanup, short enough that a one-off misconfiguration from months
+    ago does not linger forever) are ever removed. This default will
+    NOT immediately clean up entries only a few days old — pass a
+    smaller --older-than for that (see bin/README.md). Fail-loud
+    (non-zero on unexpected error) like validate/report/ingest, not
+    fail-open like event/bind-pr/snapshot-quota — silently swallowing a
+    failure here would hide whether cleanup actually ran."""
+    try:
+        apply_changes, older_than_days = _parse_prune_diagnostics_args(args)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    now = datetime.now(timezone.utc)
+    max_age = timedelta(days=older_than_days)
+    target_roots = _diagnostic_target_roots()
+
+    mode = "applied" if apply_changes else "dry-run (pass --apply to actually delete)"
+    print(f"prune-diagnostics: {mode}, --older-than {older_than_days}d")
+
+    if not target_roots:
+        print(
+            "  no reachable storage root (OCW_METER_HOME and the default "
+            "$HOME-derived root are both unset or resolve inside a Git "
+            "worktree) — nothing to clean",
+            file=sys.stderr,
+        )
+        return 0
+
+    # 孫1 round-2 review finding 4: with two files now possibly spread
+    # across two DIFFERENT physical directories, a single aggregate
+    # count no longer says which store actually gets rewritten. Always
+    # print which roots `_diagnostic_target_roots()` actually selected.
+    print(f"  checked roots: {', '.join(target_roots)}")
+
+    def _report(label, dropped, kept_count, dropped_test_like):
+        verb = "removed" if apply_changes else "would remove"
+        suffix = f" ({dropped_test_like} of those look test-derived, heuristic only)" if dropped_test_like else ""
+        print(f"  {label}: {verb} {dropped}, kept {kept_count}{suffix}")
+
+    errors_dropped_total = 0
+    errors_kept_total = 0
+    errors_dropped_test_like_total = 0
+    per_root_error_reports = []
+    for root in target_roots:
+        paths = Paths(root)
+        if not paths.meter_errors_file.exists():
+            continue
+        try:
+            raw_text = paths.meter_errors_file.read_text(encoding="utf-8")
+        except OSError as exc:
+            print(f"error: could not read {paths.meter_errors_file}: {exc}", file=sys.stderr)
+            return 1
+        kept, dropped, dropped_test_like = _split_meter_errors_by_age(raw_text, now, max_age)
+        if apply_changes and dropped:
+            try:
+                _rewrite_meter_errors_file(paths, kept)
+            except OSError as exc:
+                print(f"error: failed to rewrite {paths.meter_errors_file}: {exc}", file=sys.stderr)
+                return 1
+        per_root_error_reports.append((root, dropped, len(kept), dropped_test_like))
+        errors_dropped_total += dropped
+        errors_kept_total += len(kept)
+        errors_dropped_test_like_total += dropped_test_like
+    _report("state/meter-errors.jsonl", errors_dropped_total, errors_kept_total, errors_dropped_test_like_total)
+    if len(per_root_error_reports) > 1:
+        # More than one physical file actually contributed to the total
+        # above — break it down so it is clear which store each part
+        # came (or will come) from.
+        verb = "removed" if apply_changes else "would remove"
+        for root, dropped, kept_count, dropped_test_like in per_root_error_reports:
+            suffix = f" ({dropped_test_like} test-derived)" if dropped_test_like else ""
+            print(f"    {root}: {verb} {dropped}, kept {kept_count}{suffix}")
+
+    default_root = default_storage_root()
+    default_root = _resolve_path_str(default_root) if default_root else None
+    if default_root is None or default_root not in target_roots:
+        print("  state/quota-worktree-refusal.json: default storage root unreachable — 0 removed, 0 kept")
+        return 0
+
+    refusal_paths = Paths(default_root)
+    refusal_raw, corrupt = _read_worktree_refusal_state_raw(refusal_paths)
+    if corrupt:
+        if apply_changes:
+            try:
+                save_worktree_refusal_state(refusal_paths, {})
+            except OSError as exc:
+                print(f"error: failed to rewrite quota-worktree-refusal.json: {exc}", file=sys.stderr)
+                return 1
+            print("  state/quota-worktree-refusal.json: could not parse (corrupt or not a JSON object) — replaced with an empty state")
+        else:
+            print(
+                "  state/quota-worktree-refusal.json: could not parse (corrupt or not a JSON object) "
+                "— pass --apply to replace it with an empty state"
+            )
+        return 0
+
+    refusal_kept = {}
+    refusal_dropped = 0
+    refusal_dropped_test_like = 0
+    for bad_root, checked_at in refusal_raw.items():
+        checked_ts = parse_ts(checked_at) if isinstance(checked_at, str) else None
+        if checked_ts is not None and (now - checked_ts) > max_age:
+            refusal_dropped += 1
+            if _looks_test_derived(bad_root):
+                refusal_dropped_test_like += 1
+        else:
+            refusal_kept[bad_root] = checked_at
+
+    if apply_changes and refusal_dropped:
+        try:
+            save_worktree_refusal_state(refusal_paths, refusal_kept)
+        except OSError as exc:
+            print(f"error: failed to rewrite quota-worktree-refusal.json: {exc}", file=sys.stderr)
+            return 1
+
+    _report("state/quota-worktree-refusal.json", refusal_dropped, len(refusal_kept), refusal_dropped_test_like)
+    return 0
+
+
 # ── entry point ──────────────────────────────────────────────────────
 
 def main():
@@ -4236,13 +4654,15 @@ def main():
                 emit_meter_error(storage_root(), "cmd_snapshot_quota_unexpected_exception", exc)
             return 0
 
-    if cmd in ("validate", "report", "ingest"):
+    if cmd in ("validate", "report", "ingest", "prune-diagnostics"):
         try:
             if cmd == "validate":
                 return cmd_validate(rest)
             if cmd == "report":
                 return cmd_report(rest)
-            return cmd_ingest(rest)
+            if cmd == "ingest":
+                return cmd_ingest(rest)
+            return cmd_prune_diagnostics(rest)
         except Exception as exc:
             print(f"error: ocw-meter {cmd} failed: {redact_text(f'{type(exc).__name__}: {exc}')}", file=sys.stderr)
             return 1

--- a/bin/ocw-meter
+++ b/bin/ocw-meter
@@ -545,6 +545,9 @@ EVENT_ENUM_FIELDS = {
     "review.round": {"verdict": ("approved", "changes_requested", "ambiguous")},
     "block.start": {"cause": ("rate_limit", "api_error", "unknown")},
     "block.end": {"cause": ("rate_limit", "api_error", "unknown")},
+    "usage.message": {
+        "time_of_day_basis": ("not_applicable", "in_window", "base_rate", "unknown_timestamp"),
+    },
 }
 
 # Secret-shaped values must never survive into stored events (plan §9.2 /
@@ -1573,6 +1576,22 @@ def normalize_month_arg(month):
     return month, None
 
 
+def _price_table_predates_message(event):
+    """True when this `usage.message` event's applied `price_effective_date`
+    is AFTER the message's own date — i.e. `select_price_table()` fell
+    back to the earliest available table (`tables[0]`) at ingest time
+    because no table had yet taken effect when the message actually
+    happened (計画書 DOC-2608081456 罠5 / 孫3プロンプト §3). Purely a
+    read-time judgment from fields already stored on the event — no
+    stored event is ever rewritten to compute this (罠5's "past isn't
+    recalculated" invariant), it's just re-derived on every read."""
+    effective = event.get("price_effective_date")
+    ts = event.get("ts")
+    if not isinstance(effective, str) or not isinstance(ts, str) or len(ts) < 10:
+        return False
+    return effective > ts[:10]
+
+
 def usage_cost_footer(usage_events):
     """The cost/coverage/price_table portion of the required per-plan-
     §10.4 footer, shared by every `report` view (孫5 §1: "coverage 併記が
@@ -1581,6 +1600,7 @@ def usage_cost_footer(usage_events):
     forget a piece of it)."""
     cost_sum, has_cost = 0.0, False
     price_versions, cost_bases = set(), set()
+    fallback_count = 0
     for e in usage_events:
         cost = e.get("cost_estimate_usd")
         if isinstance(cost, (int, float)):
@@ -1590,12 +1610,23 @@ def usage_cost_footer(usage_events):
             price_versions.add(e["price_table_version"])
         if e.get("cost_basis"):
             cost_bases.add(e["cost_basis"])
+        if _price_table_predates_message(e):
+            fallback_count += 1
     if usage_events:
         coverage = (
             f"{len(usage_events)} usage.message event(s); run "
             "'ocw-meter report --reconcile' for model別 coverage against provider totals"
         )
         price_table_summary = ", ".join(sorted(price_versions)) if price_versions else "(none applied)"
+        # 孫3プロンプト §3: a table that only took effect AFTER the
+        # message it was applied to must not be silently indistinguishable
+        # from a table that genuinely covered that message's date.
+        if fallback_count:
+            price_table_summary += (
+                f"; {fallback_count} event(s) priced with a table that took effect AFTER their own "
+                "message date (fallback to the earliest available table — treat as a rough estimate, "
+                "not the period's real pricing)"
+            )
         cost_basis_summary = ", ".join(sorted(cost_bases)) if cost_bases else "(none)"
         cost_estimate_summary = f"${cost_sum:.2f} (estimated — not an invoice)" if has_cost else "null"
     else:
@@ -1620,6 +1651,7 @@ def usage_cost_footer(usage_events):
         "price_table": price_table_summary,
         "cost_basis": cost_basis_summary,
         "cost_estimate_usd": cost_estimate_summary,
+        "price_table_fallback_count": fallback_count,
     }
 
 
@@ -2173,6 +2205,71 @@ def report_month_process_efficiency(valid_events, month, repo):
     }
 
 
+def _price_tables_applied_for_month(usage_month):
+    """孫3プロンプト §3: which `price_table_version`(s) actually priced
+    this month's usage.message events, and how many of THOSE specific
+    events were a fallback — `_price_table_predates_message`'s same
+    per-event, day-granularity check `usage_cost_footer` already uses,
+    not a month-granularity comparison. Takes only the month's own
+    events (round-2 review finding 9: an earlier version also took
+    `month` as a second argument, but the per-event check needs no
+    month boundary at all — every date comparison it makes is against
+    that SAME event's own `ts`/`price_effective_date`, never against the
+    reported month string. `month` had become a dead parameter, kept
+    only because a docstring described it; the caller,
+    `report_month_cash_and_capacity`, already pre-filters `usage_month`
+    to the target month before calling this).
+
+    Round-1 review finding 2: an earlier version compared
+    `effective_date[:7] > month` (month-granularity), which MISSES a
+    same-month fallback — a table whose `effective_date` falls later in
+    the SAME month as a message it was applied to (e.g. table effective
+    2026-08-15, message 2026-08-05, `--month 2026-08`) is a genuine
+    罠5 fallback (`select_price_table` had nothing else to pick from) but
+    `"2026-08" > "2026-08"` is False, so this function said "no
+    fallback" in the same breath `usage_cost_footer`'s day-granularity
+    check said "1 event fell back" — two contradictory answers about the
+    same underlying fact, printed side by side in the same `--month`
+    output. Reusing the per-event check here removes that contradiction
+    by construction: both are now the same predicate applied to the same
+    stored fields, just aggregated differently (per version vs. summed
+    across all versions).
+
+    Round-2 review finding 8: per-event granularity also means a single
+    version can price a MIX of fallback and correctly-covered events
+    within the same month (e.g. a table effective mid-month covers the
+    back half correctly but was fallback-applied to the front half) —
+    `fallback_event_count` (out of this version's own `event_count`)
+    lets a caller distinguish "this whole month's worth of this version
+    is a rough estimate" from "only part of it is", instead of one
+    boolean forced to describe a mixed month either way.
+
+    Sorted by version for a stable, deterministic order."""
+    seen = {}
+    for e in usage_month:
+        version = e.get("price_table_version")
+        if not version:
+            continue
+        entry = seen.setdefault(version, {
+            "effective_date": e.get("price_effective_date"),
+            "event_count": 0,
+            "fallback_event_count": 0,
+        })
+        entry["event_count"] += 1
+        if _price_table_predates_message(e):
+            entry["fallback_event_count"] += 1
+    applied = []
+    for version, info in sorted(seen.items()):
+        applied.append({
+            "price_table_version": version,
+            "effective_date": info["effective_date"],
+            "event_count": info["event_count"],
+            "fallback_event_count": info["fallback_event_count"],
+            "is_fallback": info["fallback_event_count"] > 0,
+        })
+    return applied
+
+
 def report_month_cash_and_capacity(valid_events, month):
     """孫5 §1 --month: cash cost (metered API — currently only DeepSeek,
     `cost_basis: "estimated"`) and capacity (Claude subscription quota
@@ -2207,6 +2304,7 @@ def report_month_cash_and_capacity(valid_events, month):
     return {
         "usage_message_count": len(usage_month),
         "cash_cost_usd": cash_cost if has_cash else None,
+        "price_tables_applied": _price_tables_applied_for_month(usage_month),
         "capacity_message_count": capacity_message_count,
         "quota_sample_count": len(quota_month),
         "five_hour_used_pct_max": max(five_hour_vals) if five_hour_vals else None,
@@ -2808,6 +2906,7 @@ def _report_month_standalone(paths, valid_events, malformed, month, repo, as_jso
     summary["cash_cost"] = {
         "usage_message_count": cash_and_capacity["usage_message_count"],
         "cash_cost_usd": cash_and_capacity["cash_cost_usd"],
+        "price_tables_applied": cash_and_capacity["price_tables_applied"],
     }
     summary["capacity"] = {
         "capacity_message_count": cash_and_capacity["capacity_message_count"],
@@ -2827,6 +2926,27 @@ def _report_month_standalone(paths, valid_events, malformed, month, repo, as_jso
     cash_str = f"${summary['cash_cost']['cash_cost_usd']:.2f}" if isinstance(summary["cash_cost"]["cash_cost_usd"], (int, float)) else "null"
     print(f"  usage.message count: {summary['cash_cost']['usage_message_count']}")
     print(f"  cash_cost_usd:       {cash_str} (estimated — not an invoice)")
+    price_tables_applied = summary["cash_cost"]["price_tables_applied"]
+    if price_tables_applied:
+        print("  price_tables_applied:")
+        for pt in price_tables_applied:
+            # Round-2 review finding 8: `is_fallback` is per-EVENT, not
+            # per-month — a version can price a mix of fallback and
+            # correctly-covered events within the same month (e.g. its
+            # own effective_date falls mid-month). The count out of
+            # event_count says exactly how much of this version's usage
+            # this month was a fallback, instead of one boolean forced
+            # to describe a mixed month either way.
+            fallback_n, total_n = pt["fallback_event_count"], pt["event_count"]
+            if fallback_n == 0:
+                marker = ""
+            elif fallback_n == total_n:
+                marker = f" (フォールバック — この期間の{total_n}件全てが、まだ発効していなかった価格表。実際の単価とは異なる可能性)"
+            else:
+                marker = f" (フォールバック — この期間の{total_n}件中{fallback_n}件が、まだ発効していなかった価格表。実際の単価とは異なる可能性)"
+            print(f"    {pt['price_table_version']} (effective {pt['effective_date']}){marker}")
+    else:
+        print("  price_tables_applied: (none)")
     print("capacity cost (Claude subscription quota — never summed with cash cost):")
     for field, value in summary["capacity"].items():
         print(f"  {field}: {value}")
@@ -2918,34 +3038,279 @@ def select_price_table(tables, at_date_str):
     """Picks the table with the latest effective_date <= at_date_str
     (plan §5.5). Falls back to the earliest available table if every
     table's effective_date is in the future relative to at_date_str —
-    a conservative choice, never a crash, and this situation shouldn't
-    arise in practice since price files are only added once effective."""
+    a conservative choice, never a crash. This IS expected to happen in
+    practice for any message that predates the very first price table
+    ever added (計画書 DOC-2608081456 罠5 — e.g. 6〜7月 messages against
+    the sole 2026-08-01 table); callers must not assume "applicable" here
+    means "actually covers this date" (see `usage_cost_footer`'s
+    fallback-count logic, which re-derives this same fallback purely
+    from what got stored on the event — `price_effective_date` >
+    the message's own date)."""
     applicable = [t for t in tables if (t.get("effective_date") or "") <= at_date_str]
     if applicable:
         return applicable[-1]
     return tables[0] if tables else None
 
 
-def compute_cost(model, usage_fields, price_table):
+# ── time-of-day (peak/off-peak) pricing (計画書 DOC-2608081456孫3) ─────
+#
+# A price table MAY carry an optional `time_of_day_pricing` block on top
+# of its base `models` prices:
+#
+#   "time_of_day_pricing": {
+#     "tz_offset": "+08:00",
+#     "tz_label": "Beijing time (China Standard Time, UTC+8, no DST)",
+#     "boundary": "start_inclusive_end_exclusive",
+#     "windows": [
+#       {"start": "09:00", "end": "12:00", "models": {"deepseek-v4-pro": {...}}},
+#       {"start": "14:00", "end": "18:00", "models": {"deepseek-v4-pro": {...}}}
+#     ]
+#   }
+#
+# Design decisions (孫3プロンプト §1, each picked because the alternative
+# was measurably worse for THIS table's actual use case — DeepSeek's own
+# announced peak/off-peak windows):
+#
+# - **Fixed UTC offset, not a tz database name.** `zoneinfo` needs
+#   tzdata, which isn't guaranteed present everywhere this script runs.
+#   China has no DST, so "Beijing time" IS a fixed +08:00 offset with no
+#   edge cases to get wrong — a fixed-offset implementation loses nothing
+#   here while working with zero extra dependencies. The offset lives on
+#   the price table (never hardcoded in this file), so a future table
+#   covering a DST-observing region only needs a schema-compatible entry,
+#   not a code change (a hardcoded "+08:00" would silently mis-price such
+#   a table).
+# - **Start-inclusive, end-exclusive, and NOT configurable per table.**
+#   Matches this file's own existing convention for date ranges
+#   (`select_price_table`'s `effective_date <= at_date_str`) and avoids a
+#   message landing on both a matched and an unmatched window if two
+#   windows were ever defined back-to-back (`"end": "12:00"` followed by
+#   `"start": "12:00"`). The optional `boundary` field in a price table
+#   exists purely as a machine-checkable ASSERTION of this fixed
+#   convention (`_time_of_day_spec` rejects the whole block — same as a
+#   missing `tz_offset` — if a table's `boundary` disagrees with it), NOT
+#   as a way to configure a different boundary rule; this file has never
+#   implemented anything else.
+# - **Per-window basis labels are intentionally NOT part of this schema
+#   (round-1 review finding 4).** A window matching could mean either
+#   "this is the expensive peak period" or "this is the discounted
+#   off-peak period" depending on the provider's own pricing model —
+#   nothing here can know which without being told, and `time_of_day_
+#   basis` is baked into every stored `usage.message` event (this
+#   file's own "past isn't recalculated" invariant), so a wrong
+#   assumption can't be fixed later by adding a label after the fact.
+#   `time_of_day_basis` therefore uses basis-neutral values —
+#   `"in_window"` / `"base_rate"` — that describe MECHANISM (did a
+#   window match or not), never PRICE DIRECTION (which one costs more).
+# - **No cross-midnight windows.** A window with `start >= end` (e.g. an
+#   attempted `22:00`-`02:00`) is simply never matched — this is a
+#   DELIBERATE LIMITATION, not a bug: DeepSeek's own announced windows
+#   (`09:00-12:00`, `14:00-18:00`) never cross midnight, and getting
+#   wrap-around wrong (silently) is worse than not supporting it at all
+#   (see `bin/prices/README.md`, which documents this limitation for
+#   whoever adds the next price table).
+# - **Per-window explicit prices, not a multiplier.** DeepSeek's own
+#   notice ("2x pricing") doesn't say which side of the pair the 2x
+#   applies TO — writing the window's own `cache_hit_in`/`cache_miss_in`/
+#   `out` directly (mirroring the base `models` block's own shape) is
+#   unambiguous and traceable straight back to the source, exactly like
+#   the base table already is. A multiplier would require deciding
+#   "multiply against what baseline" as an extra, unstated rule.
+# - **A model absent from every window is simply not part of the
+#   time-of-day scheme** — its price is always the base `models` entry,
+#   time never enters into it (`time_of_day_basis: "not_applicable"`).
+#   This lets one table cover some models with time-of-day pricing and
+#   others without, without a separate opt-out flag.
+# - **A `time_of_day_pricing` block that IS present but unusable (bad
+#   `tz_offset`, non-list `windows`, disagreeing `boundary`, ...) is
+#   never silently indistinguishable from "no time-of-day pricing was
+#   ever intended" (round-1 review finding 3) — same underlying failure
+#   mode this whole PR exists to stop (計画書 罠5: an out-of-range
+#   period silently priced at the wrong rate). The ingest loop below
+#   emits a `meter.error` diagnostic (already surfaced in `report`'s
+#   footer) the first time it sees a table like this, in addition to
+#   `_select_prices_for_model` still falling back to base pricing rather
+#   than crashing `ingest`.
+
+def _parse_fixed_offset(offset_str):
+    """`"+08:00"` -> `timezone(timedelta(hours=8))`. Returns None for
+    anything else (missing, malformed, tz database name, or an
+    hour/minute magnitude `timezone()` itself rejects) — callers treat
+    that as "this table's time_of_day_pricing is unusable", never as a
+    reason to crash `ingest` (plan §5.5's "malformed price data is
+    skipped, not fatal" extended to this sub-block).
+
+    Round-1 review finding 1: `timezone()` raises `ValueError` for an
+    offset magnitude >= 24h, and NOTHING between here and `ingest`'s own
+    top-level loop over `build_usage_event()` catches that — an
+    unvalidated `"+25:00"` in a price table used to take down the WHOLE
+    `ingest` run (rc=1, zero events written, unrelated messages included)
+    instead of just this one table being treated as unusable. Range-
+    checking `hh`/`mm` here (same convention as `_parse_hhmm_to_minutes`)
+    keeps every value this function ever hands to `timezone()` inside
+    the range it accepts; the `try`/`except` below is defense in depth
+    for that invariant, not a substitute for the range check (a looser
+    regex in the future must not reopen the same hole)."""
+    if not isinstance(offset_str, str):
+        return None
+    m = re.match(r"^([+-])(\d{2}):(\d{2})$", offset_str)
+    if not m:
+        return None
+    sign, hh_str, mm_str = m.groups()
+    hh, mm = int(hh_str), int(mm_str)
+    if not (0 <= hh <= 23 and 0 <= mm <= 59):
+        return None
+    delta = timedelta(hours=hh, minutes=mm)
+    try:
+        return timezone(-delta if sign == "-" else delta)
+    except ValueError:
+        return None
+
+
+def _parse_hhmm_to_minutes(value):
+    """`"09:00"` -> `540` (minutes since local midnight). None if
+    malformed or out of range."""
+    if not isinstance(value, str):
+        return None
+    m = re.match(r"^(\d{2}):(\d{2})$", value)
+    if not m:
+        return None
+    hh, mm = int(m.group(1)), int(m.group(2))
+    if not (0 <= hh <= 23 and 0 <= mm <= 59):
+        return None
+    return hh * 60 + mm
+
+
+TIME_OF_DAY_BOUNDARY = "start_inclusive_end_exclusive"
+
+
+def _time_of_day_spec(price_table):
+    """Returns `price_table["time_of_day_pricing"]` if it's present and
+    minimally well-shaped (a dict with a `windows` list, a parseable
+    fixed `tz_offset`, and — if `boundary` is present at all — a value
+    matching `TIME_OF_DAY_BOUNDARY`, the ONLY boundary rule this file
+    implements), else None. To callers, "no such block at all" and "an
+    unusably malformed one" both just mean "apply base `models` pricing,
+    unconditionally" — which is exactly backward compatibility with
+    every price table that predates this feature (孫3プロンプト §1:
+    後方互換が絶対条件). What distinguishes the two cases from a
+    diagnostics standpoint is handled by the caller in the `ingest` loop
+    (round-1 review finding 3), not here — this function stays a pure
+    predicate.
+
+    Round-1 review finding 5: `boundary` used to be accepted into a
+    sample price table and this file's own design-decision comment
+    without ever being read — a table author could write
+    `"start_exclusive_end_inclusive"` and it would be silently ignored
+    in favor of the actual (opposite) hardcoded rule. Validating it here
+    turns that from a silent lie into "this table's time_of_day_pricing
+    is unusable", exactly like a bad `tz_offset`."""
+    spec = price_table.get("time_of_day_pricing")
+    if not isinstance(spec, dict):
+        return None
+    if not isinstance(spec.get("windows"), list):
+        return None
+    if _parse_fixed_offset(spec.get("tz_offset")) is None:
+        return None
+    boundary = spec.get("boundary", TIME_OF_DAY_BOUNDARY)
+    if boundary != TIME_OF_DAY_BOUNDARY:
+        return None
+    return spec
+
+
+def _time_of_day_pricing_present_but_unusable(price_table):
+    """True when a price table author clearly INTENDED time-of-day
+    pricing (the `time_of_day_pricing` key is there) but got the shape
+    wrong, as opposed to a table that simply predates this feature (key
+    absent entirely). Used only by the `ingest` loop to decide whether
+    to emit a `meter.error` diagnostic (round-1 review finding 3) — never
+    by cost computation itself, which treats both cases identically via
+    `_time_of_day_spec` returning None either way."""
+    return price_table.get("time_of_day_pricing") is not None and _time_of_day_spec(price_table) is None
+
+
+def _select_prices_for_model(price_table, model, ts_dt):
+    """Resolves which per-1M-token prices apply to this one message:
+    base `models` prices, or a matching time-of-day window's override.
+    Returns (prices_dict_or_None, time_of_day_basis) where
+    time_of_day_basis is one of:
+      - "not_applicable": no usable time_of_day_pricing block, OR this
+        model never appears in any of its windows (i.e. this model isn't
+        part of the time-of-day scheme at all)
+      - "unknown_timestamp": the model IS part of the scheme, but this
+        message's own timestamp couldn't be parsed — falls back to base
+        `models` pricing rather than guessing which basis applies
+        (計画書「推測で埋めない」原則). This is the "時刻が取れない
+        メッセージ" fallback 孫3プロンプト §2 requires deciding on.
+      - "in_window": timestamp fell inside a window that prices this
+        model — that window's prices are used. Deliberately NOT named
+        "peak": whether a matched window is the expensive period or a
+        discount period is a provider-specific pricing decision this
+        schema doesn't (and, per the design-decision comment above,
+        can't safely) encode (round-1 review finding 4)
+      - "base_rate": the model is part of the scheme and the timestamp
+        resolved fine, but fell outside every window — base `models`
+        pricing is used
+    Never raises: any malformed window is treated as never matching."""
+    base_prices = price_table.get("models", {}).get(model)
+    spec = _time_of_day_spec(price_table)
+    if spec is None:
+        return base_prices, "not_applicable"
+
+    windows = [w for w in spec["windows"] if isinstance(w, dict)]
+    model_in_scheme = any(isinstance(w.get("models"), dict) and model in w["models"] for w in windows)
+    if not model_in_scheme:
+        return base_prices, "not_applicable"
+
+    if ts_dt is None:
+        return base_prices, "unknown_timestamp"
+
+    tz = _parse_fixed_offset(spec["tz_offset"])
+    local_dt = ts_dt.astimezone(tz)
+    local_minutes = local_dt.hour * 60 + local_dt.minute
+    for window in windows:
+        window_models = window.get("models")
+        if not isinstance(window_models, dict) or model not in window_models:
+            continue
+        start = _parse_hhmm_to_minutes(window.get("start"))
+        end = _parse_hhmm_to_minutes(window.get("end"))
+        if start is None or end is None or start >= end:
+            continue  # malformed or cross-midnight window: never matches
+        if start <= local_minutes < end:
+            return window_models[model], "in_window"
+
+    return base_prices, "base_rate"
+
+
+def compute_cost(model, usage_fields, price_table, ts_dt=None):
     """plan §8.4 cost formula, with the 孫3-prompt override that
     Anthropic (`claude-*`) usage is never converted from a subscription
     into a per-token estimate (cost_basis: "subscription",
     cost_estimate_usd: null — a flat-rate plan has no meaningful
-    per-message price). Returns (cost_estimate_usd, price_table_version,
-    price_effective_date, cost_basis). Never raises."""
-    provider = infer_provider(model)
-    if provider == "anthropic":
-        return None, None, None, "subscription"
+    per-message price). `ts_dt` (a timezone-aware datetime, or None if
+    unavailable) is the message's own timestamp, used only for
+    time-of-day price resolution (see `_select_prices_for_model`) — it
+    does not affect WHICH price table is chosen (that's already decided
+    by the caller via `select_price_table` before this is called).
+    Returns (cost_estimate_usd, price_table_version, price_effective_date,
+    cost_basis, time_of_day_basis). Never raises."""
+    if infer_provider(model) == "anthropic":
+        return None, None, None, "subscription", None
 
     if price_table is None:
-        return None, None, None, "estimated"
+        return None, None, None, "estimated", None
 
-    prices = price_table.get("models", {}).get(model)
+    version = price_table.get("price_table_version")
+    effective = price_table.get("effective_date")
+    prices, time_of_day_basis = _select_prices_for_model(price_table, model, ts_dt)
     if not isinstance(prices, dict):
-        # Includes deepseek-v4-flash (plan §5.10: 0% transcript coverage,
-        # so this branch is mostly theoretical today) and any future/
-        # unrecognized model name — never guess a price.
-        return None, price_table.get("price_table_version"), price_table.get("effective_date"), "estimated"
+        # A model name the applicable price table's `models` block
+        # simply doesn't have an entry for (round-1 review finding 7:
+        # this is NOT deepseek-v4-flash — bin/prices/deepseek-2026-08-01.json
+        # prices it — it's any genuinely unrecognized/future model name,
+        # e.g. a DeepSeek-shaped name that never shipped) — never guess a
+        # price for it.
+        return None, version, effective, "estimated", time_of_day_basis
 
     values = (
         usage_fields.get("cache_read_input_tokens"),
@@ -2954,7 +3319,7 @@ def compute_cost(model, usage_fields, price_table):
         usage_fields.get("output_tokens"),
     )
     if any(not isinstance(v, (int, float)) for v in values):
-        return None, price_table.get("price_table_version"), price_table.get("effective_date"), "estimated"
+        return None, version, effective, "estimated", time_of_day_basis
 
     cache_read, input_tokens, cache_creation, output_tokens = values
     try:
@@ -2964,9 +3329,9 @@ def compute_cost(model, usage_fields, price_table):
             + output_tokens * prices["out"]
         ) / 1_000_000
     except (KeyError, TypeError):
-        return None, price_table.get("price_table_version"), price_table.get("effective_date"), "estimated"
+        return None, version, effective, "estimated", time_of_day_basis
 
-    return cost, price_table.get("price_table_version"), price_table.get("effective_date"), "estimated"
+    return cost, version, effective, "estimated", time_of_day_basis
 
 
 # ── ingest cursor (incremental, idempotent transcript reading) ────────
@@ -3401,7 +3766,7 @@ def build_usage_event(candidate, price_tables, today_str, role_map, binds, run_s
     # §5.5 forbids; it's picking the WRONG table on first write).
     price_date_str = ts_dt.strftime("%Y-%m-%d") if ts_dt is not None else today_str
     price_table = select_price_table(price_tables, price_date_str)
-    cost_estimate, price_version, price_effective, cost_basis = compute_cost(
+    cost_estimate, price_version, price_effective, cost_basis, time_of_day_basis = compute_cost(
         model,
         {
             "input_tokens": input_tokens,
@@ -3410,6 +3775,7 @@ def build_usage_event(candidate, price_tables, today_str, role_map, binds, run_s
             "output_tokens": output_tokens,
         },
         price_table,
+        ts_dt,
     )
 
     session_id = candidate["session_id"]
@@ -3496,6 +3862,7 @@ def build_usage_event(candidate, price_tables, today_str, role_map, binds, run_s
         "price_table_version": price_version,
         "price_effective_date": price_effective,
         "cost_basis": cost_basis,
+        "time_of_day_basis": time_of_day_basis,
         "currency": "USD" if cost_basis != "subscription" else None,
     }
     for key in list(event.keys()):
@@ -3732,6 +4099,13 @@ def perform_ingest(root, since_dt=None):
     role_map = resolve_herdr_role_map()
     binds, run_starts = load_local_pr_binds_and_run_starts(paths)
     price_tables = load_price_tables(price_table_dir())
+    # Round-1 review finding 3: a `time_of_day_pricing` block that's
+    # PRESENT but unusable must not look identical to "this table simply
+    # predates the feature" — `emit_meter_error` dedupes by (stage, day),
+    # so this only ever adds at most one line per day regardless of how
+    # many tables or how many messages are priced against them this run.
+    if any(_time_of_day_pricing_present_but_unusable(t) for t in price_tables):
+        emit_meter_error(paths.root, "price_table_time_of_day_pricing_unusable", None)
     today_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     gh_cache, run_id_cache, repo_cache = {}, {}, {}
 

--- a/bin/ocw-meter
+++ b/bin/ocw-meter
@@ -26,13 +26,13 @@ usage:
   ocw-meter snapshot-quota
   ocw-meter prune-diagnostics [--older-than <days>] [--apply]
   ocw-meter validate [--file <path>]
-  ocw-meter report [--pr <n>] [--repo <owner>/<name>] [--json]
-  ocw-meter report --phase [--pr <n>] [--repo <owner>/<name>] [--json]
-  ocw-meter report --model [--pr <n>] [--repo <owner>/<name>] [--json]
-  ocw-meter report --role [--pr <n>] [--repo <owner>/<name>] [--json]
-  ocw-meter report --window [--pr <n>] [--repo <owner>/<name>] [--json]
-  ocw-meter report --month [YYYY-MM] [--repo <owner>/<name>] [--json]
-  ocw-meter report --reconcile [--month <YYYY-MM>] [--provider-total <model>=<tokens> ...] [--json]
+  ocw-meter report [--pr <n>] [--repo <owner>/<name>] [--no-ingest] [--json]
+  ocw-meter report --phase [--pr <n>] [--repo <owner>/<name>] [--no-ingest] [--json]
+  ocw-meter report --model [--pr <n>] [--repo <owner>/<name>] [--no-ingest] [--json]
+  ocw-meter report --role [--pr <n>] [--repo <owner>/<name>] [--no-ingest] [--json]
+  ocw-meter report --window [--pr <n>] [--repo <owner>/<name>] [--no-ingest] [--json]
+  ocw-meter report --month [YYYY-MM] [--repo <owner>/<name>] [--no-ingest] [--json]
+  ocw-meter report --reconcile [--month <YYYY-MM>] [--provider-total <model>=<tokens> ...] [--no-ingest] [--json]
   ocw-meter help
 
 subcommands:
@@ -84,12 +84,24 @@ subcommands:
     non-zero on unexpected failure.
 
   report
-    Prints an event-count / completeness / coverage summary, including
-    total estimated cost and which price_table_version(s)/cost_basis
-    were applied once usage.message events exist. With `--pr <n>`, also
-    prints review-round/human-intervention/final-result/cash-cost
-    detail for that one PR and its same-5-hour-window-completion
-    verdict (孫5).
+    Runs `ingest` automatically before reading stored events (every
+    view below does this, at the very top of `report` — 計画書
+    DOC-2608081456孫2), so a `report` right after Claude Code activity
+    doesn't need a manual `ocw-meter ingest` first. An ingest failure
+    (including refusing to run inside a Git worktree) never aborts
+    `report` itself — it's shown as a footer line and `report` still
+    serves whatever was already stored. `--no-ingest` skips the
+    automatic run entirely (read-only use, or when you want to control
+    exactly what `report` sees). The footer also always includes the
+    last successful ingest's timestamp, this run's own ingest outcome,
+    and a staleness warning once that timestamp is 24h old or older.
+
+    Otherwise prints an event-count / completeness / coverage summary,
+    including total estimated cost and which price_table_version(s)/
+    cost_basis were applied once usage.message events exist. With
+    `--pr <n>`, also prints review-round/human-intervention/final-
+    result/cash-cost detail for that one PR and its same-5-hour-
+    window-completion verdict (孫5).
 
   report --phase / --model / --role / --window
     Grouped breakdowns (孫5), each combinable with `--pr <n>` to scope
@@ -1474,7 +1486,9 @@ def cmd_validate(args):
 def iter_stored_events(paths):
     """Yield (event_or_None, raw_line, error_or_None) for every stored
     line. Malformed lines are reported here, not moved — moving them is
-    `validate`'s job, so `report` stays read-only.
+    `validate`'s job, so iterating the store never mutates it (unlike
+    `report` as a whole since 計画書 DOC-2608081456孫2, which now writes
+    via its automatic `ingest` call BEFORE this iteration ever starts).
 
     Uses `hard_line_errors` only, not `payload_shape_issues`: a payload
     shape issue is advisory (see `payload_shape_issues`'s docstring), so
@@ -1585,7 +1599,19 @@ def usage_cost_footer(usage_events):
         cost_basis_summary = ", ".join(sorted(cost_bases)) if cost_bases else "(none)"
         cost_estimate_summary = f"${cost_sum:.2f} (estimated — not an invoice)" if has_cost else "null"
     else:
-        coverage = "no usage.message events yet — run 'ocw-meter ingest'"
+        # PR #57 review round 1 finding 1 / round 2 finding "新規2": this
+        # used to say "run 'ocw-meter ingest'", which contradicted the
+        # freshness footer a few lines below once `report` started
+        # auto-ingesting (round 1) — and a version that instead asserted
+        # ingest "already ran automatically" (round 1's own fix)
+        # contradicted the SAME footer line in the other direction under
+        # `--no-ingest`, where it deliberately didn't run. This function
+        # has no way to know which case it's in (it isn't passed
+        # `ingest_run`/`footer_freshness`), so it now says neither —
+        # whether ingest ran this time is `ingest_freshness_footer`'s
+        # `ingest (this run):` line's job alone, not duplicated (and
+        # therefore contradictable) here.
+        coverage = "no usage.message events found in transcripts"
         price_table_summary = "not applicable (no cost data ingested yet)"
         cost_basis_summary = "not applicable (no cost data ingested yet)"
         cost_estimate_summary = "null"
@@ -1613,7 +1639,97 @@ def completeness_footer(paths, scoped_events, malformed):
     }
 
 
-def print_footer_text(footer_completeness, footer_cost, total):
+def format_elapsed_seconds(seconds):
+    """`3661` -> `"1h1m"`. Coarse on purpose — this is a freshness
+    indicator for a human glancing at a footer, not a precise duration."""
+    seconds = int(seconds)
+    if seconds < 60:
+        return f"{seconds}s"
+    minutes, seconds = divmod(seconds, 60)
+    if minutes < 60:
+        return f"{minutes}m"
+    hours, minutes = divmod(minutes, 60)
+    if hours < 24:
+        return f"{hours}h{minutes}m"
+    days, hours = divmod(hours, 24)
+    return f"{days}d{hours}h"
+
+
+# 計画書 DOC-2608081456孫2 §3: how stale is too stale before `report`
+# warns about it. 24h, not shorter — the incident this whole grandchild
+# fixes (【1】) took 4 DAYS of silence to reach an 11.4% undercount, so a
+# same-order-of-magnitude threshold (one missed day) catches drift long
+# before it compounds that far, without flagging every routine gap
+# between report runs as an emergency. Matches the existing precedent
+# for "how old is too old" in this file (QUOTA_SESSION_STATE_MAX_AGE_
+# SECONDS, also 24h).
+INGEST_STALE_THRESHOLD_SECONDS = 24 * 60 * 60
+
+
+def ingest_freshness_footer(cursor, ingest_run):
+    """The ingest-freshness portion of the plan §10.4 footer (計画書
+    DOC-2608081456孫2 §3) — see `usage_cost_footer` above for why this
+    kind of thing is factored into its own function instead of being
+    inlined per view. `cursor` is `load_ingest_cursor()`'s return value;
+    `ingest_run` is `auto_ingest_for_report()`'s. Like every other footer
+    piece in this file, the values here are pre-formatted display
+    strings shared verbatim by both the text and `--json` outputs (see
+    `usage_cost_footer`'s `cost_estimate_usd` for the same convention) —
+    not raw types for a JSON consumer to reformat.
+
+    `last_ingest_at` deliberately does NOT fall back to guessing from a
+    file mtime when the cursor predates this field (plan's "推測で埋め
+    ない" principle, §全孫共通の注意5) — an old `ingest-cursor.json`
+    reports "unknown", full stop.
+
+    `last_ingest_at` itself is a display string (see above), so a
+    machine `--json` consumer can't recover the raw timestamp from it
+    without re-parsing a human sentence — `last_ingest_at_rfc3339` (PR
+    #57 review round 1 finding 6) carries the same value `cursor` itself
+    stores, untouched, specifically for that use (e.g.
+    docs/reference/DOC-2608021229-b_...'s "transcribe report --json into
+    the writeup" workflow); it is `None` when unknown, same as any other
+    JSON consumer would expect for "no value yet"."""
+    last_ingest_raw = cursor.get("last_ingest_at")
+    last_ingest_dt = parse_ts(last_ingest_raw) if isinstance(last_ingest_raw, str) else None
+    if last_ingest_dt is None:
+        last_ingest_at = "unknown (次回 ingest で記録される)"
+        last_ingest_at_rfc3339 = None
+        freshness_warning = "(none — last ingest time unknown)"
+    else:
+        age_seconds = (datetime.now(timezone.utc) - last_ingest_dt).total_seconds()
+        last_ingest_at = f"{last_ingest_raw} ({format_elapsed_seconds(age_seconds)} 経過)"
+        last_ingest_at_rfc3339 = last_ingest_raw
+        # PR #57 review round 1 finding 4: the plan's own wording
+        # ("一定時間以上経っていたら") is inclusive ("以上" = "at or
+        # above"), so a sample landing on the threshold exactly (rare,
+        # but real once ingest runs on a fixed schedule) still warns —
+        # `>=`, not `>`.
+        freshness_warning = (
+            f"最終ingestから{format_elapsed_seconds(age_seconds)}経過しています"
+            f"（閾値 {INGEST_STALE_THRESHOLD_SECONDS // 3600}h）。"
+            "自動ingestが失敗し続けていないか確認してください"
+            if age_seconds >= INGEST_STALE_THRESHOLD_SECONDS else "(none)"
+        )
+
+    status = ingest_run["status"]
+    if status == "ran":
+        stats = ingest_run["stats"]
+        ingest_this_run = f"ran (written={stats['written']}, replaced={stats['replaced']})"
+    elif status == "skipped":
+        ingest_this_run = "skipped (--no-ingest)"
+    else:
+        ingest_this_run = f"failed: {ingest_run['error']}"
+
+    return {
+        "last_ingest_at": last_ingest_at,
+        "last_ingest_at_rfc3339": last_ingest_at_rfc3339,
+        "ingest_this_run": ingest_this_run,
+        "ingest_freshness_warning": freshness_warning,
+    }
+
+
+def print_footer_text(footer_completeness, footer_cost, footer_freshness, total):
     def pct(n):
         return (100.0 * n / total) if total else 0.0
 
@@ -1632,6 +1748,10 @@ def print_footer_text(footer_completeness, footer_cost, total):
     print(f"price_table:   {footer_cost['price_table']}")
     print(f"cost_basis:    {footer_cost['cost_basis']}")
     print(f"cost_estimate: {footer_cost['cost_estimate_usd']}")
+    print(f"last_ingest_at: {footer_freshness['last_ingest_at']}")
+    print(f"last_ingest_at_rfc3339: {footer_freshness['last_ingest_at_rfc3339'] or 'unknown'}")
+    print(f"ingest (this run): {footer_freshness['ingest_this_run']}")
+    print(f"ingest_freshness_warning: {footer_freshness['ingest_freshness_warning']}")
 
 
 def events_for_pr(valid_events, pr_number, repo):
@@ -2095,7 +2215,7 @@ def report_month_cash_and_capacity(valid_events, month):
     }
 
 
-def _report_reconcile(paths, month, provider_totals, as_json):
+def _report_reconcile(paths, month, provider_totals, as_json, footer_freshness):
     """`ocw-meter report --reconcile` (孫3 §3): model別のtranscript由来
     トークン合計・推定費用を出し、`--provider-total model=tokens` で
     人間が渡した管理画面値との coverage 比率を計算する。plan §5.10 /
@@ -2182,7 +2302,11 @@ def _report_reconcile(paths, month, provider_totals, as_json):
     coverage_text = (
         f"{total_messages} usage.message event(s) for {month}; per-model coverage_ratio requires "
         "--provider-total <model>=<tokens>"
-        if total_messages else f"no usage.message events for {month} — run 'ocw-meter ingest' first"
+        # PR #57 review round 1 finding 1 / round 2 finding "新規2": see
+        # usage_cost_footer's comment above — same reasoning, this
+        # function has no way to know whether this run's ingest actually
+        # ran (--no-ingest), so it doesn't claim either way.
+        if total_messages else f"no usage.message events found in transcripts for {month}"
     )
 
     summary = {
@@ -2205,6 +2329,7 @@ def _report_reconcile(paths, month, provider_totals, as_json):
             "（計画書17章 R8）"
         ),
         "models": models_out,
+        **footer_freshness,
     }
 
     if as_json:
@@ -2214,7 +2339,7 @@ def _report_reconcile(paths, month, provider_totals, as_json):
     print(f"month:         {summary['month']}")
     print(f"cost_basis:    {summary['cost_basis']}")
     if not models_out:
-        print("models:        (no usage.message events for this month — run 'ocw-meter ingest' first)")
+        print("models:        (no usage.message events found in transcripts for this month)")
     for model, m in sorted(models_out.items()):
         print(f"  {model}:")
         print(f"    messages:             {m['messages']}")
@@ -2247,6 +2372,7 @@ def _report_reconcile(paths, month, provider_totals, as_json):
                 if any(m["cost_estimate_usd"] is not None for m in models_out.values()) else "null"
             ),
         },
+        footer_freshness,
         total_messages,
     )
     print(f"known_gaps:    {summary['known_gaps']}")
@@ -2297,12 +2423,15 @@ def pr_five_hour_window_completion(pr_events, all_events):
     return ("yes" if len(distinct) == 1 else "no"), distinct
 
 
-def _print_grouped_report(title, group_label, groups, as_json, storage_root_str, footer_completeness, footer_cost, total, extra_top=None):
+def _print_grouped_report(title, group_label, groups, as_json, storage_root_str, footer_completeness, footer_cost, footer_freshness, total, extra_top=None):
     """Shared text/JSON printer for the --model/--role/--phase/--window
     grouped views (孫5 §1): each is "a dict of rows keyed by group name"
     plus the mandatory plan §10.4 footer, so one function renders all of
     them instead of four near-identical print blocks."""
-    summary = {"storage_root": storage_root_str, group_label: groups, **(extra_top or {}), **footer_completeness, **footer_cost}
+    summary = {
+        "storage_root": storage_root_str, group_label: groups, **(extra_top or {}),
+        **footer_completeness, **footer_cost, **footer_freshness,
+    }
     if as_json:
         print(json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True))
         return 0
@@ -2325,8 +2454,38 @@ def _print_grouped_report(title, group_label, groups, as_json, storage_root_str,
             if field == "cost_estimate_usd":
                 value = f"${value:.4f}" if isinstance(value, (int, float)) else "null"
             print(f"    {field}: {value}")
-    print_footer_text(footer_completeness, footer_cost, total)
+    print_footer_text(footer_completeness, footer_cost, footer_freshness, total)
     return 0
+
+
+def auto_ingest_for_report(root, no_ingest):
+    """`report`'s automatic ingest (計画書 DOC-2608081456孫2 §1):
+    DOC-2608021229-a:440 always documented `report` as auto-triggering
+    `ingest`, but `cmd_report` never actually called it, so the last 4
+    days of transcripts (11.4% of all events) silently vanished from
+    every view. Called once at the very top of `cmd_report`, before any
+    view reads stored events, so every view (default / --phase / --model
+    / --role / --window / --month / --reconcile) sees the same freshly-
+    ingested data — missing even one view here would make that one view
+    silently see stale data while the others didn't.
+
+    Never raises: an ingest failure — including the exact same git-
+    worktree refusal `ingest` itself can hit (`perform_ingest` returns
+    `ok: False` for it, not an exception) — must never stop `report`
+    from showing whatever is already in the store; both funnel through
+    the same `{"status": "failed", "error": ...}` shape here so no
+    caller needs a special case for "which kind of failure was it".
+    `--no-ingest` (read-only use, and tests that want to control what
+    `report` sees) skips the call entirely."""
+    if no_ingest:
+        return {"status": "skipped"}
+    try:
+        result = perform_ingest(root)
+    except Exception as exc:  # ingest must never crash `report` (see docstring)
+        return {"status": "failed", "error": redact_text(f"{type(exc).__name__}: {exc}")}
+    if not result["ok"]:
+        return {"status": "failed", "error": result["error"]}
+    return {"status": "ran", "stats": result}
 
 
 def cmd_report(args):
@@ -2338,6 +2497,7 @@ def cmd_report(args):
     view = None
     explicit_repo = None
     provider_totals = {}
+    no_ingest = False
     i = 0
     while i < len(args):
         token = args[i]
@@ -2372,6 +2532,9 @@ def cmd_report(args):
             i += 1
         elif token == "--reconcile":
             reconcile = True
+            i += 1
+        elif token == "--no-ingest":
+            no_ingest = True
             i += 1
         elif token in ("--phase", "--model", "--role", "--window"):
             if view is not None and view != token[2:]:
@@ -2435,38 +2598,43 @@ def cmd_report(args):
         print("error: --repo has no effect without --pr, --window, or standalone --month — it only scopes PR attribution", file=sys.stderr)
         return 1
 
-    root = storage_root()
-    if in_git_worktree(root):
-        print(f"error: OCW_METER_HOME ({root}) resolves inside a Git worktree; refusing to operate", file=sys.stderr)
-        return 1
-    paths = ensure_storage(root)
-
-    if reconcile:
-        month, err = normalize_month_arg(month)
-        if err:
-            print(err, file=sys.stderr)
-            return 1
-        return _report_reconcile(paths, month, provider_totals, as_json)
-
+    # PR #57 review round 1 finding 7: both the repo resolution below and
+    # the --month validation that follows it used to run AFTER the
+    # auto-ingest call — a request that was always going to fail loud
+    # (a malformed --month, or no resolvable repo) still ran a whole
+    # live ingest (writing events/cursor) first. All pure input/context
+    # validation now happens before `root`/`paths` are even touched.
+    #
     # Round-2 review finding 10 (regression introduced by round-1's own
     # fix for finding 1): `events_for_pr`'s repo scoping only works if a
-    # repo is actually resolved. `report` is a read-only command that
-    # can be run from ANYWHERE (unlike `event`, which is only ever
-    # called from inside a worktree by `ocw`/`pr-review-loop`) — running
-    # it from outside any git repo makes `git_repo_slug()` return None,
-    # and `e.get("repo") == None` then matches every repo:null event
-    # (exactly the class of event `events_for_pr`'s docstring promises
-    # to EXCLUDE), while every `pr.bind`/legitimate event WITH a repo
-    # set gets rejected. Measured: this flips finding 1's fix from
-    # "correct data + contamination" to "contamination only, zero
-    # correct events" when run from outside a git repo. Since resolving
-    # "which repo" is required for --pr and for --month's
-    # process_efficiency (both call `events_for_pr`), fail loud instead
-    # of silently scoping to the wrong (or no) repo. `--repo
-    # <owner>/<name>` is the escape hatch for a case where this needs to
-    # run from outside the target repo's own worktree.
+    # repo is actually resolved. `report` can be run from ANYWHERE
+    # (unlike `event`, which is only ever called from inside a worktree
+    # by `ocw`/`pr-review-loop`) — running it from outside any git repo
+    # makes `git_repo_slug()` return None, and `e.get("repo") == None`
+    # then matches every repo:null event (exactly the class of event
+    # `events_for_pr`'s docstring promises to EXCLUDE), while every
+    # `pr.bind`/legitimate event WITH a repo set gets rejected. Measured:
+    # this flips finding 1's fix from "correct data + contamination" to
+    # "contamination only, zero correct events" when run from outside a
+    # git repo. Since resolving "which repo" is required for --pr and
+    # for --month's process_efficiency (both call `events_for_pr`), fail
+    # loud instead of silently scoping to the wrong (or no) repo.
+    # `--repo <owner>/<name>` is the escape hatch for a case where this
+    # needs to run from outside the target repo's own worktree.
     repo = explicit_repo or git_repo_slug()
-    needs_repo = filter_pr is not None or (month_flag_present and view is None) or view == "window"
+    # PR #57 review round 2 finding "新規1": moving this check up (round 1
+    # finding 7, above) exposed it to standalone --reconcile for the
+    # first time — previously the `if reconcile: return
+    # _report_reconcile(...)` early-return below made this condition
+    # dead code for that path, so it never needed the `and not
+    # reconcile` its sibling `repo_is_used` (right above) already has.
+    # `_report_reconcile()` never takes a `repo` argument at all (it does
+    # a store-wide model/token reconciliation, no PR scoping), so
+    # requiring one made `report --reconcile --month ...` — a documented
+    # workflow (docs/reference/DOC-2608021229-b) — fail outside any git
+    # repo with no `--repo` escape hatch (repo_is_used's `not reconcile`
+    # rejects `--repo` too in that combination).
+    needs_repo = filter_pr is not None or (month_flag_present and view is None and not reconcile) or view == "window"
     if needs_repo and not repo:
         print(
             "error: could not resolve a repo for PR-scoped reporting (not inside a git repo with an "
@@ -2476,6 +2644,38 @@ def cmd_report(args):
         )
         return 1
 
+    if reconcile:
+        month, err = normalize_month_arg(month)
+        if err:
+            print(err, file=sys.stderr)
+            return 1
+    elif month_flag_present and view is None:
+        # 孫5 §1 --month (standalone, i.e. NOT --reconcile): cash cost /
+        # capacity cost / process efficiency, kept separate (plan §16).
+        month, err = normalize_month_arg(month)
+        if err:
+            print(err, file=sys.stderr)
+            return 1
+
+    root = storage_root()
+    if in_git_worktree(root):
+        print(f"error: OCW_METER_HOME ({root}) resolves inside a Git worktree; refusing to operate", file=sys.stderr)
+        return 1
+    paths = ensure_storage(root)
+
+    # 計画書 DOC-2608081456孫2 §1: runs BEFORE any view reads stored
+    # events (`iter_stored_events` below, and the two per-view helpers'
+    # own calls to it), so every view sees the same freshly-ingested
+    # data. `auto_ingest_for_report` never raises and never signals
+    # failure through the return code — an ingest problem only ever
+    # shows up as a footer line (`ingest_freshness_footer` below), never
+    # as `report` itself failing.
+    ingest_run = auto_ingest_for_report(root, no_ingest)
+    footer_freshness = ingest_freshness_footer(load_ingest_cursor(paths), ingest_run)
+
+    if reconcile:
+        return _report_reconcile(paths, month, provider_totals, as_json, footer_freshness)
+
     valid_events, malformed = [], 0
     for obj, _raw, error in iter_stored_events(paths):
         if error:
@@ -2484,13 +2684,7 @@ def cmd_report(args):
             valid_events.append(obj)
 
     if month_flag_present and view is None:
-        # 孫5 §1 --month (standalone, i.e. NOT --reconcile): cash cost /
-        # capacity cost / process efficiency, kept separate (plan §16).
-        month, err = normalize_month_arg(month)
-        if err:
-            print(err, file=sys.stderr)
-            return 1
-        return _report_month_standalone(paths, valid_events, malformed, month, repo, as_json)
+        return _report_month_standalone(paths, valid_events, malformed, month, repo, as_json, footer_freshness)
 
     if filter_pr is not None:
         filtered = events_for_pr(valid_events, filter_pr, repo)
@@ -2513,7 +2707,7 @@ def cmd_report(args):
             groups = report_by_window(valid_events if filter_pr is None else filtered, repo)
         return _print_grouped_report(
             f"by {view}", f"by_{view}", groups, as_json, str(paths.root),
-            footer_completeness, footer_cost, len(filtered), extra_top,
+            footer_completeness, footer_cost, footer_freshness, len(filtered), extra_top,
         )
 
     five_hour_window_completion, five_hour_window_ids_seen = (
@@ -2535,6 +2729,7 @@ def cmd_report(args):
         "by_event_type": by_type,
         **footer_completeness,
         **footer_cost,
+        **footer_freshness,
     }
     if filter_pr is not None:
         # Round-2 review finding 10: which repo `--pr` scoped to must be
@@ -2558,7 +2753,7 @@ def cmd_report(args):
         for event_type, count in sorted(by_type.items(), key=lambda kv: (kv[0] or "")):
             print(f"  {event_type or '(none)'}: {count}")
 
-        print_footer_text(footer_completeness, footer_cost, total)
+        print_footer_text(footer_completeness, footer_cost, footer_freshness, total)
         if filter_pr is not None:
             ids_str = ", ".join(five_hour_window_ids_seen) if five_hour_window_ids_seen else "(none)"
             print(f"five_hour_window_completion: {five_hour_window_completion} (window_ids seen: {ids_str})")
@@ -2579,7 +2774,7 @@ def cmd_report(args):
     return 0
 
 
-def _report_month_standalone(paths, valid_events, malformed, month, repo, as_json):
+def _report_month_standalone(paths, valid_events, malformed, month, repo, as_json, footer_freshness):
     """`ocw-meter report --month [YYYY-MM]` (孫5 §1, NOT --reconcile):
     cash cost / capacity cost / process efficiency for one UTC month,
     always kept in separate top-level keys — see
@@ -2603,6 +2798,7 @@ def _report_month_standalone(paths, valid_events, malformed, month, repo, as_jso
         "quality_guardrail": "未計測 — 第一段階では収集項目が無い（計画書16章）。この行は 'report --month' の出力にのみ現れる（他の report ビューには quality_guardrail キー自体が無い）",
         **footer_completeness,
         **footer_cost,
+        **footer_freshness,
     }
     # cash_cost/capacity are both inside report_month_cash_and_capacity's
     # dict already; split them into their own top-level keys so a reader
@@ -2643,7 +2839,7 @@ def _report_month_standalone(paths, valid_events, malformed, month, repo, as_jso
     print(f"  avg_duration_seconds: {pe['avg_duration_seconds']}")
     print(f"  five_hour_window_completion_breakdown: {pe['five_hour_window_completion_breakdown']}")
     print(f"quality_guardrail: {summary['quality_guardrail']}")
-    print_footer_text(footer_completeness, footer_cost, len(month_events))
+    print_footer_text(footer_completeness, footer_cost, footer_freshness, len(month_events))
     return 0
 
 
@@ -3434,30 +3630,34 @@ def bulk_write_events(paths, events):
 
 # ── subcommand: ingest ──────────────────────────────────────────────────
 
-def cmd_ingest(args):
-    parsed = parse_flags(args, {"--since": "since"}) if args else {}
-    since_str = parsed.get("since")
-    since_dt = None
-    if since_str:
-        since_dt = parse_ts(since_str)
-        if since_dt is None:
-            print(f"error: --since is not a valid RFC3339 timestamp: {since_str!r}", file=sys.stderr)
-            return 1
+def perform_ingest(root, since_dt=None):
+    """Core of `ingest`: scans transcripts for new `usage.message`
+    candidates, writes them, and (for a full non-`--since` run) advances
+    the cursor. Shared by `cmd_ingest` and `report`'s automatic run
+    (計画書 DOC-2608081456孫2: DOC-2608021229-a:440 documented `report`
+    as auto-triggering `ingest`, but `cmd_report` never called it —
+    4 days / 11.4% of events silently missing) so both go through
+    identical logic instead of two implementations drifting apart.
 
-    root = storage_root()
+    Returns `{"ok": True, ...stats}` on success, or `{"ok": False,
+    "error": <str>}` for the one well-understood refusal this function
+    itself detects (storage root resolves inside a Git worktree) —
+    exactly like `event`/`bind-pr`/`validate` refuse the same way.
+    Any OTHER unexpected failure is left to raise so `ocw-meter ingest`
+    itself still fails loud (main()'s existing fail-loud wrapper for
+    `ingest`); a caller that must never fail loud (report's automatic
+    run) wraps this call in its own try/except instead of relying on
+    this function to swallow everything itself."""
     if in_git_worktree(root):
-        print(f"error: OCW_METER_HOME ({root}) resolves inside a Git worktree; refusing to operate", file=sys.stderr)
-        return 1
+        return {"ok": False, "error": f"OCW_METER_HOME ({root}) resolves inside a Git worktree; refusing to operate"}
     paths = ensure_storage(root)
 
     projects_dir = claude_projects_dir()
     if projects_dir is None:
-        print(
-            "error: could not determine the Claude projects directory "
-            "(HOME is not set; set OCW_METER_CLAUDE_PROJECTS_DIR explicitly)",
-            file=sys.stderr,
-        )
-        return 1
+        return {
+            "ok": False,
+            "error": "could not determine the Claude projects directory (HOME is not set; set OCW_METER_CLAUDE_PROJECTS_DIR explicitly)",
+        }
 
     transcript_files = sorted(projects_dir.glob("*/*.jsonl")) if projects_dir.is_dir() else []
 
@@ -3562,16 +3762,65 @@ def cmd_ingest(args):
     # the persisted cursor means it never loses data: the next run
     # (restricted or not) simply re-reads the same unconsumed range from
     # wherever the last UNRESTRICTED run left off.
+    # 計画書 DOC-2608081456孫2 §2: the cursor now also records WHEN the
+    # last full ingest completed — the freshness footer
+    # (`ingest_freshness_footer`) reads this back. Recorded here, not on
+    # failure, so a stale timestamp after this run means exactly what it
+    # says: "this is the last time ingest actually finished", not "the
+    # last time it was attempted". Not recorded under --since either,
+    # for the same reason the file cursor itself isn't: a --since run is
+    # deliberately read-only with respect to persisted ingest state (see
+    # the comment above).
+    #
+    # PR #57 review round 1 finding 5: an earlier version of this also
+    # wrote `"last_ingest_result": "ok"` — but this branch is the ONLY
+    # place that ever calls `save_ingest_cursor`, and only ever on
+    # success, so that field could structurally never hold any value
+    # other than `"ok"`. A field that can't vary carries no information;
+    # dropped rather than kept as a decoration. If a persisted FAILED-
+    # attempt record ever becomes worth having, it belongs in its own
+    # field (e.g. `last_ingest_attempt_result`) written on the failure
+    # paths too — not bolted onto this success-only one.
     if since_dt is None:
-        save_ingest_cursor(paths, {"files": new_cursor_files})
+        save_ingest_cursor(paths, {
+            "files": new_cursor_files,
+            "last_ingest_at": iso_utc(datetime.now(timezone.utc)),
+        })
 
-    print(f"transcript files scanned:            {files_scanned}")
-    print(f"transcript files with new data:      {files_with_new_data}")
-    print(f"distinct message.id in this run:     {len(candidates)}")
-    print(f"usage.message written (new):         {write_counts['written']}")
-    print(f"usage.message replaced (re-run/dup):  {write_counts['replaced']}")
-    if since_dt is None:
-        print(f"transcript lines quarantined:         {quarantined_count}")
+    return {
+        "ok": True,
+        "files_scanned": files_scanned,
+        "files_with_new_data": files_with_new_data,
+        "distinct_message_ids": len(candidates),
+        "written": write_counts["written"],
+        "replaced": write_counts["replaced"],
+        "quarantined": quarantined_count,
+        "since_used": since_dt is not None,
+    }
+
+
+def cmd_ingest(args):
+    parsed = parse_flags(args, {"--since": "since"}) if args else {}
+    since_str = parsed.get("since")
+    since_dt = None
+    if since_str:
+        since_dt = parse_ts(since_str)
+        if since_dt is None:
+            print(f"error: --since is not a valid RFC3339 timestamp: {since_str!r}", file=sys.stderr)
+            return 1
+
+    result = perform_ingest(storage_root(), since_dt)
+    if not result["ok"]:
+        print(f"error: {result['error']}", file=sys.stderr)
+        return 1
+
+    print(f"transcript files scanned:            {result['files_scanned']}")
+    print(f"transcript files with new data:      {result['files_with_new_data']}")
+    print(f"distinct message.id in this run:     {result['distinct_message_ids']}")
+    print(f"usage.message written (new):         {result['written']}")
+    print(f"usage.message replaced (re-run/dup):  {result['replaced']}")
+    if not result["since_used"]:
+        print(f"transcript lines quarantined:         {result['quarantined']}")
     else:
         # PR #27 review round 3 finding "新規2": under --since,
         # quarantine writes are skipped (round 2 finding "新規2"), so
@@ -3579,8 +3828,8 @@ def cmd_ingest(args):
         # run — even with the cursor note appended separately — read as
         # "this many were recorded" when zero were. Label matches what
         # actually happened: detected while reading, nothing persisted.
-        print(f"transcript lines with parse errors (detected, NOT persisted — see note below): {quarantined_count}")
-    if since_dt is not None:
+        print(f"transcript lines with parse errors (detected, NOT persisted — see note below): {result['quarantined']}")
+    if result["since_used"]:
         # PR #27 review round 4 finding "新規1": this string is printed
         # to the user's terminal — it must read on its own, not
         # reference an internal PR review round number nobody running

--- a/bin/prices/README.md
+++ b/bin/prices/README.md
@@ -1,0 +1,132 @@
+# `bin/prices/` — `ocw-meter` の価格表
+
+`ocw-meter ingest` が起動時にこのディレクトリ配下の全 `*.json` を読み込み
+（`load_price_tables()`、既定は `OCW_METER_SCRIPT_DIR/prices`。`OCW_METER_PRICE_DIR` で上書き可）、
+各 `usage.message` イベントの**そのメッセージ自身のtimestampの日付**に対して
+`effective_date <= その日付` のうち最も新しいテーブルを選んで適用する
+（`ingest` を実行した日ではない）。詳細な費用計算式は
+[docs/reference/DOC-2608021229-c_ocw-meterイベントスキーマ.md](../../docs/reference/DOC-2608021229-c_ocw-meterイベントスキーマ.md)
+§4 を参照。
+
+## 新しい価格表を追加する手順
+
+1. 一次情報（プロバイダの公式価格ページ）から単価を確認し、URL を控える
+2. `bin/prices/<provider>-<effective_date>.json` を作る（ファイル名は慣例。実際に読まれるのは
+   中身の `price_table_version` / `effective_date` フィールドで、ファイル名そのものではない）
+3. 必須フィールドを埋める（`load_price_tables()` がこの3つを持たないファイルを黙って
+   スキップする）:
+   - `price_table_version`: このテーブルを一意に識別する文字列。書き込み済みイベントに
+     そのままコピーされ、あとから「どのテーブルで計算したか」を追跡する唯一の手がかりになる
+   - `effective_date`: `YYYY-MM-DD`。このテーブルが有効になった日
+   - `models`: `{ "<model名>": { "cache_hit_in": ..., "cache_miss_in": ..., "out": ... } }`
+     （`unit: "per_1m_tokens"` 前提。100万トークンあたりの USD 単価）
+4. **`source`（出典 URL）と `fetched_at`（確認日）を必ず埋めること。** 単価は一次情報であり、
+   AI が記憶や推測で書くと静かに嘘の数字が入る。**このディレクトリに単価を書き込むのは
+   人間の作業とし、AI に「過去の単価を調べて追加して」と依頼しない。**
+5. コミットして `bin/tests/lint.sh` / 該当テストを流す
+
+### 過去表を足しても、既に書き込まれたイベントの費用は直らない
+
+`cost_estimate_usd` は `ingest` 時点で計算されて**イベントに焼き込まれる**。「過去は
+再計算しない」が `ocw-meter` 全体の不変条件のため、**6〜7月に有効だった価格表をあとから
+このディレクトリに足しても、その期間に既に書き込まれた `usage.message` の
+`cost_estimate_usd` / `price_table_version` / `price_effective_date` は変わらない。**
+（`test_ingest_new_price_table_does_not_touch_already_ingested_events` がこれを固定している。）
+
+過去表を足す価値は「これから初めて ingest される、その期間の未取り込みメッセージ」に対して
+正しい単価が適用されるようになることであり、過去に書き込み済みの数字を遡って直すことでは
+ない。書き込み済みの数字を直したければイベントストアを作り直すしかなく、それは
+`ocw-meter` の設計方針に反する。
+
+### 該当する価格表が無い期間はどう扱われるか
+
+対象日付以前に発効したテーブルが1枚も無いとき、`select_price_table()` は**クラッシュせず**
+最も古いテーブル（`tables[0]`）にフォールバックする。この場合、そのイベントに焼き込まれる
+`price_effective_date` は実際のメッセージの日付より**後**になる。`report` はこれを
+（イベントを書き換えずに）メッセージ自身の日付と `price_effective_date` を突き合わせる
+形で読み取り時に検出し、footer の `price_table:` 行の件数と、`report --month` の
+`price_tables_applied` の各エントリの `is_fallback` に警告として出す。**判定は日単位**
+（月の途中で発効したテーブルへのフォールバックも正しく検出される）。
+
+## 時間帯課金の書き方
+
+一部のプロバイダは時間帯によって単価が変わる（例: DeepSeek の
+`Beijing 09:00-12:00, 14:00-18:00` 告知）。これを表現したい場合は、テーブルに
+`time_of_day_pricing` を任意で追加する:
+
+```jsonc
+{
+  "price_table_version": "example-2099-01-01",
+  "effective_date": "2099-01-01",
+  "source": "https://example.invalid/pricing (実在しないダミー)",
+  "fetched_at": "2099-01-01",
+  "currency": "USD",
+  "unit": "per_1m_tokens",
+  "models": {
+    "example-model": { "cache_hit_in": 0.01, "cache_miss_in": 0.10, "out": 0.20 }
+  },
+  "time_of_day_pricing": {
+    "tz_offset": "+08:00",
+    "tz_label": "Beijing time (China Standard Time, UTC+8, no DST)",
+    "boundary": "start_inclusive_end_exclusive",
+    "windows": [
+      {
+        "start": "09:00", "end": "12:00",
+        "models": { "example-model": { "cache_hit_in": 0.02, "cache_miss_in": 0.20, "out": 0.40 } }
+      },
+      {
+        "start": "14:00", "end": "18:00",
+        "models": { "example-model": { "cache_hit_in": 0.02, "cache_miss_in": 0.20, "out": 0.40 } }
+      }
+    ]
+  }
+}
+```
+
+（上の `example-model` / URL は実在しないプロバイダの明らかなダミー値。本物の単価表を
+コピーして書き換えるときは、`price_table_version` / `source` / `fetched_at` / 単価を
+すべて本物の一次情報に差し替えること。)
+
+設計上の決まりごと（`bin/ocw-meter` の `compute_cost` 直前のコメント節に理由の詳細がある）:
+
+- **`tz_offset` は固定オフセット文字列（`"+08:00"` 形式）のみ。** タイムゾーン名
+  （`Asia/Shanghai` 等）は使えない。`zoneinfo` は Python 3.9+ かつ tzdata が必要で、
+  実行環境に無い場合があるため。表示用に `tz_label` を添えてよいが、計算に使われるのは
+  `tz_offset` のみ。時・分とも範囲外（`"+25:00"` 等）の値はテーブルごと無視され、
+  クラッシュはしない（下記「壊れた `time_of_day_pricing` はどう扱われるか」参照）
+- **境界は開始時刻を含み、終了時刻を含まない**（`start <= t < end`）。
+  `"09:00"`-`"12:00"` と `"12:00"`-`"14:00"` のように窓を隙間なく並べても、
+  境界ちょうどのタイムスタンプがどちらか片方だけに一意に決まる。**これはコード側に
+  固定された唯一の境界規則であり、価格表側から変更する手段は無い。** `boundary` を
+  書く場合は `"start_inclusive_end_exclusive"` の値のみが有効で、それ以外の値は
+  「壊れた `time_of_day_pricing`」として扱われる（実装が読まずに無視する、ではなく、
+  実装と食い違う値を書いたテーブルごと使用不可になる）
+- **日を跨ぐ窓は表現できない。** `start >= end`（例 `"22:00"`-`"02:00"`）な窓は
+  単に一致しない扱いになる（クラッシュはしないが、無いのと同じ）。日を跨ぐ課金が
+  発効した場合はコード側の対応が必要になる
+- **時間帯ごとに単価を直接書く（倍率ではない）。** 「2倍」のような倍率表記は
+  「何に対しての2倍か」が曖昧になるため、`models` ブロックと同じ形で窓ごとの単価を
+  そのまま書く。出典の単価表をそのまま転記できる
+- **窓の `models` に載っていないモデルは、その窓の時間帯であっても常に基本の `models`
+  の単価が適用される**（そのモデルは時間帯課金の対象外という意味）。同じテーブルの中で
+  一部のモデルだけ時間帯課金にできる
+- **スキーマに「どちらが高い時間帯か」という情報は無い。** 窓に一致したかどうかだけを
+  表す `in_window` / `base_rate` という中立な名前を使う（`peak` / `off_peak` のような
+  高低を暗示する名前は採用していない）。理由: 窓が「割高な時間帯」を表すのか「割引の
+  時間帯」を表すのかはプロバイダごとに違い、しかも書き込まれたイベントの
+  `time_of_day_basis` フィールドは「過去は再計算しない」不変条件のため後から意味を
+  直せない。書き込まれたイベントの `time_of_day_basis`
+  （`not_applicable` / `in_window` / `base_rate` / `unknown_timestamp`）で、実際に
+  窓の単価が適用されたか基本単価が適用されたかを後から確認できる
+
+### 壊れた `time_of_day_pricing` はどう扱われるか
+
+`time_of_day_pricing` キー自体は書いたが、`tz_offset` が範囲外・`windows` が配列でない・
+`boundary` が上記の値と食い違う、などで使用できない形になっている場合、そのテーブルは
+**時間帯課金なしのテーブルと同じ扱い**（`time_of_day_basis: "not_applicable"`、基本単価を
+適用）になる。ただし「最初から `time_of_day_pricing` を書いていない」場合と区別するため、
+`ingest` はこの状態を検知すると `state/meter-errors.jsonl` に
+`price_table_time_of_day_pricing_unusable` という診断を1件記録する（`report` の
+footer の `meter.error diagnostics: N lines` に出る既存の自己診断経路と同じもので、
+1日1件にまとめられる）。**単価計算自体はクラッシュしない**が、意図した時間帯課金が
+黙って無視されている場合はこの診断で気づけるようにしてある。

--- a/bin/tests/test_ocw_meter.py
+++ b/bin/tests/test_ocw_meter.py
@@ -3938,6 +3938,252 @@ class ReportMonthStandaloneTests(OcwMeterTestCase):
         self.assertNotEqual(result.returncode, 0)
 
 
+class ReportListPriceEquivTests(OcwMeterTestCase):
+    """docs/planning/DOC-2608081456_..._計画.md 孫4プロンプト:
+    `quota.sample`'s `session_cost_usd` aggregated into
+    `list_price_equiv_usd` by `report_capacity_list_price()`."""
+
+    def _quota_sample(self, idem_key, session_id, cost, ts, provider="anthropic", extra=None):
+        args = ["event", "quota.sample", "--idempotency-key", idem_key,
+                "--plan-source", "statusline", "--provider", provider, "--ts", ts]
+        if session_id is not None:
+            args += ["--session-id", session_id]
+        if cost is not None:
+            args += ["--session-cost-usd", str(cost)]
+        if extra:
+            args += extra
+        return run_meter(args, self.home)
+
+    # -- 罠3: 正の差分の総和。max() ではない --
+
+    def test_non_monotonic_session_sums_positive_deltas_not_max(self):
+        # 10 -> 20 -> 5 -> 15: max() だと20だが、正しくは
+        # 10 + (20-10) + max(0, 5-20) + (15-5) = 10+10+0+10 = 30。
+        for i, (cost, minute) in enumerate([(10, "00"), (20, "01"), (5, "02"), (15, "03")]):
+            self._quota_sample(f"q{i}", "sess-nonmono", cost, f"2026-08-05T09:{minute}:00.000Z")
+        data = json.loads(run_meter(["report", "--month", "2026-08", "--json"], self.home).stdout)
+        self.assertAlmostEqual(data["capacity"]["list_price_equiv_usd"], 30.0)
+
+    def test_monotonic_session_equals_final_value(self):
+        for i, (cost, minute) in enumerate([(5, "00"), (10, "01"), (20, "02")]):
+            self._quota_sample(f"q{i}", "sess-mono", cost, f"2026-08-05T09:{minute}:00.000Z")
+        data = json.loads(run_meter(["report", "--month", "2026-08", "--json"], self.home).stdout)
+        self.assertAlmostEqual(data["capacity"]["list_price_equiv_usd"], 20.0)
+
+    def test_single_sample_session_uses_its_value_as_is(self):
+        self._quota_sample("q1", "sess-single", 7.5, "2026-08-05T09:00:00.000Z")
+        data = json.loads(run_meter(["report", "--month", "2026-08", "--json"], self.home).stdout)
+        self.assertAlmostEqual(data["capacity"]["list_price_equiv_usd"], 7.5)
+
+    # -- 罠2: deepseek混入除外 --
+
+    def test_deepseek_session_cost_is_fully_excluded(self):
+        self._quota_sample("q1", "sess-anthropic", 12.0, "2026-08-05T09:00:00.000Z", provider="anthropic")
+        self._quota_sample("q2", "sess-deepseek", 93.35, "2026-08-05T09:01:00.000Z", provider="deepseek")
+        data = json.loads(run_meter(["report", "--month", "2026-08", "--json"], self.home).stdout)
+        # 93.35 が1セントも混じっていないことを、合計が anthropic 分の
+        # 12.0 ちょうどであることで確認する。
+        self.assertAlmostEqual(data["capacity"]["list_price_equiv_usd"], 12.0)
+
+    def test_rate_limits_less_deepseek_shaped_samples_are_excluded(self):
+        # 罠2は「providerフィールドが deepseek 文字列であること」ではなく
+        # 「rate_limitsを持たない実際のDeepSeek/claude-ds形状のstatusLine
+        # JSONが、その書き込み経路(snapshot-quota)を通って provider を
+        # 正しく推論され、結果として除外されること」を確認する必要がある
+        # (round-1レビュー指摘4: 直接 --provider を叩くだけのテストは
+        # rate_limits の有無がproviderに効かなくなっても緑のままだった)。
+        self._quota_sample("q1", "sess-a", 1.0, "2026-08-05T09:00:00.000Z", provider="anthropic")
+        run_snapshot_quota(json.dumps({
+            "session_id": "sess-ds-shaped", "cwd": "/tmp",
+            "model": {"id": "deepseek-v4-pro[1m]"},
+            "cost": {"total_cost_usd": 999.0},
+        }), self.home)
+        data = json.loads(run_meter(["report", "--month", "2026-08", "--json"], self.home).stdout)
+        self.assertAlmostEqual(data["capacity"]["list_price_equiv_usd"], 1.0)
+        self.assertEqual(data["capacity"]["list_price_equiv_excluded_deepseek_count"], 1)
+
+    def test_provider_unresolved_samples_are_excluded_and_counted_separately(self):
+        # round-1レビュー指摘3: model名もrate_limitsも無いサンプルは
+        # provider: null で書かれる(deepseekと判定されたわけではない)。
+        # anthropicとして合算してはいけないが、除外したこと自体は
+        # deepseekの除外とは別カウンタで報告する。
+        self._quota_sample("q1", "sess-a", 1.0, "2026-08-05T09:00:00.000Z", provider="anthropic")
+        run_snapshot_quota(json.dumps({
+            "session_id": "sess-unresolved", "cwd": "/tmp",
+            "cost": {"total_cost_usd": 999.0},
+        }), self.home)
+        event = next(e for e in read_events(self.home) if e["session_id"] == "sess-unresolved")
+        self.assertIsNone(event["provider"])
+        data = json.loads(run_meter(["report", "--month", "2026-08", "--json"], self.home).stdout)
+        self.assertAlmostEqual(data["capacity"]["list_price_equiv_usd"], 1.0)
+        self.assertEqual(data["capacity"]["list_price_equiv_excluded_other_provider_count"], 1)
+        self.assertEqual(data["capacity"]["list_price_equiv_excluded_deepseek_count"], 0)
+
+    # -- round-1レビュー指摘1: セッションがスコープをまたぐと持ち越し分を
+    # 二重計上してはいけない --
+
+    def test_window_scoped_session_does_not_double_count_carryover_from_a_prior_window(self):
+        # セッションS1: W1で 10 -> 20、W2で 30 -> 40。
+        # 真の消費は W1=20, W2=20 (合計40)。バグ版はW2の初項に30を
+        # まるごと足すため W2=40 になり、合計が60に膨らむ。
+        self._quota_sample("q1", "sess-carry", 10, "2026-08-05T09:00:00.000Z", extra=["--window-id", "winA"])
+        self._quota_sample("q2", "sess-carry", 20, "2026-08-05T09:01:00.000Z", extra=["--window-id", "winA"])
+        self._quota_sample("q3", "sess-carry", 30, "2026-08-05T10:00:00.000Z", extra=["--window-id", "winB"])
+        self._quota_sample("q4", "sess-carry", 40, "2026-08-05T10:01:00.000Z", extra=["--window-id", "winB"])
+        data = json.loads(run_meter(["report", "--window", "--json"], self.home).stdout)
+        self.assertAlmostEqual(data["by_window"]["winA"]["list_price_equiv_usd"], 20.0)
+        self.assertAlmostEqual(data["by_window"]["winB"]["list_price_equiv_usd"], 20.0)
+
+    def test_pr_scoped_session_does_not_double_count_carryover_from_a_prior_pr(self):
+        # セッションS1: PR#301で 10 -> 20、PR#302で 30 -> 45。
+        # 真の消費は #301=20, #302=25。
+        run_meter(["event", "run.start", "--idempotency-key", "r301", "--run-id", "run-301",
+                   "--ts", "2026-08-05T09:00:00.000Z"], self.home)
+        run_meter(["bind-pr", "--run", "run-301", "--pr", "301"], self.home)
+        run_meter(["event", "run.start", "--idempotency-key", "r302", "--run-id", "run-302",
+                   "--ts", "2026-08-05T10:00:00.000Z"], self.home)
+        run_meter(["bind-pr", "--run", "run-302", "--pr", "302"], self.home)
+        self._quota_sample("q1", "sess-carry-pr", 10, "2026-08-05T09:00:00.000Z",
+                            extra=["--run-id", "run-301", "--pr-number", "301"])
+        self._quota_sample("q2", "sess-carry-pr", 20, "2026-08-05T09:01:00.000Z",
+                            extra=["--run-id", "run-301", "--pr-number", "301"])
+        self._quota_sample("q3", "sess-carry-pr", 30, "2026-08-05T10:00:00.000Z",
+                            extra=["--run-id", "run-302", "--pr-number", "302"])
+        self._quota_sample("q4", "sess-carry-pr", 45, "2026-08-05T10:01:00.000Z",
+                            extra=["--run-id", "run-302", "--pr-number", "302"])
+        data301 = json.loads(run_meter(["report", "--pr", "301", "--json"], self.home).stdout)
+        data302 = json.loads(run_meter(["report", "--pr", "302", "--json"], self.home).stdout)
+        self.assertAlmostEqual(data301["pr_detail"]["list_price_equiv_usd"], 20.0)
+        self.assertAlmostEqual(data302["pr_detail"]["list_price_equiv_usd"], 25.0)
+
+    def test_window_and_pr_filter_combined_does_not_double_count_carryover(self):
+        # round-2レビュー持ち越し指摘: セッションS1が W1/PR#101(10->20)、
+        # W2/PR#102(30->45) とまたぐケースで、`--window` 単体・`--pr` 単体
+        # はround-1の修正で直ったが、`--window --pr <n>` の併用だけ
+        # report_by_window() が自分の受け取った引数(PRで絞られた
+        # filtered)からquota_contributionsを計算していたため、
+        # まったく同じ二重計上が残っていた。真の消費は #102=25。
+        run_meter(["event", "run.start", "--idempotency-key", "r101", "--run-id", "run-101",
+                   "--ts", "2026-08-05T09:00:00.000Z"], self.home)
+        run_meter(["bind-pr", "--run", "run-101", "--pr", "101"], self.home)
+        run_meter(["event", "run.start", "--idempotency-key", "r102", "--run-id", "run-102",
+                   "--ts", "2026-08-05T10:00:00.000Z"], self.home)
+        run_meter(["bind-pr", "--run", "run-102", "--pr", "102"], self.home)
+        self._quota_sample("q1", "sess-carry-both", 10, "2026-08-05T09:00:00.000Z",
+                            extra=["--run-id", "run-101", "--pr-number", "101", "--window-id", "winX"])
+        self._quota_sample("q2", "sess-carry-both", 20, "2026-08-05T09:01:00.000Z",
+                            extra=["--run-id", "run-101", "--pr-number", "101", "--window-id", "winX"])
+        self._quota_sample("q3", "sess-carry-both", 30, "2026-08-05T10:00:00.000Z",
+                            extra=["--run-id", "run-102", "--pr-number", "102", "--window-id", "winY"])
+        self._quota_sample("q4", "sess-carry-both", 45, "2026-08-05T10:01:00.000Z",
+                            extra=["--run-id", "run-102", "--pr-number", "102", "--window-id", "winY"])
+        data = json.loads(run_meter(["report", "--window", "--pr", "102", "--json"], self.home).stdout)
+        self.assertAlmostEqual(data["by_window"]["winY"]["list_price_equiv_usd"], 25.0)
+
+    def test_month_view_still_sums_the_whole_session_across_windows(self):
+        # 上のwindowテストと同じセッションでも、--monthはウィンドウを
+        # またいでも変わらず正しい合計(40)を返す(こちらは元々スコープが
+        # 月全体なのでバグの対象外だったことの回帰確認)。
+        self._quota_sample("q1", "sess-carry-month", 10, "2026-08-05T09:00:00.000Z", extra=["--window-id", "winA"])
+        self._quota_sample("q2", "sess-carry-month", 20, "2026-08-05T09:01:00.000Z", extra=["--window-id", "winA"])
+        self._quota_sample("q3", "sess-carry-month", 30, "2026-08-05T10:00:00.000Z", extra=["--window-id", "winB"])
+        self._quota_sample("q4", "sess-carry-month", 40, "2026-08-05T10:01:00.000Z", extra=["--window-id", "winB"])
+        data = json.loads(run_meter(["report", "--month", "2026-08", "--json"], self.home).stdout)
+        self.assertAlmostEqual(data["capacity"]["list_price_equiv_usd"], 40.0)
+
+    # -- round-1レビュー指摘5: null と 下限 は同時に成立しない --
+
+    def test_is_lower_bound_is_null_not_true_when_value_is_null(self):
+        data = json.loads(run_meter(["report", "--month", "2026-08", "--json"], self.home).stdout)
+        self.assertIsNone(data["capacity"]["list_price_equiv_usd"])
+        self.assertIsNone(data["capacity"]["list_price_equiv_is_lower_bound"])
+
+    # -- round-1レビュー指摘2: --prのテキスト出力でも除外件数を出す --
+
+    def test_pr_text_output_includes_exclusion_counts(self):
+        run_meter(["event", "run.start", "--idempotency-key", "r400", "--run-id", "run-400",
+                   "--ts", "2026-08-05T09:00:00.000Z"], self.home)
+        run_meter(["bind-pr", "--run", "run-400", "--pr", "400"], self.home)
+        run_meter(["event", "quota.sample", "--idempotency-key", "q1",
+                   "--plan-source", "statusline", "--provider", "anthropic",
+                   "--session-cost-usd", "5.0", "--run-id", "run-400", "--pr-number", "400",
+                   "--ts", "2026-08-05T09:05:00.000Z"], self.home)
+        result = run_meter(["report", "--pr", "400"], self.home)
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("list_price_equiv_excluded_no_session_id_count:", result.stdout)
+        self.assertIn("list_price_equiv_excluded_null_cost_count:", result.stdout)
+        self.assertIn("list_price_equiv_excluded_deepseek_count:", result.stdout)
+        self.assertIn("list_price_equiv_excluded_other_provider_count:", result.stdout)
+
+    # -- round-1レビュー指摘6: --windowのテキスト出力で説明文を行ごとに繰り返さない --
+
+    def test_window_text_output_prints_the_note_once_not_per_row(self):
+        self._quota_sample("q1", "sess-win-a", 1.0, "2026-08-05T09:00:00.000Z", extra=["--window-id", "winA"])
+        self._quota_sample("q2", "sess-win-b", 2.0, "2026-08-05T10:00:00.000Z", extra=["--window-id", "winB"])
+        result = run_meter(["report", "--window"], self.home)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout.count("list_price_equiv_note:"), 1)
+
+    # -- 表示と境界 --
+
+    def test_list_price_equiv_is_a_separate_key_from_cash_cost(self):
+        self._quota_sample("q1", "sess-a", 5.0, "2026-08-05T09:00:00.000Z")
+        data = json.loads(run_meter(["report", "--month", "2026-08", "--json"], self.home).stdout)
+        self.assertNotIn("list_price_equiv_usd", data["cash_cost"])
+        self.assertIn("list_price_equiv_usd", data["capacity"])
+        self.assertAlmostEqual(data["capacity"]["list_price_equiv_usd"], 5.0)
+
+    def test_no_anthropic_quota_sample_in_scope_is_null_not_zero(self):
+        data = json.loads(run_meter(["report", "--month", "2026-08", "--json"], self.home).stdout)
+        self.assertIsNone(data["capacity"]["list_price_equiv_usd"])
+        # deepseek-onlyなquota.sampleがあっても、anthropicデータが無い
+        # 事実は変わらない — $0.00 ではなく null のまま。
+        self._quota_sample("q1", "sess-ds", 3.0, "2026-08-05T09:00:00.000Z", provider="deepseek")
+        data = json.loads(run_meter(["report", "--month", "2026-08", "--json"], self.home).stdout)
+        self.assertIsNone(data["capacity"]["list_price_equiv_usd"])
+
+    def test_pre_august_month_explains_null_as_no_collection_yet(self):
+        # quota.sample の記録自体が2026-08-01開始なので、それより前の月は
+        # 「今月たまたま0件だった」ではなく「原理的にデータが無い」。
+        data = json.loads(run_meter(["report", "--month", "2026-07", "--json"], self.home).stdout)
+        self.assertIsNone(data["capacity"]["list_price_equiv_usd"])
+        self.assertIn("2026-08-01", data["capacity"]["list_price_equiv_note"])
+
+    def test_list_price_equiv_appears_in_pr_report(self):
+        run_meter(["event", "run.start", "--idempotency-key", "r1", "--run-id", "run-lp1",
+                   "--ts", "2026-08-05T09:00:00.000Z"], self.home)
+        run_meter(["bind-pr", "--run", "run-lp1", "--pr", "200"], self.home)
+        self._quota_sample("q1", "sess-pr", 8.25, "2026-08-05T09:05:00.000Z",
+                            extra=["--run-id", "run-lp1", "--pr-number", "200"])
+        data = json.loads(run_meter(["report", "--pr", "200", "--json"], self.home).stdout)
+        self.assertAlmostEqual(data["pr_detail"]["list_price_equiv_usd"], 8.25)
+        self.assertTrue(data["pr_detail"]["list_price_equiv_is_lower_bound"])
+
+    def test_list_price_equiv_appears_in_window_report(self):
+        self._quota_sample("q1", "sess-win", 6.5, "2026-08-05T09:00:00.000Z",
+                            extra=["--window-id", "win-lp1"])
+        data = json.loads(run_meter(["report", "--window", "--json"], self.home).stdout)
+        self.assertAlmostEqual(data["by_window"]["win-lp1"]["list_price_equiv_usd"], 6.5)
+
+    def test_excludes_samples_without_session_id_or_with_null_cost_without_crashing(self):
+        # session_idが無いサンプル(cost自体は有り)。
+        run_meter(["event", "quota.sample", "--idempotency-key", "q1",
+                   "--plan-source", "statusline", "--provider", "anthropic",
+                   "--session-cost-usd", "50.0", "--ts", "2026-08-05T09:00:00.000Z"], self.home)
+        # session_cost_usdが無い(null)サンプル(session_idは有り)。
+        run_meter(["event", "quota.sample", "--idempotency-key", "q2",
+                   "--plan-source", "statusline", "--provider", "anthropic",
+                   "--session-id", "sess-nullcost", "--ts", "2026-08-05T09:01:00.000Z"], self.home)
+        # 有効なサンプル。
+        self._quota_sample("q3", "sess-valid", 4.0, "2026-08-05T09:02:00.000Z")
+        result = run_meter(["report", "--month", "2026-08", "--json"], self.home)
+        self.assertEqual(result.returncode, 0)
+        data = json.loads(result.stdout)
+        self.assertAlmostEqual(data["capacity"]["list_price_equiv_usd"], 4.0)
+        self.assertEqual(data["capacity"]["list_price_equiv_excluded_no_session_id_count"], 1)
+        self.assertEqual(data["capacity"]["list_price_equiv_excluded_null_cost_count"], 1)
+
+
 # ── Round 1 review regression tests ─────────────────────────────────────
 # https://github.com/manemone/dotfiles/pull/28 round-1 review findings.
 

--- a/bin/tests/test_ocw_meter.py
+++ b/bin/tests/test_ocw_meter.py
@@ -254,6 +254,12 @@ def write_transcript(projects_dir, slug, session_id, line_dicts):
     return path
 
 
+def write_price_table(price_dir, filename, table):
+    price_dir = pathlib.Path(price_dir)
+    price_dir.mkdir(parents=True, exist_ok=True)
+    (price_dir / filename).write_text(json.dumps(table, ensure_ascii=False), encoding="utf-8")
+
+
 def make_ocw_style_worktree(tmp_root, run_id):
     """Creates a throwaway git repo + linked worktree and writes
     `run_id` to `<worktree's git-dir>/ocw-run-id`, mirroring bin/ocw's
@@ -1878,6 +1884,414 @@ class IngestTests(OcwMeterTestCase):
         r2 = run_ingest(self.home, self.projects_dir)
         self.assertEqual(r2.returncode, 0, r2.stderr)
         self.assertFalse(events_file.read_text(encoding="utf-8").endswith("\n"))
+
+
+class TimeOfDayPricingTests(OcwMeterTestCase):
+    """計画書 DOC-2608081456孫3: time-of-day price table extension. All
+    windows below use `tz_offset: "+08:00"` (Beijing time, matching
+    DeepSeek's own announced windows) with a deliberately simple
+    base/window price pair (1.0 / 2.0 per token) so cost assertions
+    don't need to reproduce the real formula's arithmetic.
+
+    `time_of_day_basis` uses basis-neutral values (`in_window` /
+    `base_rate`, not `peak` / `off_peak` — レビュー指摘4: this schema
+    can't know which side is actually more expensive)."""
+
+    def setUp(self):
+        super().setUp()
+        self.projects_dir = pathlib.Path(self.tmpdir.name) / "claude-projects"
+        self.projects_dir.mkdir(parents=True, exist_ok=True)
+        self.price_dir = pathlib.Path(self.tmpdir.name) / "prices-tod"
+
+    def _tod_table(self, version="deepseek-2026-08-01-tod"):
+        return {
+            "price_table_version": version,
+            "effective_date": "2026-08-01",
+            "models": {
+                "deepseek-v4-pro": {"cache_hit_in": 0, "cache_miss_in": 1.0, "out": 0},
+            },
+            "time_of_day_pricing": {
+                "tz_offset": "+08:00",
+                "boundary": "start_inclusive_end_exclusive",
+                "windows": [
+                    {"start": "09:00", "end": "12:00",
+                     "models": {"deepseek-v4-pro": {"cache_hit_in": 0, "cache_miss_in": 2.0, "out": 0}}},
+                    {"start": "14:00", "end": "18:00",
+                     "models": {"deepseek-v4-pro": {"cache_hit_in": 0, "cache_miss_in": 2.0, "out": 0}}},
+                ],
+            },
+        }
+
+    def _ingest_one(self, timestamp, table=None, session="sess-tod"):
+        write_price_table(self.price_dir, "deepseek-tod.json", table or self._tod_table())
+        write_transcript(self.projects_dir, "proj", session, [
+            assistant_line(session, "m1", model="deepseek-v4-pro", timestamp=timestamp,
+                            input_tokens=1_000_000, cache_read_input_tokens=0,
+                            cache_creation_input_tokens=0, output_tokens=0),
+        ])
+        result = run_ingest(self.home, self.projects_dir, price_dir=self.price_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return read_events(self.home)[0]
+
+    # -- backward compatibility --------------------------------------------
+
+    def test_table_without_time_of_day_pricing_is_unaffected(self):
+        # Uses the real, unmodified bin/prices/deepseek-2026-08-01.json —
+        # the primary evidence this feature is backward compatible (孫3
+        # プロンプト §テスト "既存のテストが無改変で通ることが主要な根拠").
+        write_transcript(self.projects_dir, "proj", "sess-compat", [
+            assistant_line("sess-compat", "m1", model="deepseek-v4-pro",
+                            timestamp="2026-08-05T02:00:00.000Z",  # Beijing 10:00 — would be "in_window" if defined
+                            input_tokens=1000, cache_read_input_tokens=2000, output_tokens=300),
+        ])
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = read_events(self.home)[0]
+        self.assertEqual(event["time_of_day_basis"], "not_applicable")
+        self.assertIsNotNone(event["cost_estimate_usd"])
+
+    # -- in_window / base_rate -----------------------------------------------
+
+    def test_timestamp_inside_window_gets_window_price(self):
+        # Beijing 10:00 (UTC 02:00) is inside the 09:00-12:00 window.
+        event = self._ingest_one("2026-08-05T02:00:00.000Z")
+        self.assertEqual(event["time_of_day_basis"], "in_window")
+        self.assertAlmostEqual(event["cost_estimate_usd"], 2.0)
+
+    def test_timestamp_outside_every_window_gets_base_price(self):
+        # Beijing 13:00 (UTC 05:00) is between the two windows.
+        event = self._ingest_one("2026-08-05T05:00:00.000Z")
+        self.assertEqual(event["time_of_day_basis"], "base_rate")
+        self.assertAlmostEqual(event["cost_estimate_usd"], 1.0)
+
+    # -- boundary handling -----------------------------------------------
+
+    def test_window_start_boundary_is_inclusive(self):
+        # Beijing 09:00:00 exactly (UTC 01:00:00) -- start of the window.
+        event = self._ingest_one("2026-08-05T01:00:00.000Z")
+        self.assertEqual(event["time_of_day_basis"], "in_window")
+        self.assertAlmostEqual(event["cost_estimate_usd"], 2.0)
+
+    def test_window_end_boundary_is_exclusive(self):
+        # Beijing 12:00:00 exactly (UTC 04:00:00) -- end of the window.
+        event = self._ingest_one("2026-08-05T04:00:00.000Z")
+        self.assertEqual(event["time_of_day_basis"], "base_rate")
+        self.assertAlmostEqual(event["cost_estimate_usd"], 1.0)
+
+    def test_boundary_field_mismatching_the_only_supported_rule_is_unusable(self):
+        # レビュー指摘5: `boundary` is a real, validated field now, not a
+        # documented-but-ignored one -- a table that claims a boundary
+        # rule this file doesn't implement must be treated as unusable,
+        # not silently computed with the (opposite) hardcoded rule.
+        table = self._tod_table()
+        table["time_of_day_pricing"]["boundary"] = "start_exclusive_end_inclusive"
+        event = self._ingest_one("2026-08-05T02:00:00.000Z", table=table)  # otherwise squarely in-window
+        self.assertEqual(event["time_of_day_basis"], "not_applicable")
+        self.assertAlmostEqual(event["cost_estimate_usd"], 1.0)
+
+    # -- UTC -> Beijing conversion, including a date rollover --------------
+
+    def test_utc_timestamp_is_converted_to_beijing_window_across_date_boundary(self):
+        # A window entirely inside "the day after" from UTC's point of
+        # view: Beijing 00:00-03:00 (UTC+8) only exists as UTC 16:00-
+        # 19:00 of the PREVIOUS calendar date -- exactly the "UTC 深夜 =
+        # 北京の朝" case 孫3プロンプト's test list requires. If the
+        # implementation ever forgot to actually convert timezones (e.g.
+        # read `ts_dt.hour` instead of `ts_dt.astimezone(tz).hour`), this
+        # message (2026-07-14 UTC) would be judged against the WRONG
+        # calendar date's window matching (still base_rate by accident,
+        # since the naive UTC hour 16 isn't in 00:00-03:00 either) —
+        # the assertion below instead pins the actual local hour (00:30)
+        # produced by a correct astimezone() conversion.
+        table = self._tod_table()
+        table["time_of_day_pricing"]["windows"] = [{
+            "start": "00:00", "end": "03:00",
+            "models": {"deepseek-v4-pro": {"cache_hit_in": 0, "cache_miss_in": 2.0, "out": 0}},
+        }]
+        # 2026-07-14T16:30:00Z + 08:00 = 2026-07-15T00:30:00 (next date).
+        event = self._ingest_one("2026-07-14T16:30:00.000Z", table=table)
+        self.assertEqual(event["time_of_day_basis"], "in_window")
+        self.assertAlmostEqual(event["cost_estimate_usd"], 2.0)
+
+    # -- missing timestamp -------------------------------------------------
+
+    def test_missing_timestamp_falls_back_to_base_price_without_crashing(self):
+        write_price_table(self.price_dir, "deepseek-tod.json", self._tod_table())
+        line = assistant_line("sess-notime", "m1", model="deepseek-v4-pro",
+                               input_tokens=1_000_000, cache_read_input_tokens=0,
+                               cache_creation_input_tokens=0, output_tokens=0)
+        line["timestamp"] = None
+        write_transcript(self.projects_dir, "proj", "sess-notime", [line])
+        result = run_ingest(self.home, self.projects_dir, price_dir=self.price_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = read_events(self.home)[0]
+        self.assertEqual(event["time_of_day_basis"], "unknown_timestamp")
+        self.assertAlmostEqual(event["cost_estimate_usd"], 1.0)  # base price, not guessed in/out of window
+
+    # -- a model absent from every window is unaffected ---------------------
+
+    def test_model_not_listed_in_any_window_is_not_applicable(self):
+        table = self._tod_table()
+        table["models"]["deepseek-v4-flash"] = {"cache_hit_in": 0, "cache_miss_in": 1.0, "out": 0}
+        write_price_table(self.price_dir, "deepseek-tod.json", table)
+        write_transcript(self.projects_dir, "proj", "sess-flash", [
+            # Beijing 10:00 -- inside the pro-only window, but this
+            # message uses -flash, which has no window override.
+            assistant_line("sess-flash", "m1", model="deepseek-v4-flash", timestamp="2026-08-05T02:00:00.000Z",
+                            input_tokens=1_000_000, cache_read_input_tokens=0,
+                            cache_creation_input_tokens=0, output_tokens=0),
+        ])
+        result = run_ingest(self.home, self.projects_dir, price_dir=self.price_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = read_events(self.home)[0]
+        self.assertEqual(event["time_of_day_basis"], "not_applicable")
+        self.assertAlmostEqual(event["cost_estimate_usd"], 1.0)
+
+    # -- malformed time_of_day_pricing never crashes ingest -----------------
+
+    def test_missing_tz_offset_does_not_crash_ingest(self):
+        table = self._tod_table()
+        # No tz_offset at all -- the whole block must be treated as
+        # unusable (not_applicable), not raise.
+        del table["time_of_day_pricing"]["tz_offset"]
+        event = self._ingest_one("2026-08-05T02:00:00.000Z", table=table)
+        self.assertEqual(event["time_of_day_basis"], "not_applicable")
+        self.assertAlmostEqual(event["cost_estimate_usd"], 1.0)
+
+    def test_out_of_range_tz_offset_does_not_crash_ingest(self):
+        # レビュー指摘1の回帰テスト: `timezone()` raises ValueError for a
+        # >=24h magnitude offset. This used to propagate all the way up
+        # through `_time_of_day_spec` -> `_select_prices_for_model` ->
+        # `compute_cost` -> the list comprehension in the ingest routine
+        # that calls `build_usage_event` for every candidate, with no
+        # try/except anywhere in that chain -- `ingest` exited 1 and
+        # wrote ZERO events (including unrelated messages), directly
+        # violating `compute_cost`'s own "Never raises" docstring.
+        table = self._tod_table()
+        table["time_of_day_pricing"]["tz_offset"] = "+25:00"
+        event = self._ingest_one("2026-08-05T02:00:00.000Z", table=table)
+        self.assertEqual(event["time_of_day_basis"], "not_applicable")
+        self.assertAlmostEqual(event["cost_estimate_usd"], 1.0)
+
+    def test_out_of_range_minutes_in_tz_offset_does_not_silently_normalize(self):
+        # "+08:75" must not silently become UTC+09:15 -- minutes are
+        # range-checked exactly like `_parse_hhmm_to_minutes` already
+        # checks window boundaries.
+        table = self._tod_table()
+        table["time_of_day_pricing"]["tz_offset"] = "+08:75"
+        event = self._ingest_one("2026-08-05T02:00:00.000Z", table=table)
+        self.assertEqual(event["time_of_day_basis"], "not_applicable")
+        self.assertAlmostEqual(event["cost_estimate_usd"], 1.0)
+
+    def test_tz_database_name_is_rejected_not_crashed_on(self):
+        # zoneinfo names are deliberately unsupported (孫3プロンプト §1:
+        # tzdata isn't guaranteed present) -- must fall back cleanly.
+        table = self._tod_table()
+        table["time_of_day_pricing"]["tz_offset"] = "Asia/Shanghai"
+        event = self._ingest_one("2026-08-05T02:00:00.000Z", table=table)
+        self.assertEqual(event["time_of_day_basis"], "not_applicable")
+        self.assertAlmostEqual(event["cost_estimate_usd"], 1.0)
+
+    def test_non_list_windows_does_not_crash_ingest(self):
+        table = self._tod_table()
+        table["time_of_day_pricing"]["windows"] = {"start": "09:00", "end": "12:00"}
+        event = self._ingest_one("2026-08-05T02:00:00.000Z", table=table)
+        self.assertEqual(event["time_of_day_basis"], "not_applicable")
+        self.assertAlmostEqual(event["cost_estimate_usd"], 1.0)
+
+    def test_non_dict_time_of_day_pricing_does_not_crash_ingest(self):
+        table = self._tod_table()
+        table["time_of_day_pricing"] = ["not", "a", "dict"]
+        event = self._ingest_one("2026-08-05T02:00:00.000Z", table=table)
+        self.assertEqual(event["time_of_day_basis"], "not_applicable")
+        self.assertAlmostEqual(event["cost_estimate_usd"], 1.0)
+
+    def test_malformed_hhmm_window_bounds_never_match_but_do_not_crash(self):
+        table = self._tod_table()
+        table["time_of_day_pricing"]["windows"] = [{
+            "start": "9:00", "end": "12:00",  # single-digit hour: not "HH:MM"
+            "models": {"deepseek-v4-pro": {"cache_hit_in": 0, "cache_miss_in": 2.0, "out": 0}},
+        }]
+        event = self._ingest_one("2026-08-05T02:00:00.000Z", table=table)  # would be in-window if parsed
+        self.assertEqual(event["time_of_day_basis"], "base_rate")
+        self.assertAlmostEqual(event["cost_estimate_usd"], 1.0)
+
+    def test_cross_midnight_window_never_matches_but_does_not_crash(self):
+        table = self._tod_table()
+        table["time_of_day_pricing"]["windows"] = [{
+            "start": "22:00", "end": "02:00",  # start >= end after normalization: unsupported
+            "models": {"deepseek-v4-pro": {"cache_hit_in": 0, "cache_miss_in": 2.0, "out": 0}},
+        }]
+        event = self._ingest_one("2026-08-05T15:30:00.000Z", table=table)  # Beijing 23:30
+        self.assertEqual(event["time_of_day_basis"], "base_rate")
+        self.assertAlmostEqual(event["cost_estimate_usd"], 1.0)
+
+    # -- present-but-unusable time_of_day_pricing is diagnosed, not silent --
+
+    def test_present_but_unusable_time_of_day_pricing_emits_a_meter_error(self):
+        # レビュー指摘3: a table that predates this feature (no
+        # `time_of_day_pricing` key at all) and one that tried and got
+        # the shape wrong must not be indistinguishable -- the latter
+        # records a `meter.error` diagnostic (already surfaced in
+        # `report`'s footer), the former does not.
+        table = self._tod_table()
+        del table["time_of_day_pricing"]["tz_offset"]
+        self._ingest_one("2026-08-05T02:00:00.000Z", table=table)
+        errors = read_meter_errors(self.home)
+        stages = [e.get("stage") for e in errors]
+        self.assertIn("price_table_time_of_day_pricing_unusable", stages)
+
+    def test_table_without_any_time_of_day_pricing_key_does_not_emit_a_meter_error(self):
+        write_transcript(self.projects_dir, "proj", "sess-no-tod-key", [
+            assistant_line("sess-no-tod-key", "m1", model="deepseek-v4-pro", timestamp="2026-08-05T10:00:00.000Z"),
+        ])
+        result = run_ingest(self.home, self.projects_dir)  # real REPO_PRICE_DIR table: no time_of_day_pricing key
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(read_meter_errors(self.home), [])
+
+
+class PriceTableFallbackWarningTests(OcwMeterTestCase):
+    """計画書 DOC-2608081456孫3 §3 / 罠5: 該当する価格表が無い期間を黙らせない。"""
+
+    def setUp(self):
+        super().setUp()
+        self.projects_dir = pathlib.Path(self.tmpdir.name) / "claude-projects"
+        self.projects_dir.mkdir(parents=True, exist_ok=True)
+        self.price_dir = pathlib.Path(self.tmpdir.name) / "prices-fallback"
+        write_price_table(self.price_dir, "deepseek-2026-08-01.json", {
+            "price_table_version": "deepseek-2026-08-01", "effective_date": "2026-08-01",
+            "models": {"deepseek-v4-pro": {"cache_hit_in": 0.003625, "cache_miss_in": 0.435, "out": 0.87}},
+        })
+
+    def test_footer_warns_when_price_table_took_effect_after_the_message(self):
+        # July message, only an August table exists -> fallback.
+        write_transcript(self.projects_dir, "proj", "sess-july", [
+            assistant_line("sess-july", "m1", model="deepseek-v4-pro", timestamp="2026-07-15T10:00:00.000Z"),
+        ])
+        result = run_report(self.home, self.projects_dir, args=["--json"], price_dir=self.price_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        data = json.loads(result.stdout)
+        self.assertEqual(data["price_table_fallback_count"], 1)
+        self.assertIn("took effect AFTER their own message date", data["price_table"])
+
+    def test_footer_does_not_warn_when_price_table_covers_the_message(self):
+        # August message, August table applies as intended -> no fallback.
+        write_transcript(self.projects_dir, "proj", "sess-aug", [
+            assistant_line("sess-aug", "m1", model="deepseek-v4-pro", timestamp="2026-08-05T10:00:00.000Z"),
+        ])
+        result = run_report(self.home, self.projects_dir, args=["--json"], price_dir=self.price_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        data = json.loads(result.stdout)
+        self.assertEqual(data["price_table_fallback_count"], 0)
+        self.assertNotIn("took effect AFTER", data["price_table"])
+
+    def test_month_report_flags_price_table_effective_after_the_month(self):
+        write_transcript(self.projects_dir, "proj", "sess-july2", [
+            assistant_line("sess-july2", "m1", model="deepseek-v4-pro", timestamp="2026-07-15T10:00:00.000Z"),
+        ])
+        result = run_report(self.home, self.projects_dir, args=["--month", "2026-07", "--json"], price_dir=self.price_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        data = json.loads(result.stdout)
+        applied = data["cash_cost"]["price_tables_applied"]
+        self.assertEqual(len(applied), 1)
+        self.assertEqual(applied[0]["price_table_version"], "deepseek-2026-08-01")
+        self.assertEqual(applied[0]["effective_date"], "2026-08-01")
+        self.assertTrue(applied[0]["is_fallback"])
+        self.assertEqual(applied[0]["event_count"], 1)
+        self.assertEqual(applied[0]["fallback_event_count"], 1)
+
+    def test_month_report_does_not_flag_price_table_covering_the_month(self):
+        write_transcript(self.projects_dir, "proj", "sess-aug2", [
+            assistant_line("sess-aug2", "m1", model="deepseek-v4-pro", timestamp="2026-08-05T10:00:00.000Z"),
+        ])
+        result = run_report(self.home, self.projects_dir, args=["--month", "2026-08", "--json"], price_dir=self.price_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        data = json.loads(result.stdout)
+        applied = data["cash_cost"]["price_tables_applied"]
+        self.assertEqual(len(applied), 1)
+        self.assertFalse(applied[0]["is_fallback"])
+        self.assertEqual(applied[0]["event_count"], 1)
+        self.assertEqual(applied[0]["fallback_event_count"], 0)
+
+    def test_month_report_flags_a_same_month_fallback(self):
+        # レビュー指摘2の回帰テスト: the sole price table is effective
+        # 2026-08-15 -- LATER in the SAME month as the message it's
+        # applied to (2026-08-05). Month-granularity comparison
+        # (`"2026-08" > "2026-08"`) missed this; day-granularity
+        # (reusing `_price_table_predates_message`) must catch it, and
+        # must agree with the footer's own (day-granularity) verdict in
+        # the same JSON response.
+        price_dir = pathlib.Path(self.tmpdir.name) / "prices-same-month-fallback"
+        write_price_table(price_dir, "deepseek-2026-08-15.json", {
+            "price_table_version": "deepseek-2026-08-15", "effective_date": "2026-08-15",
+            "models": {"deepseek-v4-pro": {"cache_hit_in": 0.003625, "cache_miss_in": 0.435, "out": 0.87}},
+        })
+        write_transcript(self.projects_dir, "proj", "sess-samemonth", [
+            assistant_line("sess-samemonth", "m1", model="deepseek-v4-pro", timestamp="2026-08-05T10:00:00.000Z"),
+        ])
+        result = run_report(self.home, self.projects_dir, args=["--month", "2026-08", "--json"], price_dir=price_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        data = json.loads(result.stdout)
+        applied = data["cash_cost"]["price_tables_applied"]
+        self.assertEqual(len(applied), 1)
+        self.assertTrue(applied[0]["is_fallback"])
+        # Must agree with the footer's own (independently computed) verdict.
+        self.assertEqual(data["price_table_fallback_count"], 1)
+
+    def test_month_report_flags_a_mixed_fallback_and_covered_month(self):
+        # レビュー指摘8の回帰テスト: the sole price table is effective
+        # 2026-08-15. One message (08-05) predates it (fallback); another
+        # (08-20) is genuinely covered by it. Both are priced by the SAME
+        # `price_table_version`, so a single per-version boolean can't
+        # honestly describe the month -- `fallback_event_count` must be
+        # 1 out of `event_count` 2, not "all" or "none".
+        price_dir = pathlib.Path(self.tmpdir.name) / "prices-mixed-month"
+        write_price_table(price_dir, "deepseek-2026-08-15.json", {
+            "price_table_version": "deepseek-2026-08-15", "effective_date": "2026-08-15",
+            "models": {"deepseek-v4-pro": {"cache_hit_in": 0.003625, "cache_miss_in": 0.435, "out": 0.87}},
+        })
+        write_transcript(self.projects_dir, "proj", "sess-mixed", [
+            assistant_line("sess-mixed", "m1", model="deepseek-v4-pro", timestamp="2026-08-05T10:00:00.000Z"),
+            assistant_line("sess-mixed", "m2", model="deepseek-v4-pro", timestamp="2026-08-20T10:00:00.000Z"),
+        ])
+        result = run_report(self.home, self.projects_dir, args=["--month", "2026-08", "--json"], price_dir=price_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        data = json.loads(result.stdout)
+        applied = data["cash_cost"]["price_tables_applied"]
+        self.assertEqual(len(applied), 1)
+        self.assertEqual(applied[0]["event_count"], 2)
+        self.assertEqual(applied[0]["fallback_event_count"], 1)
+        self.assertTrue(applied[0]["is_fallback"])
+        self.assertEqual(data["price_table_fallback_count"], 1)
+        # Text output must say "2件中1件" (partial), not claim the whole
+        # month (2件) is a fallback.
+        text_result = run_report(self.home, self.projects_dir, args=["--month", "2026-08"], price_dir=price_dir)
+        self.assertIn("2件中1件", text_result.stdout)
+
+    def test_month_report_text_output_shows_the_fallback_marker(self):
+        # レビュー指摘6: only --json was ever asserted on for this view;
+        # the text renderer builds its marker string independently
+        # (bin/ocw-meter's _report_month_standalone) and could silently
+        # diverge from the JSON without any test catching it.
+        write_transcript(self.projects_dir, "proj", "sess-july3", [
+            assistant_line("sess-july3", "m1", model="deepseek-v4-pro", timestamp="2026-07-15T10:00:00.000Z"),
+        ])
+        result = run_report(self.home, self.projects_dir, args=["--month", "2026-07"], price_dir=self.price_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("price_tables_applied:", result.stdout)
+        self.assertIn("deepseek-2026-08-01 (effective 2026-08-01)", result.stdout)
+        self.assertIn("フォールバック", result.stdout)
+        # Full-month fallback (1件全て), not the mixed-case wording.
+        self.assertIn("1件全て", result.stdout)
+
+    def test_month_report_text_output_has_no_fallback_marker_when_covered(self):
+        write_transcript(self.projects_dir, "proj", "sess-aug3", [
+            assistant_line("sess-aug3", "m1", model="deepseek-v4-pro", timestamp="2026-08-05T10:00:00.000Z"),
+        ])
+        result = run_report(self.home, self.projects_dir, args=["--month", "2026-08"], price_dir=self.price_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("deepseek-2026-08-01 (effective 2026-08-01)", result.stdout)
+        self.assertNotIn("フォールバック", result.stdout)
 
 
 class ReportAutoIngestTests(OcwMeterTestCase):

--- a/bin/tests/test_ocw_meter.py
+++ b/bin/tests/test_ocw_meter.py
@@ -4459,5 +4459,481 @@ class SnapshotQuotaRoundTwoReviewTests(OcwMeterTestCase):
         self.assertEqual(status.stdout.strip(), "", "suppression cache must not write inside $HOME's own git worktree")
 
 
+class SessionAttributionTests(OcwMeterTestCase):
+    """docs/planning/DOC-2608081456_..._計画.md 孫5プロンプン: session_id
+    joinによるrun_id/roleの帰属解決(B: ingest側フォールバック / A: report
+    側join)と、attribution行。
+
+    quota.sample events here are written directly via `ocw-meter event
+    quota.sample ...` (bypassing `snapshot-quota`'s statusLine-JSON
+    parsing entirely) — this phase's own scope is the session_id join
+    logic itself, not statusLine ingestion (already covered by
+    SnapshotQuotaBasicsTests etc.), and `event` is the same forward-
+    compatible primitive `_seed_full_pr` above already uses for the same
+    reason."""
+
+    def setUp(self):
+        super().setUp()
+        self.projects_dir = pathlib.Path(self.tmpdir.name) / "claude-projects"
+        self.projects_dir.mkdir(parents=True, exist_ok=True)
+
+    # -- B: ingest側フォールバック --
+
+    def test_ingest_run_id_resolved_via_session_id_join_when_ocw_run_id_file_absent(self):
+        session_id = "sess-join-1"
+        run_meter(["event", "quota.sample", "--idempotency-key", "q1", "--plan-source", "statusline",
+                   "--session-id", session_id, "--run-id", "run-from-session",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        write_transcript(self.projects_dir, "proj", session_id, [
+            assistant_line(session_id, "m1", cwd="/nonexistent/not-a-worktree", timestamp="2026-08-01T09:05:00.000Z"),
+        ])
+        result = run_ingest(self.home, self.projects_dir, extra_env={"PATH": "/usr/bin:/bin"})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = next(e for e in read_events(self.home) if e["event_type"] == "usage.message")
+        self.assertEqual(event["run_id"], "run-from-session")
+        self.assertEqual(event["run_id_source"], "session_id")
+
+    def test_ingest_run_id_prefers_ocw_run_id_file_over_session_join(self):
+        session_id = "sess-join-2"
+        worktree_dir = make_ocw_style_worktree(self.tmpdir.name, run_id="run-direct")
+        run_meter(["event", "quota.sample", "--idempotency-key", "q2", "--plan-source", "statusline",
+                   "--session-id", session_id, "--run-id", "run-from-session",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        write_transcript(self.projects_dir, "proj", session_id, [
+            assistant_line(session_id, "m1", cwd=str(worktree_dir), timestamp="2026-08-01T09:05:00.000Z"),
+        ])
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = next(e for e in read_events(self.home) if e["event_type"] == "usage.message")
+        self.assertEqual(event["run_id"], "run-direct")
+        self.assertEqual(event["run_id_source"], "direct")
+
+    def test_ingest_role_resolved_via_session_id_join_when_herdr_unavailable(self):
+        session_id = "sess-join-role"
+        run_meter(["event", "quota.sample", "--idempotency-key", "q3", "--plan-source", "statusline",
+                   "--session-id", session_id, "--role", "implementer",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        write_transcript(self.projects_dir, "proj", session_id, [
+            assistant_line(session_id, "m1", timestamp="2026-08-01T09:05:00.000Z"),
+        ])
+        result = run_ingest(self.home, self.projects_dir, extra_env={"PATH": "/usr/bin:/bin"})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = next(e for e in read_events(self.home) if e["event_type"] == "usage.message")
+        self.assertEqual(event["role"], "implementer")
+        self.assertEqual(event["role_source"], "session_id")
+
+    def test_ingest_role_prefers_herdr_live_over_session_join(self):
+        session_id = "sess-join-role-2"
+        write_transcript(self.projects_dir, "proj", session_id, [assistant_line(session_id, "m1")])
+        run_meter(["event", "quota.sample", "--idempotency-key", "q4", "--plan-source", "statusline",
+                   "--session-id", session_id, "--role", "reviewer",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+
+        pane_json = json.dumps({"panes": [{
+            "pane_id": "w1:p2", "label": "implementer", "workspace_id": "w1",
+            "agent_session": {"agent": "claude", "kind": "id", "value": session_id},
+            "cwd": "/whatever",
+        }]})
+        fake_bin = pathlib.Path(self.tmpdir.name) / "fake-bin"
+        fake_bin.mkdir()
+        herdr_script = fake_bin / "herdr"
+        herdr_script.write_text(
+            "#!/usr/bin/env bash\n"
+            'if [ "$1" = "status" ] && [ "$2" = "server" ]; then exit 0; fi\n'
+            'if [ "$1" = "workspace" ] && [ "$2" = "list" ]; then echo \'{"workspaces":[{"workspace_id":"w1"}]}\'; exit 0; fi\n'
+            f"if [ \"$1\" = \"pane\" ] && [ \"$2\" = \"list\" ]; then echo '{pane_json}'; exit 0; fi\n"
+            "exit 1\n",
+            encoding="utf-8",
+        )
+        herdr_script.chmod(0o755)
+        path_with_fake_herdr_first = f"{fake_bin}:{os.environ.get('PATH', '')}"
+
+        result = run_ingest(self.home, self.projects_dir, extra_env={"PATH": path_with_fake_herdr_first})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = next(e for e in read_events(self.home) if e["event_type"] == "usage.message")
+        self.assertEqual(event["role"], "implementer")
+        self.assertEqual(event["role_source"], "direct")
+
+    def test_ingest_role_falls_back_to_session_join_when_herdr_label_is_the_string_unknown(self):
+        # レビュー指摘5: `"unknown"`はこのスキーマ全体で「未解決」を表す
+        # 文字列センチネル。Herdrのペインlabelは`herdr pane rename`で人間が
+        # 自由に付けられるため、labelがたまたま`"unknown"`だった場合に
+        # それを「directで解決済み」と誤認してsession joinへの
+        # フォールバックを飛ばしてはいけない。
+        session_id = "sess-join-role-unknown-label"
+        write_transcript(self.projects_dir, "proj", session_id, [assistant_line(session_id, "m1")])
+        run_meter(["event", "quota.sample", "--idempotency-key", "q5", "--plan-source", "statusline",
+                   "--session-id", session_id, "--role", "reviewer",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+
+        pane_json = json.dumps({"panes": [{
+            "pane_id": "w1:p2", "label": "unknown", "workspace_id": "w1",
+            "agent_session": {"agent": "claude", "kind": "id", "value": session_id},
+            "cwd": "/whatever",
+        }]})
+        fake_bin = pathlib.Path(self.tmpdir.name) / "fake-bin-unknown-label"
+        fake_bin.mkdir()
+        herdr_script = fake_bin / "herdr"
+        herdr_script.write_text(
+            "#!/usr/bin/env bash\n"
+            'if [ "$1" = "status" ] && [ "$2" = "server" ]; then exit 0; fi\n'
+            'if [ "$1" = "workspace" ] && [ "$2" = "list" ]; then echo \'{"workspaces":[{"workspace_id":"w1"}]}\'; exit 0; fi\n'
+            f"if [ \"$1\" = \"pane\" ] && [ \"$2\" = \"list\" ]; then echo '{pane_json}'; exit 0; fi\n"
+            "exit 1\n",
+            encoding="utf-8",
+        )
+        herdr_script.chmod(0o755)
+        path_with_fake_herdr_first = f"{fake_bin}:{os.environ.get('PATH', '')}"
+
+        result = run_ingest(self.home, self.projects_dir, extra_env={"PATH": path_with_fake_herdr_first})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = next(e for e in read_events(self.home) if e["event_type"] == "usage.message")
+        self.assertEqual(event["role"], "reviewer")
+        self.assertEqual(event["role_source"], "session_id")
+
+    def test_ingest_run_id_and_role_stay_unresolved_without_any_source(self):
+        session_id = "sess-none"
+        write_transcript(self.projects_dir, "proj", session_id, [
+            assistant_line(session_id, "m1", timestamp="2026-08-01T09:05:00.000Z"),
+        ])
+        result = run_ingest(self.home, self.projects_dir, extra_env={"PATH": "/usr/bin:/bin"})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = next(e for e in read_events(self.home) if e["event_type"] == "usage.message")
+        self.assertIsNone(event["run_id"])
+        self.assertIsNone(event["run_id_source"])
+        self.assertEqual(event["role"], "unknown")
+        self.assertIsNone(event["role_source"])
+
+    def test_ingest_run_id_and_role_from_session_join_can_come_from_different_samples(self):
+        # quota.sampleはOCW_RUN_ID/OCW_ROLEを独立に持ちうる(片方だけ
+        # 設定されている、あるいは無い場合がある) — run_idとroleを
+        # それぞれ別サンプルの「最も時刻が近いもの」から独立に解決する。
+        session_id = "sess-split-fields"
+        run_meter(["event", "quota.sample", "--idempotency-key", "split-q1", "--plan-source", "statusline",
+                   "--session-id", session_id, "--run-id", "run-split",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        run_meter(["event", "quota.sample", "--idempotency-key", "split-q2", "--plan-source", "statusline",
+                   "--session-id", session_id, "--role", "commander",
+                   "--ts", "2026-08-01T09:01:00.000Z"], self.home)
+        write_transcript(self.projects_dir, "proj", session_id, [
+            assistant_line(session_id, "m1", timestamp="2026-08-01T09:02:00.000Z"),
+        ])
+        result = run_ingest(self.home, self.projects_dir, extra_env={"PATH": "/usr/bin:/bin"})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = next(e for e in read_events(self.home) if e["event_type"] == "usage.message")
+        self.assertEqual(event["run_id"], "run-split")
+        self.assertEqual(event["role"], "commander")
+
+    # -- 罠1: session_id由来のrun_idにrun.start逆転チェックを適用しない --
+
+    def test_session_join_run_id_not_subject_to_run_start_reversal_check(self):
+        # ocw-run-idファイル経由なら、メッセージがそのrun_idのrun.startより
+        # 前なら捨てられる(test_ingest_run_id_not_misattributed_when_
+        # worktree_path_is_reusedで確認済み)。session_id由来のrun_idは
+        # worktreeパスのように再利用されることが無いため、同じチェックを
+        # 適用してはいけない(計画書DOC-2608081456 罠1)。
+        session_id = "sess-trap1"
+        run_meter(["event", "run.start", "--idempotency-key", "trap1-start", "--run-id", "run-trap1",
+                   "--ts", "2026-08-01T12:00:00.000Z", "--base-ref", "master", "--command", "claude"],
+                  self.home)
+        run_meter(["event", "quota.sample", "--idempotency-key", "trap1-q", "--plan-source", "statusline",
+                   "--session-id", session_id, "--run-id", "run-trap1",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        # メッセージ(09:05)はrun-trap1のrun.start(12:00)より前。
+        write_transcript(self.projects_dir, "proj", session_id, [
+            assistant_line(session_id, "m1", timestamp="2026-08-01T09:05:00.000Z"),
+        ])
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = next(e for e in read_events(self.home) if e["event_type"] == "usage.message")
+        self.assertEqual(event["run_id"], "run-trap1")
+        self.assertEqual(event["run_id_source"], "session_id")
+
+    def test_direct_run_id_still_subject_to_run_start_reversal_check_regression(self):
+        # 罠1修正の対偶: ocw-run-idファイル経由の逆転チェック自体は
+        # 従来どおり効いたまま — session_id側の除外がdirect側にまで
+        # 波及していないことの回帰確認。
+        worktree_dir = make_ocw_style_worktree(self.tmpdir.name, run_id="run-trap1-direct")
+        run_meter(["event", "run.start", "--idempotency-key", "trap1d-start", "--run-id", "run-trap1-direct",
+                   "--ts", "2026-08-01T12:00:00.000Z", "--base-ref", "master", "--command", "claude"],
+                  self.home)
+        write_transcript(self.projects_dir, "proj", "sess-trap1-direct", [
+            assistant_line("sess-trap1-direct", "m1", cwd=str(worktree_dir), timestamp="2026-08-01T09:05:00.000Z"),
+        ])
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = next(e for e in read_events(self.home) if e["event_type"] == "usage.message")
+        self.assertIsNone(event["run_id"])
+
+    # -- 曖昧なケース: 1つのsession_idに複数のrun_id/roleが紐づく --
+
+    def test_ambiguous_session_run_id_resolves_to_nearest_in_time_sample(self):
+        session_id = "sess-ambiguous"
+        run_meter(["event", "quota.sample", "--idempotency-key", "amb-q1", "--plan-source", "statusline",
+                   "--session-id", session_id, "--run-id", "run-early",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        run_meter(["event", "quota.sample", "--idempotency-key", "amb-q2", "--plan-source", "statusline",
+                   "--session-id", session_id, "--run-id", "run-late",
+                   "--ts", "2026-08-01T11:00:00.000Z"], self.home)
+        run_meter(["event", "phase.start", "--idempotency-key", "amb-ps-early", "--run-id", "run-early",
+                   "--phase", "fix", "--round", "1", "--ts", "2026-08-01T08:00:00.000Z"], self.home)
+        run_meter(["event", "phase.end", "--idempotency-key", "amb-pe-early", "--run-id", "run-early",
+                   "--phase", "fix", "--round", "1", "--ts", "2026-08-01T23:59:00.000Z"], self.home)
+        run_meter(["event", "phase.start", "--idempotency-key", "amb-ps-late", "--run-id", "run-late",
+                   "--phase", "review", "--round", "1", "--ts", "2026-08-01T08:00:00.000Z"], self.home)
+        run_meter(["event", "phase.end", "--idempotency-key", "amb-pe-late", "--run-id", "run-late",
+                   "--phase", "review", "--round", "1", "--ts", "2026-08-01T23:59:00.000Z"], self.home)
+        # メッセージのtsはrun-earlyのサンプル(09:00, 差110分)よりrun-late
+        # のサンプル(11:00, 差10分)に近い — run-lateに解決されるはず。
+        write_transcript(self.projects_dir, "proj", session_id, [
+            assistant_line(session_id, "m1", timestamp="2026-08-01T10:50:00.000Z"),
+        ])
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        data = json.loads(run_meter(["report", "--phase", "--json"], self.home).stdout)
+        self.assertEqual(data["by_phase"]["review"]["messages"], 1)
+        self.assertEqual(data["by_phase"]["fix"]["messages"], 0)
+
+    def test_ambiguous_session_role_resolves_to_nearest_in_time_sample(self):
+        session_id = "sess-ambiguous-role"
+        run_meter(["event", "quota.sample", "--idempotency-key", "ambr-q1", "--plan-source", "statusline",
+                   "--session-id", session_id, "--role", "commander",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        run_meter(["event", "quota.sample", "--idempotency-key", "ambr-q2", "--plan-source", "statusline",
+                   "--session-id", session_id, "--role", "reviewer",
+                   "--ts", "2026-08-01T11:00:00.000Z"], self.home)
+        run_meter(["event", "usage.message", "--idempotency-key", "ambr-u1", "--message-id", "m-ambiguous-role",
+                   "--session-id", session_id, "--model", "deepseek-v4-pro", "--cost-basis", "estimated",
+                   "--ts", "2026-08-01T10:50:00.000Z"], self.home)
+        data = json.loads(run_meter(["report", "--role", "--json"], self.home).stdout)
+        self.assertEqual(data["by_role"]["reviewer"]["messages"], 1)
+        # "commander"バケット自体はcommanderサンプルのquota.sample自身の
+        # roleフィールドで存在する(total_events)が、usage.messageは
+        # そちら側には計上されない。
+        self.assertEqual(data["by_role"].get("commander", {}).get("messages", 0), 0)
+
+    def test_session_join_tie_break_prefers_earlier_sample(self):
+        session_id = "sess-tie"
+        run_meter(["event", "quota.sample", "--idempotency-key", "tie-q1", "--plan-source", "statusline",
+                   "--session-id", session_id, "--run-id", "run-tie-early",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        run_meter(["event", "quota.sample", "--idempotency-key", "tie-q2", "--plan-source", "statusline",
+                   "--session-id", session_id, "--run-id", "run-tie-late",
+                   "--ts", "2026-08-01T11:00:00.000Z"], self.home)
+        # メッセージは2つのサンプルのちょうど中間 -> 同点。仕様上、前方
+        # (早い方)のサンプルを優先する。
+        write_transcript(self.projects_dir, "proj", session_id, [
+            assistant_line(session_id, "m1", timestamp="2026-08-01T10:00:00.000Z"),
+        ])
+        result = run_ingest(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        event = next(e for e in read_events(self.home) if e["event_type"] == "usage.message")
+        self.assertEqual(event["run_id"], "run-tie-early")
+
+    # -- A: report側join --
+
+    def test_report_backfills_null_run_id_and_unknown_role_without_touching_stored_file(self):
+        session_id = "sess-report-join"
+        run_meter(["event", "quota.sample", "--idempotency-key", "rq1", "--plan-source", "statusline",
+                   "--session-id", session_id, "--run-id", "run-report-1", "--role", "implementer",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        run_meter(["event", "usage.message", "--idempotency-key", "ru1", "--message-id", "m-report-1",
+                   "--session-id", session_id, "--model", "deepseek-v4-pro", "--cost-basis", "estimated",
+                   "--ts", "2026-08-01T09:05:00.000Z"], self.home)
+
+        data = json.loads(run_meter(["report", "--role", "--json"], self.home).stdout)
+        self.assertEqual(data["by_role"]["implementer"]["messages"], 1)
+
+        # 保存済みイベントファイル自体は一切書き換わっていない
+        # (read-time解決のみ)。
+        stored = next(e for e in read_events(self.home) if e["event_type"] == "usage.message")
+        self.assertIsNone(stored["run_id"])
+        self.assertEqual(stored["role"], "unknown")
+
+    def test_report_side_join_feeds_phase_view(self):
+        session_id = "sess-report-phase"
+        run_meter(["event", "quota.sample", "--idempotency-key", "rp-q1", "--plan-source", "statusline",
+                   "--session-id", session_id, "--run-id", "run-report-phase",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        run_meter(["event", "phase.start", "--idempotency-key", "rp-ps", "--run-id", "run-report-phase",
+                   "--phase", "fix", "--round", "1", "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        run_meter(["event", "phase.end", "--idempotency-key", "rp-pe", "--run-id", "run-report-phase",
+                   "--phase", "fix", "--round", "1", "--ts", "2026-08-01T09:10:00.000Z"], self.home)
+        run_meter(["event", "usage.message", "--idempotency-key", "rp-u1", "--message-id", "m-report-phase",
+                   "--session-id", session_id, "--model", "deepseek-v4-pro", "--cost-basis", "estimated",
+                   "--ts", "2026-08-01T09:05:00.000Z"], self.home)
+        data = json.loads(run_meter(["report", "--phase", "--json"], self.home).stdout)
+        self.assertEqual(data["by_phase"]["fix"]["messages"], 1)
+        self.assertNotIn("(unassigned)", data["by_phase"])
+
+    def test_report_side_join_lets_events_for_pr_and_pr_review_summary_match_backfilled_run_id(self):
+        session_id = "sess-report-pr"
+        run_meter(["event", "quota.sample", "--idempotency-key", "rpr-q1", "--plan-source", "statusline",
+                   "--session-id", session_id, "--run-id", "run-report-pr",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        run_meter(["bind-pr", "--run", "run-report-pr", "--pr", "77"], self.home)
+        run_meter(["event", "usage.message", "--idempotency-key", "rpr-u1", "--message-id", "m-report-pr",
+                   "--session-id", session_id, "--model", "deepseek-v4-pro", "--cost-basis", "estimated",
+                   "--cost-estimate-usd", "0.05",
+                   "--ts", "2026-08-01T09:05:00.000Z"], self.home)
+        data = json.loads(run_meter(["report", "--pr", "77", "--json"], self.home).stdout)
+        self.assertAlmostEqual(data["pr_detail"]["cash_cost_usd"], 0.05)
+
+    def test_report_side_join_backfills_pr_number_symmetric_with_ingest_side(self):
+        # レビュー指摘2: B(ingest側フォールバック)はrun_idが決まると
+        # pr_number/pr_urlも一緒に埋める(build_usage_eventの
+        # `pr_info = binds.get(run_id)`)。A(report側join)がrun_idだけ
+        # 補完してpr_numberを埋めないと、report_by_windowのpr_ranges
+        # (`e.get("pr_number")`が非nullのイベントだけからPRの時刻レンジを
+        # 作る)が「session joinのrun_idを最初から持っていたか
+        # (ingest側で解決済み)、read-timeに初めて解決したか」で
+        # prs_time_overlapの中身が変わってしまう。
+        session_id = "sess-report-pr-window"
+        run_meter(["event", "quota.sample", "--idempotency-key", "rprw-q1", "--plan-source", "statusline",
+                   "--session-id", session_id, "--run-id", "run-report-pr-window",
+                   "--window-id", "win-report-pr-window",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        run_meter(["event", "quota.sample", "--idempotency-key", "rprw-q2", "--plan-source", "statusline",
+                   "--session-id", session_id, "--run-id", "run-report-pr-window",
+                   "--window-id", "win-report-pr-window",
+                   "--ts", "2026-08-01T09:10:00.000Z"], self.home)
+        run_meter(["bind-pr", "--run", "run-report-pr-window", "--pr", "88"], self.home)
+        # session_idのみ(run_id/pr_numberは無し) — Aがrun_idをsession
+        # joinで解決した後、それをbindsに引いてpr_numberも埋める必要が
+        # ある。
+        run_meter(["event", "usage.message", "--idempotency-key", "rprw-u1", "--message-id", "m-report-pr-window",
+                   "--session-id", session_id, "--model", "deepseek-v4-pro", "--cost-basis", "estimated",
+                   "--ts", "2026-08-01T09:05:00.000Z"], self.home)
+        data = json.loads(run_meter(["report", "--window", "--json"], self.home).stdout)
+        self.assertIn(88, data["by_window"]["win-report-pr-window"]["prs_time_overlap"])
+
+    def test_report_side_pr_number_backfill_is_scoped_to_repo(self):
+        # レビュー指摘(ラウンド2 新規1): `pr_binds_from_events()`が`repo`
+        # でスコープしないと、別リポジトリでbindされたPR番号が
+        # read-timeにこのイベントのpr_numberとして焼き込まれ、
+        # `events_for_pr()`の直接マッチ(pr_number一致 + repo一致)を
+        # すり抜けて別リポジトリの費用が混入してしまう。`run_id`は
+        # グローバルに一意な値なので、このセッションのrun_idと別
+        # リポジトリのpr.bindのrun_idを衝突させて再現する。
+        session_id = "sess-cross-repo"
+        run_meter(["event", "pr.bind", "--idempotency-key", "cross-repo-bind",
+                   "--run-id", "run-cross-repo", "--pr-number", "55",
+                   "--repo", "someone/other-repo"], self.home)
+        run_meter(["event", "quota.sample", "--idempotency-key", "cross-repo-q1", "--plan-source", "statusline",
+                   "--session-id", session_id, "--run-id", "run-cross-repo",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        # 自リポジトリ(このテストの実行cwdから自動解決される)の
+        # usage.message。session_idのみでrun_id/pr_numberは無い —
+        # session joinでrun_idを"run-cross-repo"に解決した後、修正前は
+        # そのrun_idを(repoでスコープせず)binds に引いてpr_number=55を
+        # 焼き込んでしまっていた。
+        run_meter(["event", "usage.message", "--idempotency-key", "cross-repo-u1", "--message-id", "m-cross-repo",
+                   "--session-id", session_id, "--model", "deepseek-v4-pro", "--cost-basis", "estimated",
+                   "--cost-estimate-usd", "999.0",
+                   "--ts", "2026-08-01T09:05:00.000Z"], self.home)
+        data = json.loads(run_meter(["report", "--pr", "55", "--json"], self.home).stdout)
+        # このリポジトリにはPR55への直接紐づけも無いはずなので、上の
+        # usage.message(別リポジトリのPR55にbindされたrun_id経由)は
+        # 一切拾われてはいけない。
+        self.assertIsNone(data["pr_detail"]["cash_cost_usd"])
+
+    def test_report_side_join_does_not_overwrite_already_resolved_run_id(self):
+        session_id = "sess-report-nooverwrite"
+        run_meter(["event", "quota.sample", "--idempotency-key", "rno-q1", "--plan-source", "statusline",
+                   "--session-id", session_id, "--run-id", "run-from-session-should-not-be-used",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        run_meter(["event", "usage.message", "--idempotency-key", "rno-u1", "--message-id", "m-noover",
+                   "--session-id", session_id, "--run-id", "run-already-direct",
+                   "--model", "deepseek-v4-pro", "--cost-basis", "estimated",
+                   "--ts", "2026-08-01T09:05:00.000Z"], self.home)
+        data = json.loads(run_meter(["report", "--json"], self.home).stdout)
+        self.assertEqual(data["attribution_run_id_counts"], {"direct": 1, "session_id": 0, "unresolved": 0})
+
+    def test_report_side_join_does_not_overwrite_already_resolved_role(self):
+        session_id = "sess-role-noover"
+        run_meter(["event", "quota.sample", "--idempotency-key", "rrn-q1", "--plan-source", "statusline",
+                   "--session-id", session_id, "--role", "reviewer",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        run_meter(["event", "usage.message", "--idempotency-key", "rrn-u1", "--message-id", "m-role-noover",
+                   "--session-id", session_id, "--role", "implementer",
+                   "--model", "deepseek-v4-pro", "--cost-basis", "estimated",
+                   "--ts", "2026-08-01T09:05:00.000Z"], self.home)
+        data = json.loads(run_meter(["report", "--role", "--json"], self.home).stdout)
+        self.assertEqual(data["by_role"]["implementer"]["messages"], 1)
+        # "reviewer"バケット自体はquota.sample自身のroleフィールドで
+        # 存在する(total_events)が、usage.messageは上書きされずimplementer
+        # のまま — そちら側には計上されない。
+        self.assertEqual(data["by_role"].get("reviewer", {}).get("messages", 0), 0)
+
+    # -- attribution行 --
+
+    def test_attribution_footer_present_on_empty_storage(self):
+        data = json.loads(run_meter(["report", "--json"], self.home).stdout)
+        self.assertEqual(data["attribution_run_id"], "n/a (no usage.message events)")
+        self.assertEqual(data["attribution_role"], "n/a (no usage.message events)")
+
+    def test_attribution_known_limits_present_in_text_and_json(self):
+        # 孫5プロンプト §4「残る限界を出力または文書に書く」/ レビュー
+        # 指摘1: session_id joinを入れても100%解決には到達しない構造的な
+        # 理由を、attribution行と一緒に毎回出す。
+        # レビュー指摘(ラウンド2 新規2): 絶対日付(2026-08-01)はこの
+        # マシン固有の事実であり、`bin/ocw-meter`は各マシンへ個別に
+        # デプロイされるツールの出力として断言してはいけない。ここでは
+        # マシン非依存の構造的な言い回しの一部だけを固定する。
+        data = json.loads(run_meter(["report", "--json"], self.home).stdout)
+        self.assertIn("quota.sampleの記録が始まるより前の期間は", data["attribution_known_limits"])
+        self.assertNotIn("2026-08-01", data["attribution_known_limits"])
+        text = run_meter(["report"], self.home).stdout
+        self.assertIn("attribution_known_limits:", text)
+
+    def test_attribution_footer_counts_direct_session_and_unresolved_and_sums_to_total(self):
+        # direct: run_idが直接設定されている(session join不要)。
+        run_meter(["event", "usage.message", "--idempotency-key", "att-direct", "--message-id", "m-direct",
+                   "--run-id", "run-direct-x", "--model", "deepseek-v4-pro", "--cost-basis", "estimated",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        # via session_id: quota.sampleとのjoinで解決。
+        session_id = "sess-attribution"
+        run_meter(["event", "quota.sample", "--idempotency-key", "att-q1", "--plan-source", "statusline",
+                   "--session-id", session_id, "--run-id", "run-session-x", "--role", "reviewer",
+                   "--ts", "2026-08-01T09:00:00.000Z"], self.home)
+        run_meter(["event", "usage.message", "--idempotency-key", "att-session", "--message-id", "m-session",
+                   "--session-id", session_id, "--model", "deepseek-v4-pro", "--cost-basis", "estimated",
+                   "--ts", "2026-08-01T09:05:00.000Z"], self.home)
+        # unresolved: どちらの手段でも解決できない。
+        run_meter(["event", "usage.message", "--idempotency-key", "att-unresolved", "--message-id", "m-unresolved",
+                   "--model", "deepseek-v4-pro", "--cost-basis", "estimated",
+                   "--ts", "2026-08-01T09:10:00.000Z"], self.home)
+
+        data = json.loads(run_meter(["report", "--json"], self.home).stdout)
+        run_id_counts = data["attribution_run_id_counts"]
+        self.assertEqual(run_id_counts, {"direct": 1, "session_id": 1, "unresolved": 1})
+        self.assertEqual(sum(run_id_counts.values()), 3)
+        self.assertIn("direct 33.3%", data["attribution_run_id"])
+        self.assertIn("via session_id 33.3%", data["attribution_run_id"])
+        self.assertIn("unresolved 33.3%", data["attribution_run_id"])
+
+        # role: session joinで解決したメッセージ(reviewer)のみ埋まる。
+        role_counts = data["attribution_role_counts"]
+        self.assertEqual(role_counts, {"direct": 0, "session_id": 1, "unresolved": 2})
+
+        text = run_meter(["report"], self.home).stdout
+        self.assertIn("attribution (run_id):", text)
+        self.assertIn("attribution (role):", text)
+
+    def test_reconcile_view_omits_attribution_entirely_in_text_and_json(self):
+        # レビュー指摘4: `--reconcile`はvalid_events構築・session_id join
+        # を経由しないためattributionを計算していない。「computeしていない
+        # ものは出さない」をテキスト・--json両方で徹底し、"n/a"のような
+        # フォールバック文字列で欠落をごまかさない。
+        text_result = run_meter(["report", "--reconcile"], self.home)
+        self.assertEqual(text_result.returncode, 0, text_result.stderr)
+        self.assertNotIn("attribution", text_result.stdout)
+
+        json_result = run_meter(["report", "--reconcile", "--json"], self.home)
+        self.assertEqual(json_result.returncode, 0, json_result.stderr)
+        data = json.loads(json_result.stdout)
+        self.assertFalse(any(key.startswith("attribution") for key in data))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/bin/tests/test_ocw_meter.py
+++ b/bin/tests/test_ocw_meter.py
@@ -39,20 +39,71 @@ completion criteria this maps to (idempotency, message.id dedup,
 message.content non-exposure, cost formula, price-table versioning).
 """
 
+import atexit
 import concurrent.futures
+import hashlib
 import json
 import os
 import pathlib
 import pty
+import shutil
 import stat
 import subprocess
 import sys
 import tempfile
 import time
 import unittest
+from datetime import datetime, timedelta, timezone
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
 OCW_METER = REPO_ROOT / "bin" / "ocw-meter"
+
+# ocw-meter's OWN fallback logic (emit_meter_error, the worktree-refusal
+# suppression cache) derives paths from real $HOME whenever OCW_METER_HOME
+# itself is refused (resolves inside a Git worktree) — not just from
+# OCW_METER_HOME. A test that forgets to override $HOME too therefore
+# silently writes into the developer's REAL ~/.local/state/ocw-meter
+# whenever it exercises that path (found live on this machine — see
+# docs/planning/DOC-2608081456_..._計画.md【4】: 37 stale worktree-refusal
+# entries and 6 meter-error diagnostics, all test-shaped).
+#
+# run_meter/run_snapshot_quota default $HOME (whenever a caller doesn't
+# explicitly pass its own via extra_env) to a directory keyed off `home`
+# (the OCW_METER_HOME argument), under this ONE scratch root — not a
+# single directory shared process-wide, and not a plain sibling of
+# `home` either (孫1 round-1 review findings 7 and 9, plus a round-2
+# fix for a bug the first attempt at finding 9 introduced):
+#
+# - **Independence** (finding 9): a single shared fallback directory let
+#   one test's write silently satisfy another, unrelated test's
+#   `idempotency_key`-deduped assertion (`emit_meter_error`'s dedup key
+#   is `meter-error:<stage>:<YYYY-MM-DD>` — two tests hitting the same
+#   stage on the same day only ever produce ONE line, written by
+#   whichever ran first). Keying the fallback directory off `home`,
+#   which is unique per call site in this file, means each test's own
+#   write path is what actually gets exercised and asserted on.
+# - **Cleanup** (finding 7): a single `atexit`-registered scratch root
+#   covers every per-`home` subdirectory ever created, however many
+#   distinct `home` values this file uses, instead of leaking one
+#   never-cleaned directory per test run.
+# - A first attempt at this made the fallback a plain SIBLING of `home`
+#   (`<home>-home-env-fallback`) to piggyback on `self.tmpdir`'s own
+#   cleanup. That breaks for exactly the tests worth having (the
+#   worktree-refusal ones): when `home` sits inside a throwaway Git repo
+#   (e.g. `repo_dir / "ocw-meter-home"`), a sibling of `home` sits
+#   inside that SAME repo, so `default_storage_root()` built from it
+#   resolves inside a Git worktree too — `emit_meter_error`'s own
+#   `in_git_worktree(target_root)` guard then refuses to write the
+#   diagnostic at all, silently defeating the very scenario under test.
+#   Hashing `home` into a name under a fixed, git-free scratch root
+#   sidesteps that entirely.
+_HOME_FALLBACK_SCRATCH_ROOT = tempfile.mkdtemp(prefix="ocw-meter-test-home-fallbacks-")
+atexit.register(shutil.rmtree, _HOME_FALLBACK_SCRATCH_ROOT, ignore_errors=True)
+
+
+def _default_home_for(home):
+    digest = hashlib.sha1(str(home).encode("utf-8")).hexdigest()[:16]
+    return str(pathlib.Path(_HOME_FALLBACK_SCRATCH_ROOT) / digest)
 
 
 def run_meter(args, home, extra_env=None, timeout=30, cwd=None):
@@ -62,6 +113,8 @@ def run_meter(args, home, extra_env=None, timeout=30, cwd=None):
     # under, so assertions about "unset -> null" stay meaningful.
     for key in ("OCW_RUN_ID", "OCW_ROLE", "HERDR_WORKSPACE_ID", "HERDR_PANE_ID"):
         env.pop(key, None)
+    if not extra_env or "HOME" not in extra_env:
+        env["HOME"] = _default_home_for(home)
     if extra_env:
         env.update(extra_env)
     return subprocess.run(
@@ -82,6 +135,8 @@ def run_snapshot_quota(stdin_text, home, extra_env=None, timeout=30):
     env["OCW_METER_HOME"] = str(home)
     for key in ("OCW_RUN_ID", "OCW_ROLE", "HERDR_WORKSPACE_ID", "HERDR_PANE_ID"):
         env.pop(key, None)
+    if not extra_env or "HOME" not in extra_env:
+        env["HOME"] = _default_home_for(home)
     if extra_env:
         env.update(extra_env)
     return subprocess.run(
@@ -93,6 +148,37 @@ def run_snapshot_quota(stdin_text, home, extra_env=None, timeout=30):
         text=True,
         timeout=timeout,
     )
+
+
+def real_ocw_meter_home_contamination_fingerprint():
+    """A NARROW fingerprint of the developer's REAL
+    ~/.local/state/ocw-meter — deliberately NOT a full directory
+    snapshot (孫1 round-1 review finding 5): Claude Code's own statusLine
+    hook calls the real `ocw-meter snapshot-quota` roughly every 60s
+    independently of this test run, touching
+    events/YYYY-MM-DD.jsonl / state/quota-last-sample.json /
+    state/seen-keys/YYYY-MM.txt on this developer's machine — legitimate
+    activity a before/after full-tree equality check flags as a false
+    positive. This instead looks only at what a HOME-isolation bug in
+    THIS test file could plausibly cause: new test-shaped keys appearing
+    in quota-worktree-refusal.json, or meter-errors.jsonl growing."""
+    root = pathlib.Path(os.path.expanduser("~")) / ".local" / "state" / "ocw-meter"
+    refusal_path = root / "state" / "quota-worktree-refusal.json"
+    test_like_refusal_keys = set()
+    if refusal_path.exists():
+        try:
+            data = json.loads(refusal_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            data = {}
+        if isinstance(data, dict):
+            test_like_refusal_keys = {k for k in data if "ocw-meter-home" in k}
+    meter_errors_path = root / "state" / "meter-errors.jsonl"
+    meter_errors_line_count = 0
+    if meter_errors_path.exists():
+        meter_errors_line_count = len(
+            [line for line in meter_errors_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        )
+    return test_like_refusal_keys, meter_errors_line_count
 
 
 def read_events(home):
@@ -2147,6 +2233,13 @@ class SnapshotQuotaBasicsTests(OcwMeterTestCase):
         self.assertEqual(event["raw_ref"], str(raw_files[0]))
 
     def test_git_worktree_home_refuses_write_but_still_prints_display(self):
+        # 孫1 (計画書 DOC-2608081456【4】): this test deliberately does NOT
+        # pass its own extra_env={"HOME": ...} — it exists specifically to
+        # exercise run_snapshot_quota's DEFAULT isolation (see
+        # _default_home_for above). Before that fix, the meter.error
+        # fallback this triggers landed in this developer's real
+        # ~/.local/state/ocw-meter every single test run.
+        real_home_before = real_ocw_meter_home_contamination_fingerprint()
         repo_dir = pathlib.Path(self.tmpdir.name) / "repo"
         subprocess.run(["git", "init", "-q", str(repo_dir)], check=True)
         bad_home = repo_dir / "ocw-meter-home"
@@ -2155,6 +2248,424 @@ class SnapshotQuotaBasicsTests(OcwMeterTestCase):
         self.assertEqual(result.stdout.strip(), "5h:37% 7d:12% ctx:24%")
         self.assertIn("resolves inside a Git worktree", result.stderr)
         self.assertFalse((bad_home / "events").exists())
+
+        # The refusal's meter.error self-diagnostic must land under the
+        # isolated $HOME the helper substituted for THIS call (derived
+        # from bad_home — round-1 review finding 9's per-call
+        # isolation), not the real one.
+        fallback_root = pathlib.Path(_default_home_for(bad_home)) / ".local" / "state" / "ocw-meter"
+        diagnostics = read_meter_errors(fallback_root)
+        self.assertTrue(
+            any(d["stage"] == "storage_home_inside_git_worktree" for d in diagnostics),
+            "expected the worktree-refusal meter.error under the isolated $HOME fallback",
+        )
+        self.assertEqual(real_ocw_meter_home_contamination_fingerprint(), real_home_before)
+
+
+class HomeIsolationContractTests(OcwMeterTestCase):
+    """孫1 (計画書 DOC-2608081456【4】): a contract test for run_meter/
+    run_snapshot_quota themselves, not for ocw-meter — any test in this
+    file that forgets to override $HOME must still never touch the
+    developer's real ~/.local/state/ocw-meter, because the helpers
+    default it to a throwaway directory unless a test opts out."""
+
+    def test_run_snapshot_quota_never_touches_the_real_home_without_an_explicit_override(self):
+        before = real_ocw_meter_home_contamination_fingerprint()
+        repo_dir = pathlib.Path(self.tmpdir.name) / "repo-for-home-isolation-contract"
+        subprocess.run(["git", "init", "-q", str(repo_dir)], check=True)
+        bad_home = repo_dir / "ocw-meter-home"
+        # Triggers the one code path (worktree-refusal fallback) that
+        # ever reads $HOME at all — anything less would pass trivially.
+        result = run_snapshot_quota(json.dumps(CLAUDE_STATUSLINE_SAMPLE), bad_home)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(real_ocw_meter_home_contamination_fingerprint(), before)
+
+    def test_run_meter_never_touches_the_real_home_without_an_explicit_override(self):
+        before = real_ocw_meter_home_contamination_fingerprint()
+        repo_dir = pathlib.Path(self.tmpdir.name) / "repo-for-home-isolation-contract-2"
+        subprocess.run(["git", "init", "-q", str(repo_dir)], check=True)
+        bad_home = repo_dir / "ocw-meter-home"
+        result = run_meter(["event", "run.start", "--idempotency-key", "k1"], bad_home)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(real_ocw_meter_home_contamination_fingerprint(), before)
+
+
+def _iso(dt):
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{dt.microsecond // 1000:03d}Z"
+
+
+def _write_worktree_refusal_state(home, entries):
+    # The refusal cache lives at the DEFAULT storage root
+    # ($HOME/.local/state/ocw-meter), not at $HOME itself — mirrors
+    # default_storage_root() in bin/ocw-meter.
+    state_dir = pathlib.Path(home) / ".local" / "state" / "ocw-meter" / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    path = state_dir / "quota-worktree-refusal.json"
+    path.write_text(json.dumps(entries), encoding="utf-8")
+    return path
+
+
+class WorktreeRefusalPruningTests(OcwMeterTestCase):
+    """孫1 (計画書 DOC-2608081456【6】): quota-worktree-refusal.json used to
+    only drop entries older than QUOTA_SESSION_STATE_MAX_AGE_SECONDS (24h)
+    at the moment a NEW refusal was recorded — once refusals stopped
+    happening, stale entries sat in the file forever (37 of them, all
+    >24h old, found on this machine's real store). Pruning must now also
+    happen on every READ, so a normal (non-refusing) `snapshot-quota`
+    call cleans them up too."""
+
+    def _fresh_default_home(self):
+        # The refusal cache always lives at the DEFAULT ($HOME-derived)
+        # root, never at OCW_METER_HOME itself (see
+        # load_and_prune_worktree_refusal_state's docstring in
+        # bin/ocw-meter) — this must be a directory distinct from
+        # self.home (OCW_METER_HOME) for that caching code path to
+        # engage at all.
+        default_home = pathlib.Path(self.tmpdir.name) / "fake-home-for-pruning"
+        default_home.mkdir()
+        return default_home
+
+    def _call(self, default_home):
+        return run_snapshot_quota(
+            json.dumps(CLAUDE_STATUSLINE_SAMPLE),
+            self.home,
+            extra_env={"HOME": str(default_home), "OCW_METER_QUOTA_INTERVAL": "0"},
+        )
+
+    def test_stale_entries_are_pruned_when_ocw_meter_home_is_unset_matching_the_default_root(self):
+        # round-1 review finding 1: THE single most common real
+        # configuration is OCW_METER_HOME unset entirely, in which case
+        # bin/ocw-meter's own bash wrapper defaults it to
+        # `$HOME/.local/state/ocw-meter` — i.e. `storage_root() ==
+        # default_storage_root()`. An earlier version of the read-time
+        # pruning fix additionally required the two to DIFFER before
+        # even loading (and therefore pruning) the file, which silently
+        # skipped pruning in exactly this configuration — the one this
+        # machine's real 37 stale entries needed. This reproduces that
+        # configuration directly (OCW_METER_HOME left unset, unlike
+        # every other test in this class, which always sets it via
+        # run_snapshot_quota's `home` argument).
+        home = pathlib.Path(self.tmpdir.name) / "home-for-unset-ocw-meter-home"
+        home.mkdir()
+        old_ts = _iso(datetime.now(timezone.utc) - timedelta(hours=25))
+        state_path = _write_worktree_refusal_state(home, {"/some/old/bad/root": old_ts})
+
+        env = dict(os.environ)
+        env.pop("OCW_METER_HOME", None)
+        env["HOME"] = str(home)
+        env["OCW_METER_QUOTA_INTERVAL"] = "0"
+        for key in ("OCW_RUN_ID", "OCW_ROLE", "HERDR_WORKSPACE_ID", "HERDR_PANE_ID"):
+            env.pop(key, None)
+        result = subprocess.run(
+            [str(OCW_METER), "snapshot-quota"],
+            cwd=str(REPO_ROOT),
+            env=env,
+            input=json.dumps(CLAUDE_STATUSLINE_SAMPLE),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(json.loads(state_path.read_text(encoding="utf-8")), {})
+
+    def test_stale_entries_are_pruned_on_a_normal_non_refusing_call(self):
+        default_home = self._fresh_default_home()
+        old_ts = _iso(datetime.now(timezone.utc) - timedelta(hours=25))
+        state_path = _write_worktree_refusal_state(default_home, {"/some/old/bad/root": old_ts})
+
+        result = self._call(default_home)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(json.loads(state_path.read_text(encoding="utf-8")), {})
+
+    def test_entries_within_24h_are_kept(self):
+        default_home = self._fresh_default_home()
+        recent_ts = _iso(datetime.now(timezone.utc) - timedelta(hours=1))
+        state_path = _write_worktree_refusal_state(default_home, {"/some/recent/bad/root": recent_ts})
+
+        result = self._call(default_home)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(
+            json.loads(state_path.read_text(encoding="utf-8")),
+            {"/some/recent/bad/root": recent_ts},
+        )
+
+    def test_stale_and_fresh_entries_mixed_only_stale_ones_are_dropped(self):
+        default_home = self._fresh_default_home()
+        old_ts = _iso(datetime.now(timezone.utc) - timedelta(hours=25))
+        recent_ts = _iso(datetime.now(timezone.utc) - timedelta(hours=1))
+        state_path = _write_worktree_refusal_state(
+            default_home, {"/old/root": old_ts, "/recent/root": recent_ts}
+        )
+
+        result = self._call(default_home)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(
+            json.loads(state_path.read_text(encoding="utf-8")),
+            {"/recent/root": recent_ts},
+        )
+
+    def test_mtime_is_unchanged_when_nothing_needs_pruning(self):
+        # No wasted write-back on the common case: snapshot-quota is
+        # called on essentially every statusLine tick (~60s throttle), so
+        # a machine with zero or all-fresh refusal entries must not pay
+        # for a rewrite on every single call.
+        default_home = self._fresh_default_home()
+        recent_ts = _iso(datetime.now(timezone.utc) - timedelta(hours=1))
+        state_path = _write_worktree_refusal_state(default_home, {"/recent/root": recent_ts})
+        mtime_before = state_path.stat().st_mtime_ns
+
+        result = self._call(default_home)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(state_path.stat().st_mtime_ns, mtime_before)
+
+
+def _write_meter_errors(home, event_dicts):
+    state_dir = pathlib.Path(home) / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    path = state_dir / "meter-errors.jsonl"
+    path.write_text("".join(json.dumps(d, ensure_ascii=False) + "\n" for d in event_dicts), encoding="utf-8")
+    return path
+
+
+def _write_refusal_state_at_default_root(ocw_meter_home, entries):
+    # round-1 review finding 2: quota-worktree-refusal.json is ALWAYS at
+    # the DEFAULT ($HOME-derived) root, never under a custom
+    # OCW_METER_HOME — same as WorktreeRefusalPruningTests'
+    # _write_worktree_refusal_state above. run_meter (used without an
+    # explicit extra_env={"HOME": ...} override here) defaults $HOME to
+    # `_default_home_for(ocw_meter_home)`, so that is where
+    # prune-diagnostics will actually look.
+    default_home = _default_home_for(ocw_meter_home)
+    state_dir = pathlib.Path(default_home) / ".local" / "state" / "ocw-meter" / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    path = state_dir / "quota-worktree-refusal.json"
+    path.write_text(json.dumps(entries), encoding="utf-8")
+    return path
+
+
+class PruneDiagnosticsTests(OcwMeterTestCase):
+    """孫1 (計画書 DOC-2608081456【4】の後始末): `ocw-meter prune-diagnostics`
+    cleans up state/meter-errors.jsonl and state/quota-worktree-
+    refusal.json only, dry-run by default."""
+
+    def _seed(self):
+        old_ts = _iso(datetime.now(timezone.utc) - timedelta(days=31))
+        new_ts = _iso(datetime.now(timezone.utc) - timedelta(days=1))
+        errors_path = _write_meter_errors(
+            self.home,
+            [
+                {
+                    "schema_version": 1, "event_type": "meter.error",
+                    "idempotency_key": "meter-error:storage_home_inside_git_worktree:old",
+                    "ts": old_ts, "stage": "storage_home_inside_git_worktree", "completeness": "unknown",
+                },
+                {
+                    "schema_version": 1, "event_type": "meter.error",
+                    "idempotency_key": "meter-error:storage_home_inside_git_worktree:new",
+                    "ts": new_ts, "stage": "storage_home_inside_git_worktree", "completeness": "unknown",
+                },
+            ],
+        )
+        refusal_path = _write_refusal_state_at_default_root(
+            self.home, {"/old/root": old_ts, "/new/root": new_ts}
+        )
+        return old_ts, new_ts, errors_path, refusal_path
+
+    def test_dry_run_default_removes_nothing_but_reports_counts(self):
+        old_ts, new_ts, errors_path, refusal_path = self._seed()
+
+        result = run_meter(["prune-diagnostics"], self.home)
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("dry-run", result.stdout)
+        self.assertIn("would remove 1, kept 1", result.stdout)
+
+        self.assertEqual(len(errors_path.read_text(encoding="utf-8").splitlines()), 2)
+        self.assertEqual(len(json.loads(refusal_path.read_text(encoding="utf-8"))), 2)
+
+    def test_apply_removes_only_old_entries(self):
+        old_ts, new_ts, errors_path, refusal_path = self._seed()
+
+        result = run_meter(["prune-diagnostics", "--apply"], self.home)
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("applied", result.stdout)
+        self.assertIn("removed 1, kept 1", result.stdout)
+
+        remaining_errors = [
+            json.loads(line) for line in errors_path.read_text(encoding="utf-8").splitlines() if line.strip()
+        ]
+        self.assertEqual(len(remaining_errors), 1)
+        self.assertEqual(remaining_errors[0]["ts"], new_ts)
+
+        self.assertEqual(json.loads(refusal_path.read_text(encoding="utf-8")), {"/new/root": new_ts})
+
+    def test_older_than_overrides_the_default_retention(self):
+        old_ts, new_ts, errors_path, refusal_path = self._seed()
+        # new_ts is 1 day old; --older-than 0 makes even that eligible.
+        result = run_meter(["prune-diagnostics", "--older-than", "0", "--apply"], self.home)
+        self.assertEqual(result.returncode, 0)
+        # Every entry was eligible, so the emptied meter-errors.jsonl is
+        # removed outright rather than left behind as a 0-byte file.
+        self.assertFalse(errors_path.exists())
+        self.assertEqual(json.loads(refusal_path.read_text(encoding="utf-8")), {})
+
+    def test_events_directory_is_never_touched(self):
+        old_ts, _new_ts, _errors_path, _refusal_path = self._seed()
+        # A real event, well outside the retention window, in events/ —
+        # must survive byte-for-byte. Deleting observation events is
+        # `prune`'s territory (deliberately unimplemented); this
+        # subcommand must never touch events/*.jsonl.
+        run_meter(["event", "run.start", "--idempotency-key", "k1", "--ts", old_ts], self.home)
+        events_dir = self.home / "events"
+        before = {p.name: p.read_bytes() for p in events_dir.glob("*.jsonl")}
+        self.assertTrue(before)
+
+        result = run_meter(["prune-diagnostics", "--apply"], self.home)
+        self.assertEqual(result.returncode, 0)
+
+        after = {p.name: p.read_bytes() for p in events_dir.glob("*.jsonl")}
+        self.assertEqual(before, after)
+
+    def test_missing_target_files_report_zero_and_exit_zero(self):
+        result = run_meter(["prune-diagnostics"], self.home)
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("would remove 0, kept 0", result.stdout)
+
+        result_apply = run_meter(["prune-diagnostics", "--apply"], self.home)
+        self.assertEqual(result_apply.returncode, 0)
+        self.assertIn("removed 0, kept 0", result_apply.stdout)
+
+    def test_corrupt_refusal_json_is_reported_as_corrupt_not_silently_treated_as_empty(self):
+        # round-1 review finding 8: silently treating a corrupt file as
+        # {} (load_json_state_file's normal, correct behavior for every
+        # OTHER caller) let this subcommand report "kept 0" for a file
+        # that, in fact, was still sitting there unreadable. The dry-run
+        # output must say so, and --apply must repair it (replace with a
+        # valid empty state), not just avoid crashing.
+        default_home = _default_home_for(self.home)
+        refusal_path = pathlib.Path(default_home) / ".local" / "state" / "ocw-meter" / "state" / "quota-worktree-refusal.json"
+        refusal_path.parent.mkdir(parents=True, exist_ok=True)
+        refusal_path.write_text("{not valid json", encoding="utf-8")
+
+        result = run_meter(["prune-diagnostics"], self.home)
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("could not parse", result.stdout)
+        # Untouched in dry-run.
+        self.assertEqual(refusal_path.read_text(encoding="utf-8"), "{not valid json")
+
+        result_apply = run_meter(["prune-diagnostics", "--apply"], self.home)
+        self.assertEqual(result_apply.returncode, 0)
+        self.assertIn("replaced with an empty state", result_apply.stdout)
+        self.assertEqual(json.loads(refusal_path.read_text(encoding="utf-8")), {})
+
+    def test_meter_errors_under_the_default_root_fallback_are_also_cleaned(self):
+        # round-1 review finding 2: emit_meter_error falls back to the
+        # DEFAULT ($HOME-derived) root whenever OCW_METER_HOME itself is
+        # refused for resolving inside a Git worktree — this subcommand
+        # must reach diagnostics stored there too, not only under
+        # OCW_METER_HOME (which, in this exact scenario, cannot hold
+        # ANY of ocw-meter's own files at all).
+        repo_dir = pathlib.Path(self.tmpdir.name) / "repo-for-default-root-fallback"
+        subprocess.run(["git", "init", "-q", str(repo_dir)], check=True)
+        bad_home = repo_dir / "ocw-meter-home"
+        fake_home = pathlib.Path(self.tmpdir.name) / "fake-home-for-default-root-fallback"
+        fake_home.mkdir()
+        old_ts = _iso(datetime.now(timezone.utc) - timedelta(days=31))
+        errors_path = _write_meter_errors(
+            fake_home / ".local" / "state" / "ocw-meter",
+            [
+                {
+                    "schema_version": 1, "event_type": "meter.error",
+                    "idempotency_key": "meter-error:storage_home_inside_git_worktree:old",
+                    "ts": old_ts, "stage": "storage_home_inside_git_worktree", "completeness": "unknown",
+                },
+            ],
+        )
+
+        result = run_meter(["prune-diagnostics", "--apply"], bad_home, extra_env={"HOME": str(fake_home)})
+        self.assertEqual(result.returncode, 0)
+        self.assertFalse(errors_path.exists())
+
+    def test_trailing_slash_ocw_meter_home_does_not_double_count_meter_errors(self):
+        # round-2 review finding 2: storage_root() and
+        # default_storage_root() were deduped by bare string equality —
+        # a trailing slash on OCW_METER_HOME made the SAME real
+        # directory look like two distinct roots, so meter-errors.jsonl
+        # got read (and reported) twice, and dry-run/--apply disagreed.
+        fake_home = pathlib.Path(self.tmpdir.name) / "fake-home-for-trailing-slash"
+        fake_home.mkdir()
+        default_root = fake_home / ".local" / "state" / "ocw-meter"
+        old_ts = _iso(datetime.now(timezone.utc) - timedelta(days=31))
+        errors_path = _write_meter_errors(
+            default_root,
+            [
+                {
+                    "schema_version": 1, "event_type": "meter.error",
+                    "idempotency_key": "meter-error:storage_home_inside_git_worktree:old",
+                    "ts": old_ts, "stage": "storage_home_inside_git_worktree", "completeness": "unknown",
+                },
+            ],
+        )
+        # Same real directory as default_storage_root() would compute,
+        # spelled with a trailing slash as OCW_METER_HOME.
+        ocw_meter_home_with_slash = str(default_root) + "/"
+
+        result = run_meter(["prune-diagnostics"], ocw_meter_home_with_slash, extra_env={"HOME": str(fake_home)})
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("would remove 1, kept 0", result.stdout)
+
+        result_apply = run_meter(
+            ["prune-diagnostics", "--apply"], ocw_meter_home_with_slash, extra_env={"HOME": str(fake_home)}
+        )
+        self.assertEqual(result_apply.returncode, 0)
+        self.assertIn("removed 1, kept 0", result_apply.stdout)
+        # The only entry was dropped, so the file is removed outright
+        # (same convention as an emptied meter-errors.jsonl elsewhere) —
+        # if it had instead been double-counted, this would still exist
+        # with the second, incorrectly-kept "copy" of the entry.
+        self.assertFalse(errors_path.exists())
+
+    def test_per_root_breakdown_shown_when_both_roots_have_meter_errors(self):
+        # round-2 review finding 4: once meter-errors.jsonl could live
+        # under either root, the aggregate count alone no longer says
+        # which physical file(s) actually get rewritten.
+        fake_home = pathlib.Path(self.tmpdir.name) / "fake-home-for-breakdown"
+        fake_home.mkdir()
+        default_root = fake_home / ".local" / "state" / "ocw-meter"
+        old_ts = _iso(datetime.now(timezone.utc) - timedelta(days=31))
+        _write_meter_errors(
+            default_root,
+            [
+                {
+                    "schema_version": 1, "event_type": "meter.error",
+                    "idempotency_key": "meter-error:storage_home_inside_git_worktree:default",
+                    "ts": old_ts, "stage": "storage_home_inside_git_worktree", "completeness": "unknown",
+                },
+            ],
+        )
+        _write_meter_errors(
+            self.home,
+            [
+                {
+                    "schema_version": 1, "event_type": "meter.error",
+                    "idempotency_key": "meter-error:write_event_lock_timeout:custom",
+                    "ts": old_ts, "stage": "write_event_lock_timeout", "completeness": "unknown",
+                },
+            ],
+        )
+
+        result = run_meter(["prune-diagnostics"], self.home, extra_env={"HOME": str(fake_home)})
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("would remove 2, kept 0", result.stdout)
+        self.assertIn(str(pathlib.Path(default_root).resolve()), result.stdout)
+        self.assertIn(str(pathlib.Path(self.home).resolve()), result.stdout)
+
+    def test_negative_older_than_is_rejected(self):
+        result = run_meter(["prune-diagnostics", "--older-than", "-1"], self.home)
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_non_numeric_older_than_is_rejected(self):
+        result = run_meter(["prune-diagnostics", "--older-than", "not-a-number"], self.home)
+        self.assertNotEqual(result.returncode, 0)
 
 
 class SnapshotQuotaThrottleTests(OcwMeterTestCase):

--- a/bin/tests/test_ocw_meter.py
+++ b/bin/tests/test_ocw_meter.py
@@ -4143,11 +4143,14 @@ class ReportListPriceEquivTests(OcwMeterTestCase):
         self.assertIsNone(data["capacity"]["list_price_equiv_usd"])
 
     def test_pre_august_month_explains_null_as_no_collection_yet(self):
-        # quota.sample の記録自体が2026-08-01開始なので、それより前の月は
-        # 「今月たまたま0件だった」ではなく「原理的にデータが無い」。
+        # quota.sample が1件も無い月は list_price_equiv_usd が null になり、
+        # ノートに理由が添えられる。理由の文言は「記録開始前」「該当セッションが
+        # 無かった」のどちらか特定のマシン日付を主張しない（レビュー指摘 最終PR
+        # ラウンド1 finding 3: 絶対日付をハードコードしない）。
         data = json.loads(run_meter(["report", "--month", "2026-07", "--json"], self.home).stdout)
         self.assertIsNone(data["capacity"]["list_price_equiv_usd"])
-        self.assertIn("2026-08-01", data["capacity"]["list_price_equiv_note"])
+        self.assertIn("quota.sampleの記録が始まる前の期間", data["capacity"]["list_price_equiv_note"])
+        self.assertNotIn("2026-08-01", data["capacity"]["list_price_equiv_note"])
 
     def test_list_price_equiv_appears_in_pr_report(self):
         run_meter(["event", "run.start", "--idempotency-key", "r1", "--run-id", "run-lp1",

--- a/bin/tests/test_ocw_meter.py
+++ b/bin/tests/test_ocw_meter.py
@@ -4142,7 +4142,7 @@ class ReportListPriceEquivTests(OcwMeterTestCase):
         data = json.loads(run_meter(["report", "--month", "2026-08", "--json"], self.home).stdout)
         self.assertIsNone(data["capacity"]["list_price_equiv_usd"])
 
-    def test_pre_august_month_explains_null_as_no_collection_yet(self):
+    def test_null_month_before_any_quota_sample_explains_null_as_no_collection_yet(self):
         # quota.sample が1件も無い月は list_price_equiv_usd が null になり、
         # ノートに理由が添えられる。理由の文言は「記録開始前」「該当セッションが
         # 無かった」のどちらか特定のマシン日付を主張しない（レビュー指摘 最終PR
@@ -4151,6 +4151,22 @@ class ReportListPriceEquivTests(OcwMeterTestCase):
         self.assertIsNone(data["capacity"]["list_price_equiv_usd"])
         self.assertIn("quota.sampleの記録が始まる前の期間", data["capacity"]["list_price_equiv_note"])
         self.assertNotIn("2026-08-01", data["capacity"]["list_price_equiv_note"])
+
+    def test_null_month_after_collection_started_still_gets_the_note(self):
+        # レビュー指摘 最終PRラウンド2 新規1: 判定条件を month<"2026-08" から
+        # list_price_equiv_usd is None のみに一本化した結果、「記録開始後だが
+        # この月はたまたまanthropicセッションが無かった」ケースにも注記が付く
+        # ようになった。この挙動自体をテストで固定する — 月による絞り込みを
+        # 誰かが復活させると、このテストだけが検知できる。
+        self._quota_sample("q1", "sess-has-data", 10.0, "2026-08-05T09:00:00.000Z")
+        data = json.loads(run_meter(["report", "--month", "2026-08", "--json"], self.home).stdout)
+        self.assertAlmostEqual(data["capacity"]["list_price_equiv_usd"], 10.0)
+        self.assertEqual(data["capacity"]["list_price_equiv_note"].count(
+            "quota.sampleの記録が始まる前の期間"), 0)
+
+        data = json.loads(run_meter(["report", "--month", "2026-12", "--json"], self.home).stdout)
+        self.assertIsNone(data["capacity"]["list_price_equiv_usd"])
+        self.assertIn("quota.sampleの記録が始まる前の期間", data["capacity"]["list_price_equiv_note"])
 
     def test_list_price_equiv_appears_in_pr_report(self):
         run_meter(["event", "run.start", "--idempotency-key", "r1", "--run-id", "run-lp1",

--- a/bin/tests/test_ocw_meter.py
+++ b/bin/tests/test_ocw_meter.py
@@ -296,6 +296,21 @@ def run_ingest(home, projects_dir, args=None, price_dir=None, extra_env=None, ti
     return run_meter(["ingest", *(args or [])], home, extra_env=env, timeout=timeout)
 
 
+def run_report(home, projects_dir=None, args=None, price_dir=None, extra_env=None, timeout=60):
+    """Like `run_ingest`, but drives `report` (whose automatic ingest —
+    計画書 DOC-2608081456孫2 — is what most callers of this helper mean
+    to exercise) instead of `ingest` directly."""
+    env = {
+        "OCW_METER_PRICE_DIR": str(price_dir if price_dir is not None else REPO_PRICE_DIR),
+        "OCW_METER_INGEST_USE_GH": "0",
+    }
+    if projects_dir is not None:
+        env["OCW_METER_CLAUDE_PROJECTS_DIR"] = str(projects_dir)
+    if extra_env:
+        env.update(extra_env)
+    return run_meter(["report", *(args or [])], home, extra_env=env, timeout=timeout)
+
+
 class OcwMeterTestCase(unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.TemporaryDirectory()
@@ -1865,6 +1880,187 @@ class IngestTests(OcwMeterTestCase):
         self.assertFalse(events_file.read_text(encoding="utf-8").endswith("\n"))
 
 
+class ReportAutoIngestTests(OcwMeterTestCase):
+    """計画書 DOC-2608081456孫2: `report` auto-runs `ingest` at the top of
+    every view (DOC-2608021229-a:440 documented this from the start, but
+    `cmd_report` never actually called it — 4 days / 11.4% of events
+    silently missing on the real machine)."""
+
+    def setUp(self):
+        super().setUp()
+        self.projects_dir = pathlib.Path(self.tmpdir.name) / "claude-projects"
+        self.projects_dir.mkdir(parents=True, exist_ok=True)
+
+    def test_report_auto_ingests_transcripts_without_an_explicit_ingest_call(self):
+        write_transcript(self.projects_dir, "proj", "sess-auto", [assistant_line("sess-auto", "m1")])
+        self.assertEqual(read_events(self.home), [])
+
+        result = run_report(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        usage_events = [e for e in read_events(self.home) if e["event_type"] == "usage.message"]
+        self.assertEqual(len(usage_events), 1)
+
+    def test_no_ingest_flag_skips_the_automatic_ingest(self):
+        write_transcript(self.projects_dir, "proj", "sess-skip", [assistant_line("sess-skip", "m1")])
+        result = run_report(self.home, self.projects_dir, args=["--no-ingest"])
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(read_events(self.home), [])
+        self.assertIn("ingest (this run): skipped (--no-ingest)", result.stdout)
+        # PR #57 review round 2 finding "新規2": the "no events yet"
+        # messages must not assert anything about whether ingest ran —
+        # round 1's own fix for finding 1 made them unconditionally claim
+        # "ingest already ran automatically", which is false right here
+        # under --no-ingest. Whether it ran is the freshness footer's
+        # `ingest (this run):` line's job alone (asserted above).
+        self.assertNotIn("ingest already ran automatically", result.stdout)
+        self.assertIn("no usage.message events found in transcripts", result.stdout)
+
+        reconcile_result = run_report(self.home, self.projects_dir, args=["--reconcile", "--no-ingest"])
+        self.assertEqual(reconcile_result.returncode, 0, reconcile_result.stderr)
+        self.assertNotIn("ingest already ran automatically", reconcile_result.stdout)
+
+    def test_invalid_month_fails_before_running_the_automatic_ingest(self):
+        # PR #57 review round 1 finding 7: argument validation (a
+        # malformed --month) used to run AFTER the automatic ingest call,
+        # so a request that was always going to fail loud still wrote a
+        # live ingest-cursor.json/events first.
+        write_transcript(self.projects_dir, "proj", "sess-bad-month", [assistant_line("sess-bad-month", "m1")])
+        result = run_report(self.home, self.projects_dir, args=["--reconcile", "--month", "2026-13"])
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse((self.home / "state" / "ingest-cursor.json").exists())
+        self.assertEqual(read_events(self.home), [])
+
+    def test_auto_ingest_runs_for_every_report_view(self):
+        # 計画書「1つでも漏れると、そのビューだけ古いデータを見る」: each
+        # view gets its OWN isolated home/projects_dir so a prior view's
+        # ingest can't accidentally satisfy this one's assertion.
+        view_cases = [
+            [], ["--phase"], ["--model"], ["--role"], ["--window"],
+            ["--month", "2026-07"], ["--reconcile", "--month", "2026-07"],
+        ]
+        for i, view_args in enumerate(view_cases):
+            with self.subTest(view=view_args):
+                home = pathlib.Path(self.tmpdir.name) / f"view-home-{i}"
+                projects_dir = pathlib.Path(self.tmpdir.name) / f"view-projects-{i}"
+                projects_dir.mkdir()
+                write_transcript(projects_dir, "proj", f"sess-view-{i}", [
+                    assistant_line(f"sess-view-{i}", "m1", timestamp="2026-07-15T10:00:00.000Z"),
+                ])
+                result = run_report(home, projects_dir, args=view_args)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                usage_events = [e for e in read_events(home) if e["event_type"] == "usage.message"]
+                self.assertEqual(len(usage_events), 1, f"view {view_args} did not auto-ingest: {result.stdout}")
+
+    def test_ingest_failure_does_not_crash_report_and_is_shown_in_the_footer(self):
+        # An empty HOME makes claude_projects_dir() unable to resolve a
+        # projects directory (and OCW_METER_CLAUDE_PROJECTS_DIR is
+        # deliberately not passed) — perform_ingest's own "could not
+        # determine" refusal, exercised without needing a git-worktree
+        # storage root (report's own top-level worktree guard would
+        # short-circuit before auto-ingest ever runs for that case).
+        run_meter(["event", "run.start", "--idempotency-key", "k1"], self.home)
+        result = run_meter(["report"], self.home, extra_env={"HOME": ""})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("total events:  1", result.stdout)
+        self.assertIn("ingest (this run): failed: could not determine the Claude projects directory", result.stdout)
+
+    def test_json_output_stays_pure_json_even_when_auto_ingest_runs(self):
+        write_transcript(self.projects_dir, "proj", "sess-json", [assistant_line("sess-json", "m1")])
+        result = run_report(self.home, self.projects_dir, args=["--json"])
+        self.assertEqual(result.returncode, 0, result.stderr)
+        summary = json.loads(result.stdout)  # raises if anything besides JSON hit stdout
+        self.assertEqual(summary["total_events"], 1)
+
+    def test_footer_shows_last_ingest_timestamp_after_a_successful_run(self):
+        write_transcript(self.projects_dir, "proj", "sess-fresh", [assistant_line("sess-fresh", "m1")])
+        result = run_report(self.home, self.projects_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("last_ingest_at: unknown", result.stdout)
+        cursor = json.loads((self.home / "state" / "ingest-cursor.json").read_text(encoding="utf-8"))
+        self.assertIn("last_ingest_at", cursor)
+        # The raw RFC3339 the footer's --json field (last_ingest_at_rfc3339)
+        # must carry, unmodified, for a machine consumer (PR #57 review
+        # round 1 finding 6) — round-trips through the text footer too.
+        self.assertIn(f"last_ingest_at_rfc3339: {cursor['last_ingest_at']}", result.stdout)
+
+    def test_old_format_ingest_cursor_without_last_ingest_at_shows_unknown(self):
+        state_dir = self.home / "state"
+        state_dir.mkdir(parents=True, exist_ok=True)
+        (state_dir / "ingest-cursor.json").write_text(json.dumps({"files": {}}), encoding="utf-8")
+        result = run_meter(["report", "--no-ingest"], self.home)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("last_ingest_at: unknown", result.stdout)
+        self.assertIn("last_ingest_at_rfc3339: unknown", result.stdout)
+
+    def test_freshness_warning_only_appears_past_the_staleness_threshold(self):
+        # PR #57 review round 1 finding 4: the threshold comparison is
+        # `>=` (inclusive — see ingest_freshness_footer's comment, chosen
+        # because the plan's own wording "一定時間以上経っていたら" is
+        # inclusive). This test cannot pin the literal single-instant
+        # edge (age_seconds == INGEST_STALE_THRESHOLD_SECONDS exactly):
+        # this is a black-box subprocess test built on real wall-clock
+        # `datetime.now()`, and the round trip between writing the
+        # fixture timestamp here and `ingest_freshness_footer` reading
+        # "now" always adds strictly positive latency — so any nominal
+        # age computed here always reads back slightly HIGHER once the
+        # subprocess evaluates it, which makes `>` and `>=` behave
+        # identically in practice (verified: reverting to `>` still
+        # passes every case below). Matches this file's existing
+        # precedent for other 24h-based staleness checks
+        # (WorktreeRefusalPruningTests uses a 1h/25h margin, not an
+        # exact-instant one, for the same reason).
+        state_dir = self.home / "state"
+        state_dir.mkdir(parents=True, exist_ok=True)
+
+        def cursor_at_age(**age_kwargs):
+            ts = (datetime.now(timezone.utc) - timedelta(**age_kwargs)).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+            (state_dir / "ingest-cursor.json").write_text(
+                json.dumps({"files": {}, "last_ingest_at": ts}), encoding="utf-8",
+            )
+            return run_meter(["report", "--no-ingest"], self.home)
+
+        fresh_result = cursor_at_age(minutes=5)
+        self.assertEqual(fresh_result.returncode, 0, fresh_result.stderr)
+        self.assertIn("ingest_freshness_warning: (none)", fresh_result.stdout)
+
+        just_under_result = cursor_at_age(hours=23, minutes=59)
+        self.assertEqual(just_under_result.returncode, 0, just_under_result.stderr)
+        self.assertIn("ingest_freshness_warning: (none)", just_under_result.stdout)
+
+        just_over_result = cursor_at_age(hours=24, minutes=1)
+        self.assertEqual(just_over_result.returncode, 0, just_over_result.stderr)
+        self.assertNotIn("ingest_freshness_warning: (none)", just_over_result.stdout)
+        self.assertIn("経過しています", just_over_result.stdout)
+
+        stale_result = cursor_at_age(hours=25)
+        self.assertEqual(stale_result.returncode, 0, stale_result.stderr)
+        self.assertNotIn("ingest_freshness_warning: (none)", stale_result.stdout)
+        self.assertIn("経過しています", stale_result.stdout)
+
+    def test_json_output_includes_freshness_footer_keys_for_every_view(self):
+        # PR #57 review round 1 finding 3: `footer_freshness` is `**`-
+        # expanded into 4 separate JSON summary dicts
+        # (cmd_report/_print_grouped_report/_report_month_standalone/
+        # _report_reconcile) — a dropped `**footer_freshness` in any ONE
+        # of them would otherwise go undetected, since every other
+        # existing test only checks the text footer's print lines.
+        write_transcript(self.projects_dir, "proj", "sess-json-fresh", [
+            assistant_line("sess-json-fresh", "m1", timestamp="2026-07-15T10:00:00.000Z"),
+        ])
+        freshness_keys = {"last_ingest_at", "last_ingest_at_rfc3339", "ingest_this_run", "ingest_freshness_warning"}
+        view_cases = [
+            [], ["--phase"], ["--model"], ["--role"], ["--window"],
+            ["--month", "2026-07"], ["--reconcile", "--month", "2026-07"],
+        ]
+        for view_args in view_cases:
+            with self.subTest(view=view_args):
+                result = run_report(self.home, self.projects_dir, args=[*view_args, "--json"])
+                self.assertEqual(result.returncode, 0, result.stderr)
+                summary = json.loads(result.stdout)
+                missing = freshness_keys - summary.keys()
+                self.assertFalse(missing, f"view {view_args} --json is missing freshness keys: {missing}")
+
+
 class SymlinkInvocationTests(OcwMeterTestCase):
     """ADR DOC-2608040229 §2.6: deploy.sh installs this script as a
     symlink (e.g. ~/bin/ocw-meter). `dirname` on an unresolved
@@ -2058,6 +2254,21 @@ class ReportReconcileTests(OcwMeterTestCase):
         data = json.loads(report.stdout)
         self.assertEqual(data["transcript_lines_quarantined"], 1)
         self.assertEqual(data["quarantined_lines"], 0)
+
+    def test_reconcile_with_month_works_outside_any_git_repo(self):
+        # PR #57 review round 2 finding "新規1": moving the repo-
+        # resolution-needed check earlier (round 1 finding 7, to run
+        # before the automatic-ingest side effect) accidentally exposed
+        # `--reconcile --month` to it for the first time — previously
+        # `_report_reconcile`'s early return made the check dead code on
+        # this path. `_report_reconcile` never takes (or needs) a `repo`
+        # argument at all, so this combination must keep working from
+        # outside any git repo, exactly like it always has (this is a
+        # documented workflow — docs/reference/DOC-2608021229-b_...).
+        no_git_dir = pathlib.Path(self.tmpdir.name) / "not-a-git-repo-reconcile"
+        no_git_dir.mkdir()
+        result = run_meter(["report", "--reconcile", "--month", "2026-07"], self.home, cwd=no_git_dir)
+        self.assertEqual(result.returncode, 0, result.stderr)
 
 
 CLAUDE_STATUSLINE_SAMPLE = {

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,6 +71,7 @@
 | DOC-2608021229-a | [ai-llm-cost-observability_計画.md](planning/DOC-2608021229-a_ai-llm-cost-observability_計画.md) | LLM費用・Claude利用枠の観測基盤（`ocw-meter`）構築計画（傘 `ai/llm-cost-observability`、全孫マージ済。旧ID: `DOC-003`） |
 | DOC-2608040234 | [ai-deploy-stability_計画.md](planning/DOC-2608040234_ai-deploy-stability_計画.md) | デプロイ配布方式の安定化の傘ブランチ計画書（傘 `ai/deploy-stability`）。ADR DOC-2608040229 で確定した配布実体方式を6本の孫へ分解したもの |
 | DOC-2608062259 | [ai-ocw-naming-and-layout_計画.md](planning/DOC-2608062259_ai-ocw-naming-and-layout_計画.md) | `ocw` のワークツリー命名とリポジトリレイアウト外部化の傘ブランチ計画書（傘 `ai/ocw-naming-and-layout`）。ADR DOC-2608062258 で確定した方式を4本の孫へ分解したもの |
+| DOC-2608081456 | [ocw-meter-accuracy_計画.md](planning/DOC-2608081456_ocw-meter-accuracy_計画.md) | `ocw-meter` の計測精度是正の傘ブランチ計画書（傘 `ocw-meter-accuracy`）。実ストア突合で判明した6件の計測ズレ（ingest 欠測・費用メトリクスの空洞化・帰属不能・テストによるストア汚染・価格表のズレ・退避キャッシュのプルーニング漏れ）を6本の孫へ分解したもの |
 
 ### reference/ — 運用リファレンス
 

--- a/docs/adr/DOC-2608021229_llm-cost-observability-collection-method.md
+++ b/docs/adr/DOC-2608021229_llm-cost-observability-collection-method.md
@@ -333,6 +333,51 @@ probe結果を踏まえた孫1〜5の実装規模。P1〜P5の結果により計
 
 ---
 
+## 10. 追記: Anthropic自己申告値の採用は本ADRの判断を覆さない
+
+- **Status**: Accepted（本ADRの判断本体は不変。以下は線引きの記録の追記）
+- **Date**: 2026-08-08
+- **Decision by**: 傘ブランチ `ocw-meter-accuracy`（計画書
+  [DOC-2608081456](../planning/DOC-2608081456_ocw-meter-accuracy_計画.md)）孫4・孫6
+
+本ADR §6は「事後読み取り + 軽量イベント刻み」という収集アーキテクチャを採用した。その前提と
+なっているのが計画書
+[DOC-2608021229-a](../planning/DOC-2608021229-a_ai-llm-cost-observability_計画.md) §8.4の判断
+「Anthropic（`claude-*`）は定額契約のためAPI単価に換算しない（`cost_estimate_usd: null` /
+`cost_basis: "subscription"`）」である（実装は`bin/ocw-meter`の`compute_cost()`、
+`infer_provider(model) == "anthropic"`分岐）。
+本傘の孫4で`quota.sample`の`session_cost_usd`（statusLineの`cost.total_cost_usd`。Claude Code
+自身が申告するセッション累積コスト）を`list_price_equiv_usd`として集計・表示する機能を追加したが、
+**これはこの判断を覆すものではない。** 以下にその線引きを記録する。
+
+> **Anthropic自己申告値（`session_cost_usd`）の採用は「換算」ではない。**
+> 計画書DOC-2608021229-a §8.4が却下したのは「ocw-meterが定額契約をAPI単価に換算して推定額を
+> 作ること」であって、「Claude Code自身が申告した値をそのまま記録・集計すること」ではない。
+> 前者はocw-meterの推定であり、後者はAnthropic側の自己申告である。
+> データの出所も信頼レベルも異なるため、別カラム・別行として共存させる。
+
+具体的には:
+
+- `usage.message`の`cost_estimate_usd`（cash cost）は、**ocw-meterが`bin/prices/*.json`の単価表から
+  自分で計算した推定値**。Anthropicモデルはこの式を一切適用せず、常に`null`のままである
+  （計画書DOC-2608021229-a §8.4の判断を維持。本ADR §6の採用アーキテクチャがその前提の上に立つ）
+- `quota.sample`の`session_cost_usd`から集計する`list_price_equiv_usd`（capacity側。孫4）は、
+  **Claude Code自身がstatusLineで申告した値をそのまま合計しただけ**であり、ocw-meterは単価計算を
+  一切行っていない。定額契約を従量制の単価へ変換する行為（計画書DOC-2608021229-a §8.4が却下した
+  もの）はどこにも無い
+- 両者は`report`上で常に別の行・別のフィールド（`cash_cost_usd`と`list_price_equiv_usd`）として
+  表示され、**絶対に合算しない**（詳細な集計定義は
+  `docs/reference/DOC-2608021229-c_ocw-meterイベントスキーマ.md` §4.4参照）
+
+### 10.1 検討して却下した案（孫4、蒸し返さないこと）
+
+| 案 | 内容 | 不採用理由 |
+|---|---|---|
+| **B. 価格表にanthropicを足して`usage.message`側で自前計算** | 定額契約をAPI単価に換算した推定値を`cost_estimate_usd`として計算する | 計画書DOC-2608021229-a §8.4の「定額契約をAPI単価に換算しない」という判断そのものを覆す必要がある。**ただしAの後から共存させることは可能**（Aは「Anthropic自己申告値」、Bは「ocw-meter推定値」で意味の異なるカラムのため）。最初からB込みで設計すると計画書の判断の改訂が必要になり傘が重くなるため、本傘ではAのみを採用した |
+| **C. サブスク月額を按分** | 月額料金をセッション・PR・工程等で按分する | 実支払額と一致する唯一の方式だが、月末まで確定せず按分の分母（何を基準に割るか）が恣意的になる |
+
+---
+
 ## Appendix A: P1 probe 後始末チェックリスト
 
 - [x] `claude/settings.machine.json` の `statusLine` 削除、`hooks` は保持（probe終了時に実施済み）

--- a/docs/planning/DOC-2608081456_ocw-meter-accuracy_計画.md
+++ b/docs/planning/DOC-2608081456_ocw-meter-accuracy_計画.md
@@ -20,7 +20,7 @@
 
 | 孫 | ブランチ | 内容 | 状況 |
 |---|---|---|---|
-| 1 | `ocw-meter-01-store-hygiene` | 【4】【6】テストによる実ストア汚染の停止・`quota-worktree-refusal.json` のプルーニング片手落ち修正・診断ファイル専用の掃除サブコマンド新設 | ⬜ 待機中 |
+| 1 | `ocw-meter-01-store-hygiene` | 【4】【6】テストによる実ストア汚染の停止・`quota-worktree-refusal.json` のプルーニング片手落ち修正・診断ファイル専用の掃除サブコマンド新設 | 🔄 実装中 |
 | 2 | `ocw-meter-02-ingest-freshness` | 【1】`report` からの ingest 自動実行と、最終 ingest 時刻・鮮度のフッター表示 | ⬜ 待機中 |
 | 3 | `ocw-meter-03-price-tables` | 【5】価格表スキーマの時間帯（peak/off-peak）対応・フォールバック時の警告・適用期間ミスマッチの可視化 | ⬜ 待機中 |
 | 4 | `ocw-meter-04-list-price-equiv` | 【2】`quota.sample` の `session_cost_usd` から `list_price_equiv_usd` を集計して `report` に出す | ⬜ 待機中 |

--- a/docs/planning/DOC-2608081456_ocw-meter-accuracy_計画.md
+++ b/docs/planning/DOC-2608081456_ocw-meter-accuracy_計画.md
@@ -22,8 +22,8 @@
 |---|---|---|---|
 | 1 | `ocw-meter-01-store-hygiene` | 【4】【6】テストによる実ストア汚染の停止・`quota-worktree-refusal.json` のプルーニング片手落ち修正・診断ファイル専用の掃除サブコマンド新設 | ✅ PR #56 マージ済 |
 | 2 | `ocw-meter-02-ingest-freshness` | 【1】`report` からの ingest 自動実行と、最終 ingest 時刻・鮮度のフッター表示 | ✅ PR #57 マージ済 |
-| 3 | `ocw-meter-03-price-tables` | 【5】価格表スキーマの時間帯（peak/off-peak）対応・フォールバック時の警告・適用期間ミスマッチの可視化 | 🔄 実装中 |
-| 4 | `ocw-meter-04-list-price-equiv` | 【2】`quota.sample` の `session_cost_usd` から `list_price_equiv_usd` を集計して `report` に出す | ⬜ 待機中 |
+| 3 | `ocw-meter-03-price-tables` | 【5】価格表スキーマの時間帯（peak/off-peak）対応・フォールバック時の警告・適用期間ミスマッチの可視化 | ✅ PR #58 マージ済 |
+| 4 | `ocw-meter-04-list-price-equiv` | 【2】`quota.sample` の `session_cost_usd` から `list_price_equiv_usd` を集計して `report` に出す | 🔄 実装中 |
 | 5 | `ocw-meter-05-session-attribution` | 【3】`session_id` join による `run_id` / `role` の帰属解決（ingest 側フォールバック + report 側 join）と attribution 行 | ⬜ 待機中 |
 | 6 | `ocw-meter-06-docs` | 文書（`bin/README.md` / スキーマ文書 DOC-2608021229-c / ADR DOC-2608021229 への追記節 / ルート `README.md`） | ⬜ 待機中 |
 

--- a/docs/planning/DOC-2608081456_ocw-meter-accuracy_計画.md
+++ b/docs/planning/DOC-2608081456_ocw-meter-accuracy_計画.md
@@ -1,0 +1,1369 @@
+# 計画書: `ocw-meter` の計測精度の是正
+
+傘ブランチ: `ocw-meter-accuracy`
+ターゲット: `master`
+作成日: 2026-08-08
+
+## 概要
+
+`ocw-meter` は「観測基盤としては動いているが、出している数字が事実とズレている」状態にある。
+このマシンの実ストア（`~/.local/state/ocw-meter`、events 68MB / 62,763件）を transcript と
+実際に突合した結果、6つの問題が確認された。本傘でこの6つをすべて解消する。
+
+**この計画書に書かれた数値はすべて実測済みである。孫は再調査しなくてよい**（するなら
+それは検証であって発見ではない）。**逆に、ここに書かれていない数値を推測で補わないこと。**
+
+対象コード: `bin/ocw-meter`（4,283行）/ `bin/tests/test_ocw_meter.py`（3,081行）/
+`bin/prices/` / `bin/README.md` / `docs/reference/DOC-2608021229-c_ocw-meterイベントスキーマ.md`
+
+## 孫ブランチ進捗
+
+| 孫 | ブランチ | 内容 | 状況 |
+|---|---|---|---|
+| 1 | `ocw-meter-01-store-hygiene` | 【4】【6】テストによる実ストア汚染の停止・`quota-worktree-refusal.json` のプルーニング片手落ち修正・診断ファイル専用の掃除サブコマンド新設 | ⬜ 待機中 |
+| 2 | `ocw-meter-02-ingest-freshness` | 【1】`report` からの ingest 自動実行と、最終 ingest 時刻・鮮度のフッター表示 | ⬜ 待機中 |
+| 3 | `ocw-meter-03-price-tables` | 【5】価格表スキーマの時間帯（peak/off-peak）対応・フォールバック時の警告・適用期間ミスマッチの可視化 | ⬜ 待機中 |
+| 4 | `ocw-meter-04-list-price-equiv` | 【2】`quota.sample` の `session_cost_usd` から `list_price_equiv_usd` を集計して `report` に出す | ⬜ 待機中 |
+| 5 | `ocw-meter-05-session-attribution` | 【3】`session_id` join による `run_id` / `role` の帰属解決（ingest 側フォールバック + report 側 join）と attribution 行 | ⬜ 待機中 |
+| 6 | `ocw-meter-06-docs` | 文書（`bin/README.md` / スキーマ文書 DOC-2608021229-c / ADR DOC-2608021229 への追記節 / ルート `README.md`） | ⬜ 待機中 |
+
+**ブランチ名に `ai/` 接頭辞は付けない。** PR #54（DOC-2608062258）で `ocw` の `ai/` 接頭辞は
+廃止済みであり、傘ブランチ自体も `ocw-meter-accuracy`（接頭辞なし）である。
+`ocw -H <孫ブランチ名> ocw-meter-accuracy` には上表の「ブランチ」列の値をそのまま渡すこと。
+
+## 依存関係と実行順序
+
+```
+孫1 (ストア衛生: テスト汚染の停止 + refusal プルーニング + 診断掃除)
+  ↓ 以後の孫がテストを回すたびに実ストアが汚れるのを先に止める
+孫2 (ingest 自動実行 + 鮮度表示)
+  ↓ 欠測を塞いでから、その上に乗る数字の意味を直す。孫5 と同じ ingest 経路を触るので先に入れる
+孫3 (価格表: 時間帯対応 + フォールバック警告)
+  ↓ compute_cost() のシグネチャが変わる。build_usage_event() を触る孫5 より前に入れる
+孫4 (list_price_equiv: quota.sample 集計)
+  ↓ report のフッター/月次/PR出力に行が増える。孫5 の attribution 行はその上に足す
+孫5 (session_id join による帰属解決)
+  ↓ 挙動が全部確定してから文書を書く（先に書くと必ず嘘になる）
+孫6 (文書)
+```
+
+**全孫が直列。** 6本とも同じ `bin/ocw-meter`（単一ファイル4,283行）と
+`bin/tests/test_ocw_meter.py` を触るため、並列に走らせると衝突が避けられない。
+**前の孫が傘へマージされてから次を spawn すること。**
+
+---
+
+## 調査で判明した事実（実測。再調査不要）
+
+### 計測の仕組み（前提の共有）
+
+| 系統 | 入口 | 内容 |
+|---|---|---|
+| `usage.message` | `ocw-meter ingest` が `~/.claude/projects/*/*.jsonl` を走査 | トークン4種・model・推定費用。`message.id` で重複排除、`state/ingest-cursor.json` に (inode,size,mtime,offset) で増分・冪等 |
+| 工程イベント | `bin/ocw:19` の fail-open 呼び出し | `run.start` / `phase.start`/`end` / `review.round` / `pr.bind` |
+| `quota.sample` | `claude/settings.json` の statusLine → `snapshot-quota` | 5時間枠・週間枠の使用率、`window_id`、ctx%、**`session_cost_usd`**。60秒スロットル |
+
+費用計算式は `bin/ocw-meter:2717`（`compute_cost`）。`claude-*` は定額契約なので一律
+`cost_estimate_usd: null` / `cost_basis: "subscription"`（`bin/ocw-meter:2693`）。
+
+### 【1】ingest が手動のみ → 直近4日分が丸ごと欠落（最重要）
+
+`state/ingest-cursor.json` の最終更新が **2026-08-05 02:50**。transcript と events を
+`message.id` で突合した実測:
+
+```
+transcript の distinct message.id : 60,460
+events の distinct message_id     : 57,164
+未取り込み                        : 6,878 件（全体の 11.4%）
+  内訳 8/04:1312  8/05:610  8/06:2477  8/07:1407  8/08:1072
+```
+
+`phase.start` / `run.start` は 8/8 まで流れ続けているため、
+**「工程は記録されているのにトークンだけゼロ」という歪んだ月次が出る。**
+
+`report` にも `report --month` にも「最後に ingest したのはいつか」を示す行が一切ない
+（`usage_cost_footer()` = `bin/ocw-meter:1514` は件数と `--reconcile` の案内だけ）。
+
+**計画書 DOC-2608021229-a:440 は ingest の実行契機を「手動 / `report` が自動実行」と
+書いているが、`cmd_report()`（`bin/ocw-meter:2284-2534`）に ingest 呼び出しは1つも無い。**
+計画書と実装の食い違いが、そのまま欠測になっている。
+
+### 【2】費用メトリクスが「もう使っていないプロバイダ」専用になっている
+
+月別・モデル別の実測:
+
+```
+2026-06  cost=$0.00   claude-opus-4-8:327
+2026-07  cost=$46.78  deepseek-v4-pro:29676 / claude系:9390
+2026-08  cost=$1.34   claude系:16750 / deepseek-v4-pro:918   ← 95%がClaude
+```
+
+`OCW_*_COMMAND` の既定が `claude` になった今、**メッセージの46%（26,467件）は設計上ずっと
+`cost_estimate_usd: null`**。看板の `$48.12` は事実上7月の DeepSeek 代。
+`report --month` の process efficiency も **`avg_cash_cost_usd: None`**（承認済み8PR全部）。
+
+### 【3】`--phase` / `--role` がほぼ機能していない
+
+```
+run_id が入っている usage.message : 3,043 / 57,164 (5.3%)
+role=unknown                      : 51,959 / 57,164 (90.9%)
+report --phase の (unassigned)    : 56,648 / 57,164 (99.1%)
+```
+
+原因は共通で、**解決タイミングが「ingest 実行時点のライブ状態」だから**。
+
+- `run_id`: `cwd` 配下の `<git-dir>/ocw-run-id` を読む（`resolve_run_id_via_ocw_run_id_file`
+  = `bin/ocw-meter:3041`）→ `ocw rm` 済みなら消えている
+- `role`: `herdr pane list`（`bin/ocw-meter:2954`）→ ペインを閉じていたら引けない
+
+しかも「過去は再計算しない」不変条件があるため、**後から ingest し直しても永久に直らない。**
+
+### 【4】テストが実ストアを汚染している（純粋なバグ）
+
+`bin/tests/test_ocw_meter.py:2149`
+`test_git_worktree_home_refuses_write_but_still_prints_display` が `HOME` を上書きしていない。
+ヘルパ `run_snapshot_quota()`（同 :78）は `dict(os.environ)` ベースなので実 `HOME` が素通りし、
+`default_storage_root()` が実 `~/.local/state/ocw-meter` を指して退避キャッシュを書く。
+
+証拠（実ストアに現存）:
+
+```
+state/quota-worktree-refusal.json
+  → "/tmp/tmp0aymq67u/repo/ocw-meter-home": "2026-08-06T15:05:04Z" ... 計37件
+state/meter-errors.jsonl
+  → storage_home_inside_git_worktree × 6件（8/1〜8/7）
+```
+
+パス形状 `<tmpdir>/repo/ocw-meter-home` がそのテストと完全一致。
+**同ファイル :2895 の兄弟テスト `test_worktree_refusal_is_throttled_and_stops_rewarning` は
+「HOME を上書きしないとこの開発者の実 `~/.local/state/ocw-meter` を触ってしまう」という
+コメント付きで正しく `extra_env={"HOME": str(fake_home)}` を渡している**ため、片方が漏れている
+だけである。
+
+副作用: `report` の「meter.error diagnostics: 7 lines」のうち **6件がテストのゴミ**で、
+自己診断シグナルが濁っている。
+
+### 【5】価格表の適用が実態とズレている
+
+`bin/prices/` に `deepseek-2026-08-01.json` の**1枚しかない**。
+`select_price_table()`（`bin/ocw-meter:2673`）は「`effective_date <= 対象日` の最新」を選ぶが、
+該当が1枚も無いときは `tables[0]`（＝最古の表）にフォールバックする。
+唯一の表の `effective_date` が `2026-08-01` なので、**6月〜7月の29,676件も8月の価格表で
+計算されている**（`$46.78` はその前提の数字）。フォールバックしたことは出力のどこにも出ない。
+
+さらにその表の `notes` に
+`peak/off-peak 2x pricing announced (Beijing 09:00-12:00, 14:00-18:00) — effective date TBD`
+とあるが、価格表の粒度は**日単位**（`effective_date`）なので、これが発効したら時間帯を
+表現する手段が無い。最大2倍の過小計上になる構造。
+
+### 【6】細かいもの
+
+- **`quota-worktree-refusal.json` のプルーニングが片手落ち**（`bin/ocw-meter:3999` 付近）。
+  24時間超（`QUOTA_SESSION_STATE_MAX_AGE_SECONDS`）の古いエントリを消すのは
+  **新しい refusal を書き込む瞬間だけ**なので、汚染が止まると古いエントリが残り続ける
+  （現に 8/6〜8/7 の37件が居座っている）
+- **`<synthetic>` が103件混入**（本傘のスコープ外。人間の判断で見送り）
+- **`five_hour_window_completion` が実質ノイズ**（本傘のスコープ外。人間の判断で見送り）
+- **`prune` 未実装**（本傘のスコープ外。`bin/README.md:457` の意図的据え置きを維持する）
+- **`bin/README.md:525` の記述が古い**。「run_id が設定されているものは0件」→ 実測3,043件
+
+### 問題なかったもの（再調査不要）
+
+- `validate` 0件、malformed 0行。`message.id` 重複排除は正しく機能
+  （transcript の assistant 135,926行 → 60,460 distinct = 重複59.4%）
+- transcript 側の壊れた行の隔離は2件のみ。生コンテンツを保存せず reason だけ残す実装は妥当
+- fail-open 契約（`event`/`bind-pr`/`snapshot-quota` は必ず exit 0）は実装・テストとも一貫
+- `is_sidechain` が全件 False なのは `ocw-meter` のバグではない
+  （transcript 側の assistant 行 135,926件すべてが `isSidechain: false`）
+
+---
+
+## 【2】【3】の鍵: 答えは既に `quota.sample` の中にある
+
+**【2】【3】とも、新しく測り足す必要はない。**
+
+### 材料A: `session_cost_usd` が実は全件埋まっている
+
+`snapshot-quota` が statusLine の `cost.total_cost_usd` を `session_cost_usd` として記録している
+（`bin/README.md:412` が「別カラムであり合算しない」と書いているもの）。
+**これが 4,704 / 4,705 件で埋まっていて、しかもどのレポートにも一切出てこない。**
+
+```
+provider別（セッション累積の最大値を合計）
+  anthropic : $2,995.36 / 205 sessions（全部 2026-08）
+  deepseek  : $93.35    / 10 sessions
+
+PR単位にも落ちる（anthropic セッション 140/205 に pr_number あり）
+  PR #33: $103.36   PR #39: $126.94   PR #32: $58.14
+  PR #41: $56.56    PR #28: $49.60    PR #35: $33.77 ...
+```
+
+→ **`report --month 2026-08` が `$1.34` と表示している裏で、同じストアに $2,995 分の
+Claude 側自己申告コストが眠っている。**
+
+### 材料B: `session_id` で join できる
+
+`quota.sample` は `session_id` 100% / `run_id` 78% / `role` 78%（unknown 22%）を持つ。
+`usage.message` も transcript 由来の `session_id` を100%持つ。
+**両者を `session_id` で突き合わせるだけ**で、実測こうなる:
+
+```
+8/1以降（quota.sample 稼働後）の usage.message 17,670件
+  run_id : 3,043 (17.2%)  ->  10,885 (61.6%)
+  role   : 4,814 (27.2%)  ->  12,740 (72.1%)
+```
+
+**この join は `ocw rm` に一切影響されない。** 現行の
+`resolve_run_id_via_ocw_run_id_file()`（`bin/ocw-meter:3041`）が
+`<git-dir>/ocw-run-id` という *消える実ファイル* を見ているのが根本原因で、
+`quota.sample` は *消えないイベント* なので、worktree を消した後でも遡って解決できる。
+
+---
+
+## 確定事項（人間が選択済み。孫の判断で覆さないこと）
+
+| 領域 | 決定 |
+|---|---|
+| 【1】ingest | **`report` から ingest を自動実行する**（計画書 DOC-2608021229-a:440 の記述に実装を合わせる）。加えてフッターに最終 ingest 時刻と鮮度を出す |
+| 【2】費用 | **A案: `quota.sample` の `session_cost_usd` を集計する。** 価格表に anthropic を足して自前計算する案（B）、サブスク月額を按分する案（C）は採らない |
+| 【3】帰属 | **A+B 併用。** ingest 側フォールバック（B）と report 側 join（A）の両方を入れる。既存イベントを書き戻す `reattribute` 案（C）は採らない |
+| 【4】汚染 | テスト側の `HOME` 上書き修正に加え、**掃除手段を `ocw-meter` に足す** |
+| 【5】価格表 | **時間帯（peak/off-peak）課金に対応できるスキーマまで入れる。** 加えてフォールバック時の警告 |
+| 【6】細部 | **`quota-worktree-refusal.json` のプルーニング修正のみ。** `<synthetic>` / `five_hour_window_completion` / `prune` は本傘のスコープ外 |
+| ADR | **改訂は不要。** ただし「Anthropic 自己申告値は *換算* ではないので採用する」という線引きを**追記節として1つ足す**（孫6） |
+
+### 検討して却下した案（蒸し返さないこと）
+
+**【2】について:**
+
+- **B「価格表に anthropic を足して `usage.message` 側で自前計算」** → 全期間を遡れるが、
+  「定額契約を API 単価に換算しない」という ADR DOC-2608021229 の判断を覆す必要がある。
+  なお B は A の後から足すこともできる（A は「Anthropic 自己申告値」、B は「ocw-meter 推定値」で
+  意味の異なるカラムなので共存可能）。**最初から B 込みにすると ADR 改訂が必要になり傘が重くなる**
+- **C「サブスク月額を按分」** → 実支払額と一致する唯一の方式だが、月末まで確定せず
+  按分の分母が恣意的になる
+
+**【3】について:**
+
+- **C「`reattribute` サブコマンドで既存イベントを埋め直す」** → 保存値も過去も直るが、
+  **「過去は再計算しない」不変条件を明示的に破る。** A（読み取り時解決）で同じ結果が得られる以上、
+  不変条件を破ってまで書き戻す価値が薄い
+
+**【4】について:**
+
+- **「何もしない（テスト修正のみ）」** → 汚染は止まるが、`report` の
+  「meter.error diagnostics: 7 lines」のうち6件がテストのゴミのまま残り、
+  自己診断シグナルが濁った状態が続く
+- **「README に手動削除手順を書くだけ」** → ツールが自分のストアを消す経路を作らずに済むが、
+  診断ファイルの掃除という定型作業を毎回人間の手作業に落とすことになる
+
+**【5】について:**
+
+- **「フォールバック警告のみ」** → 数字の意味は変わらないまま。発効済みの時間帯課金を
+  表現できない構造が残る
+
+**【6】について:**
+
+- `<synthetic>` の除外・`five_hour_window_completion` の再定義・`prune` の実装は、
+  いずれも**本傘では扱わない**と人間が決めた。**孫が先回りして実装しないこと**
+  （AGENTS.md「指示された範囲外の機能を先回りして実装しない」）
+
+---
+
+## 実装上の罠（絶対に踏まないこと）
+
+ここに書かれた5点は**実測で判明した落とし穴**である。素直に実装すると必ず踏む。
+
+### 罠1: `quota.sample` 由来の `run_id` に `run.start` 逆転チェックを適用してはいけない（孫5）
+
+`build_usage_event()`（`bin/ocw-meter:3141`）付近には、`ocw-run-id` ファイルから引いた
+`run_id` に対して「その `run_id` の `run.start` より前のメッセージなら捨てる」という
+逆転チェックがある（`bin/ocw-meter:3186` 付近）。
+
+**これは「worktree パスは再利用される」ことを前提にした stale path 対策であり、
+`session_id` 由来の `run_id` に適用してはいけない。** `session_id` は再利用されないため、
+かけると**正しい帰属まで null 化してしまう**。解決経路ごとにチェックの適用を分けること。
+
+### 罠2: `deepseek` の `session_cost_usd`（$93.35）は絶対に混ぜない（孫4）
+
+Claude Code が DeepSeek のモデル名に何の単価を当てているか不明であり、
+`ocw-meter` 自身の推定 $48.12 と**二重計上**になる。
+`provider == "anthropic"` で明示的にスコープすること。
+
+`quota.sample` の `provider` フィールドは `infer_provider(model_normalized)`、
+`model` が取れないときは `has_rate_limits` から `"anthropic"` にフォールバックして
+決まっている（`bin/ocw-meter:4069` 付近）。DeepSeek セッションは `rate_limits` を持たないため、
+`provider == "anthropic"` によるスコープはこの実装で正しく機能する。
+
+### 罠3: `session_cost_usd` は非単調。`max()` ではなく「正の差分の総和」を取る（孫4）
+
+**214セッション中26セッションで値が減少している**（累積のはずが非単調）。
+`/clear` やコンパクションでリセットされていると思われる。単純な `max()` では
+リセット前の分を取りこぼす。**`session_id` ごとに時系列でソートし、正の差分だけを合計する。**
+
+上記の **$2,995.36 は `max()` による集計なので下振れした値**である。
+正の差分の総和で取り直せば、これ以上の値になるはずである。
+
+### 罠4: 必ず「下限値」として表示する（孫4）
+
+最後の statusLine 描画以降の消費が入らないため、この数字は原理的に下限である。
+`$2,995+ (下限・請求書ではない)` のような出し方にすること。
+**cash cost と絶対に足さない**（現行の設計方針どおり維持）。
+
+### 罠5: 過去の価格表を足しても、既に保存されたイベントの費用は直らない（孫3）
+
+`cost_estimate_usd` は `ingest` 時点で計算されて**イベントに焼き込まれる**。
+「過去は再計算しない」不変条件があるため、**6〜7月に有効だった価格表を後から
+`bin/prices/` に足しても、既存の29,676件の `cost_estimate_usd` は変わらない。**
+
+したがって孫3の実質的な価値は「過去表を足すこと」ではなく、次の3点にある:
+
+1. **フォールバックしたことを黙らせない**（該当する価格表が無い期間の費用は概算であると明示する）
+2. **時間帯課金を表現できる構造を用意する**（発効したときに慌てない）
+3. **適用された `price_table_version` と対象期間のミスマッチを可視化する**
+
+**孫3は「6〜7月の正しい DeepSeek 単価」を自分で調べて価格表を作ってはいけない。**
+価格表は出典 URL 付きの一次情報であり、AI が記憶から書くと静かに嘘の数字が入る。
+過去表の投入は**人間の作業**として手順だけ整備する。
+
+---
+
+## 残る限界（正直に書くこと。「直った」と言わない）
+
+- **7月以前の帰属は救えない。** `quota.sample` が 8/1 開始のため、7月の29,676件
+  （DeepSeek 時代）の `run_id` / `role` は復元手段が無い
+- 8月でも `run_id` 61.6% / `role` 72.1% で100%にはならない。
+  `claude-ds` セッションや statusLine が回らなかったセッションは取れない
+- `role` の 22% unknown は Herdr 外で起動した Claude なので**原理的に取得不能**
+  （推測で埋めない方針を維持する）
+- **6〜7月の Claude 側コストは永久に不明。** `quota.sample` が無い期間である
+- `list_price_equiv_usd` は常に下限値であり、請求書ではない
+
+---
+
+## 全孫共通の注意（プロンプトにも再掲するが、ここが正）
+
+### 1. `AGENTS.md` の最重要ルールに従う
+
+- **人間の明示的指示がない限り `git merge` / `git pull` / `git reset --hard` /
+  `git push --force` / `gh pr merge` を実行しない。**
+- **deploy スクリプトを実オペレーションで実行しない。** 本傘は `bin/` と `docs/` しか触らないが、
+  `pre-commit` のフックが `./deploy-all.sh --dry-run` を走らせる点は変わらない。
+- **linter の抑制ディレクティブ（`# shellcheck disable=...` 等）を AI の判断で追加しない。**
+  指摘が設計上不合理だと判断したら、抑制せず内容・対象・理由を人間に報告する。
+- **指示された範囲外の機能を先回りして実装しない。**
+
+### 2. `bin/ocw-meter` は「bash スクリプトの中に Python が heredoc で埋まっている」
+
+これを知らないと編集も lint も外す。
+
+- shebang は `#!/usr/bin/env bash`、`set -uo pipefail`（**`-e` は意図的に付けていない**。
+  fail-open 契約を手で管理しているため。`bin/ocw-meter:10` のコメント参照）
+- Python 本体は `bin/ocw-meter:353` の `cat >"$_ocw_meter_py" <<'PY'` から `:4255` の `PY` まで。
+  **クォート付き heredoc（`<<'PY'`）なのでシェル展開は起きない**が、行頭の `PY` を
+  Python コード中に書くと heredoc がそこで終わる
+- `bin/tests/lint.sh` はこの heredoc を `awk` で抽出して `py_compile` にかける。
+  **shellcheck / shfmt（シェル部分）と `py_compile`（Python 部分）の両方が効く**
+- macOS（BSD / bash 3.2）互換を壊さない。直近の PR #49 がまさにこの非互換の解消である
+
+### 3. テストは黒箱。そして**実 `$HOME` を絶対に触らない**
+
+`bin/tests/test_ocw_meter.py` は tempdir に使い捨てストアを作り、実 `bin/ocw-meter` を
+subprocess で叩く方式。**この方式を変えない。**
+
+**本傘の主題そのものだが、新しく書くテストでも同じ穴に落ちないこと。**
+`run_meter()` / `run_snapshot_quota()` は `dict(os.environ)` ベースなので、
+`OCW_METER_HOME` を tempdir に向けても**実 `HOME` は素通りする**。
+`default_storage_root()`（`bin/ocw-meter:698`）や `emit_meter_error()` のフォールバック先は
+`HOME` から組み立てられるため、**`HOME` を明示的に上書きしないと実ストアに書き込む**。
+
+### 4. 検証（省略しない。省略してよいのは人間が明示的に指示した場合のみ）
+
+```
+pre-commit run --all-files
+bin/tests/lint.sh
+python3 -m unittest discover -s bin/tests -v      # 193件・約40秒（本傘で増える）
+```
+
+**テストを回したあとに、実ストアが汚れていないことを確認すること:**
+
+```
+git -C ~/.local/state/ocw-meter status 2>/dev/null || true
+python3 -c "import json,pathlib; p=pathlib.Path.home()/'.local/state/ocw-meter/state/quota-worktree-refusal.json'; print(len(json.loads(p.read_text())) if p.exists() else 'absent')"
+```
+
+### 5. 「推測で埋めない」がこのツールの根本方針
+
+補完・推定・下限値は、**そうであることを出力に明示する**こと。
+黙って数字を良く見せる変更は、たとえ正確でも本ツールの方針に反する。
+
+### 6. PR の作法
+
+[docs/design/DOC-2608020715_プルリクエストの作法.md](../design/DOC-2608020715_プルリクエストの作法.md)
+を PR 作成前に読むこと。
+**PR の向き先は必ず傘ブランチ `ocw-meter-accuracy`。`master` には出さない。**
+
+---
+
+## 孫1用プロンプト:
+
+````
+`ocw-meter` のストア衛生を直してください（テストによる実ストア汚染の停止・
+`quota-worktree-refusal.json` のプルーニング片手落ち修正・診断ファイル専用の掃除サブコマンド新設）。
+
+## 最初に読むもの（順番に）
+
+1. リポジトリルートの `AGENTS.md`（最重要ルール）
+2. `docs/planning/DOC-2608081456_ocw-meter-accuracy_計画.md`（この計画書。
+   「調査で判明した事実」の【4】【6】、「確定事項」、「全孫共通の注意」を必ず読む）
+3. `docs/reference/DOC-2608021229-c_ocw-meterイベントスキーマ.md`
+4. `bin/ocw-meter`（4,283行。特に `default_storage_root`:698 / `emit_meter_error` /
+   `load_worktree_refusal_state` / `save_worktree_refusal_state` / `cmd_snapshot_quota` の
+   refusal 判定部 3955-4010 付近）
+5. `bin/tests/test_ocw_meter.py`（3,081行。特に `run_meter`:60付近 / `run_snapshot_quota`:78 /
+   `OcwMeterTestCase`:213 / :2149 / :2895）
+
+## この孫のスコープ
+
+**ストアの衛生だけ。** 費用計算・ingest・帰属・価格表には一切触らないこと（孫2〜5の担当）。
+
+### 1. テストによる実ストア汚染を止める（本傘の【4】）
+
+`bin/tests/test_ocw_meter.py:2149`
+`test_git_worktree_home_refuses_write_but_still_prints_display` が `HOME` を上書きしていない。
+
+同ファイル :2895 の兄弟テスト `test_worktree_refusal_is_throttled_and_stops_rewarning` は
+`extra_env={"HOME": str(fake_home)}` を渡していて正しい。片方が漏れているだけである。
+
+**個別テストに1行足すだけで終わらせないこと。** 同じ穴は今後も開く。
+次の優先順で検討し、選んだ理由を PR 説明文に書くこと:
+
+- **第一候補: ヘルパ側での横断防御。** `run_meter()` / `run_snapshot_quota()` が
+  `extra_env` で明示されない限り `HOME` を必ずテスト専用の tempdir に差し替える。
+  これで「HOME を書き忘れる」という失敗モード自体が消える。
+  既存テストの中に実 `HOME` に依存しているものが無いかを確認すること
+  （あれば、そのテストが何を確認しているのかを読んでから判断する）
+- **第二候補（第一候補が既存テストを壊す場合）**: :2149 に `extra_env` を足したうえで、
+  「`HOME` を差し替えていないテストが無いか」を検出する仕組み（テストヘルパでの
+  アサーション等）を入れる
+
+**`OcwMeterTestCase.setUp` は tempdir しか作っていない**（`bin/tests/test_ocw_meter.py:213`）。
+ここに `HOME` 用の tempdir も用意するのが素直だが、`self.home`（= `OCW_METER_HOME`）と
+**別のディレクトリにすること**（同じにすると、退避キャッシュの「refused root とは別の場所に
+書く」という設計そのものがテストで検証できなくなる）。
+
+### 2. `quota-worktree-refusal.json` のプルーニング片手落ちを直す（本傘の【6】）
+
+`bin/ocw-meter:3999` 付近。24時間超（`QUOTA_SESSION_STATE_MAX_AGE_SECONDS`）の古いエントリを
+消しているのは **新しい refusal を書き込む瞬間だけ**。汚染が止まると古いエントリが残り続ける
+（実測: このマシンの実ストアに 8/6〜8/7 の37件が居座っている）。
+
+**読み取り時にもプルーニングすること。** `load_worktree_refusal_state()` が返す時点で
+期限切れエントリを落とすのが素直だが、次の2点に注意:
+
+- **`snapshot-quota` は statusLine から高頻度（60秒スロットル）で呼ばれる。**
+  読み取りのたびにファイルを書き戻すと、正常系（refusal が1件も無い普通のマシン）で
+  無駄な書き込みが毎回走る。**落とすべきエントリが実際にあったときだけ書き戻す**こと
+- refusal 判定に到達する前の早期 return 経路（スロットル成立時など）でも、
+  期限切れエントリが読み取り側で除外されていること
+
+この修正により、**実ストアに居座っている37件は次回の `snapshot-quota` で自然に消える**
+（すべて24時間より古いため）。これを PR 説明文で明示すること。
+
+### 3. 診断ファイル専用の掃除サブコマンドを新設する（本傘の【4】の後始末）
+
+上記2で refusal 37件は自動的に消えるが、**`state/meter-errors.jsonl` の6件は append-only の
+診断ログなので残る**（`storage_home_inside_git_worktree` × 6件、8/1〜8/7。全部テスト由来）。
+
+新サブコマンド `ocw-meter prune-diagnostics` を追加する。設計制約:
+
+- **対象は `state/meter-errors.jsonl` と `state/quota-worktree-refusal.json` の2つだけ。**
+  `events/` には**絶対に触らない**。`prune`（`events/` の削除）は `bin/README.md:457` で
+  意図的に据え置くと決めた機能であり、**この孫でその決定を覆さない**
+- **既定は dry-run。** 何件消えるかを表示して終わる。実際に消すのは `--apply` を明示したときだけ
+- 保持期間は `--older-than <日数>` で指定。既定値を決め、その根拠をヘルプに書く
+- 消した件数・残した件数を報告する。**黙って消さない**
+- `report` / `validate` と同じく **fail-loud**（失敗したら非0で終わる）。
+  `event` / `bind-pr` / `snapshot-quota` の fail-open 契約とは別系統である
+- 「テスト由来と思われるエントリ」（`<tmpdir>/repo/ocw-meter-home` のようなパス形状）の
+  **判別はヒューリスティックなので、削除条件にはしない**。dry-run の表示で
+  「うち N 件はテスト由来の可能性がある」と**補助情報として出すだけ**にとどめること。
+  パス形状で自動削除すると、本物の設定ミスによる診断まで消しかねない
+
+`usage()`（`bin/ocw-meter:20` 付近）と `bin/README.md` のサブコマンド一覧にも追加すること
+（README の詳細な説明は孫6が書くので、この孫では1行の追加でよい）。
+
+## テスト（`bin/tests/test_ocw_meter.py`）
+
+追加するテスト:
+
+**汚染防止:**
+- `HOME` を上書きしていない状態で `run_snapshot_quota` を呼んでも、テスト用 tempdir の外に
+  何も書かれない（第一候補を採った場合、これがヘルパの契約テストになる）
+- :2149 のテストが `bad_home` の外（＝差し替えた `HOME` 配下）に退避キャッシュを書き、
+  **実 `HOME` 配下には書かない**
+
+**プルーニング:**
+- 24時間より古いエントリだけが入った `quota-worktree-refusal.json` を用意し、
+  refusal が一切発生しない普通の `snapshot-quota` を1回呼ぶと、古いエントリが消えている
+- 期限内のエントリは残る
+- **落とすべきエントリが無いときはファイルの mtime が変わらない**（無駄な書き戻しをしない）
+
+**prune-diagnostics:**
+- 既定（`--apply` なし）では何も消えず、件数だけが出る
+- `--apply` で古いエントリだけが消え、新しいものは残る
+- `events/` 配下のファイルが**1バイトも変わっていない**
+- 対象ファイルが存在しないストアでも exit 0 で「0件」と出る
+- 壊れた JSON の `quota-worktree-refusal.json` があっても落ちない
+
+## 完了条件
+
+- `pre-commit run --all-files` が通る
+- `bin/tests/lint.sh` が通る
+- `python3 -m unittest discover -s bin/tests -v` が全件通る（既存193件 + 追加分）
+- **テストスイートを回した直後に、実 `~/.local/state/ocw-meter` が変化していない**ことを
+  確認済み（確認方法は計画書「全孫共通の注意」§4 を参照。結果を PR 説明文に書くこと）
+
+## 実装完了後の流れ（必須）
+
+実装が完了したら、以下を**自律的に**実行してください:
+1. PRを作成する。**PRの向き先は必ず `ocw-meter-accuracy` にすること。master には絶対に出さない。**
+2. /pr-review-loop を起動する（PRがない場合は自動で作成し、そのままレビューを開始する）
+3. レビュー指摘があれば修正し、承認されるまで繰り返す
+4. 承認されたら人間に「マージしてください」と依頼する
+実装が終わったタイミングで止まらず、必ずここまでやりきってください。
+
+## ブランチ作成時の注意（最重要）
+
+作業ブランチは**必ず `ocw-meter-accuracy` から切ること**。
+master から切ると PR の diff に傘ブランチ全体が混入してレビュー不能になる。
+実装開始前に以下を必ず実行すること:
+git checkout ocw-meter-accuracy && git pull --rebase origin ocw-meter-accuracy
+git checkout -b ocw-meter-01-store-hygiene
+````
+
+## 孫2用プロンプト:
+
+````
+`ocw-meter report` から `ingest` を自動実行し、最終 ingest 時刻と鮮度をフッターに出してください。
+
+## 最初に読むもの（順番に）
+
+1. リポジトリルートの `AGENTS.md`（最重要ルール）
+2. `docs/planning/DOC-2608081456_ocw-meter-accuracy_計画.md`（この計画書。
+   「調査で判明した事実」の【1】、「確定事項」、「全孫共通の注意」を必ず読む）
+3. `docs/planning/DOC-2608021229-a_ai-llm-cost-observability_計画.md` の440行目付近
+   （**実装をこの記述に合わせるのが本孫の主目的**）
+4. `bin/ocw-meter`（孫1がマージ済み。特に `cmd_report`:2284 / `cmd_ingest`:3389 /
+   `usage_cost_footer`:1514 / `print_footer_text` / `load_ingest_cursor`:2724 付近 /
+   `save_ingest_cursor` / `_report_month_standalone`:2534 付近）
+5. `bin/tests/test_ocw_meter.py`
+
+## この孫のスコープ
+
+**ingest の実行契機と鮮度表示だけ。** 費用の中身・帰属・価格表には触らないこと（孫3〜5の担当）。
+
+## 背景（実測）
+
+`state/ingest-cursor.json` の最終更新が 2026-08-05 02:50 で止まっており、
+transcript と events を `message.id` で突合すると **6,878件（11.4%）が未取り込み**だった
+（8/04:1312 / 8/05:610 / 8/06:2477 / 8/07:1407 / 8/08:1072）。
+一方 `phase.start` / `run.start` は 8/8 まで流れているので、
+**「工程は記録されているのにトークンだけゼロ」という歪んだ月次が出ている。**
+
+計画書 DOC-2608021229-a:440 は ingest の実行契機を「手動 / `report` が自動実行」と書いているが、
+`cmd_report()` に ingest 呼び出しは1つも無い。**計画書と実装の食い違いがそのまま欠測になっている。**
+
+### 1. `report` の先頭で ingest を実行する
+
+`cmd_report()`（`bin/ocw-meter:2284`）の先頭、イベントを読み込む前に ingest を走らせる。
+`report --month` のスタンドアロン経路（`_report_month_standalone`）も含め、
+**`report` の全ビュー（既定 / `--phase` / `--model` / `--role` / `--window` / `--month` /
+`--reconcile`）で同じように効くこと**。1つでも漏れると、そのビューだけ古いデータを見る。
+
+設計上の要件:
+
+- **`--no-ingest` オプションを用意する。** 読み取り専用で使いたい場合と、
+  テストで ingest を切りたい場合の両方に要る
+- **ingest の失敗で `report` を落とさない。** ingest が失敗したら警告を出し、
+  既に保存済みのイベントでレポートを出す。ただし**失敗したという事実をフッターに必ず出す**
+  （黙って古いデータを新しい顔で出すのが最悪）
+- **ingest の詳細な進捗出力で `report` の出力を汚さない。** 要約1行に抑えるか stderr に出す。
+  `--json` 指定時は **stdout に JSON 以外を1バイトも出さない**こと
+  （既存の `--json` 経路が JSON のみを stdout に出していることを確認してから書く）
+- `ingest` は `in_git_worktree(root)` で refuse する経路を持つ（`bin/ocw-meter:3400` 付近）。
+  そのケースも「ingest できなかった」として上記と同じ扱いにすること
+- **`report` に書き込み副作用が生まれる。** これは意図した変更だが、
+  `iter_stored_events` の docstring が「`report` stays read-only」と書いている等、
+  読み取り専用を前提にしたコメントが他にもあるはずなので、**探して追随させること**
+
+### 2. 最終 ingest 時刻を記録する
+
+**ファイルの mtime に頼らないこと。** `cp -a` や rsync や世代デプロイで mtime は動きうる。
+`save_ingest_cursor()` が書く `ingest-cursor.json` の中に、
+**最終 ingest の実行時刻と結果を明示的なフィールドとして書く**。
+
+**後方互換**: 既存の `ingest-cursor.json` にはこのフィールドが無い。
+`load_ingest_cursor()` は現状 `{"files": {}}` を返すフォールバックを持っているので、
+そこを壊さないこと。フィールドが無い場合は「unknown（次回 ingest で記録される）」と出し、
+**mtime から推測して埋めない**（このツールの「推測で埋めない」方針）。
+
+`schema_version` の変更が要るかどうかを
+`docs/reference/DOC-2608021229-c_ocw-meterイベントスキーマ.md` §6 のルールに照らして判断すること
+（`ingest-cursor.json` はイベントではなく状態ファイルなので、おそらく不要。判断理由を PR に書く）。
+
+### 3. 鮮度をフッターに出す
+
+`usage_cost_footer()`（`bin/ocw-meter:1514`）に行を足す。この関数は
+**「どのビューでも同じフッターが出る」ことを保証するために切り出されている**
+（docstring 参照）ので、ここに足せば全ビューに乗る。
+
+出すべき情報:
+
+- 最終 ingest 時刻（RFC3339）と、そこからの経過時間
+- 今回の `report` が ingest を実行したか / スキップしたか（`--no-ingest`）/ 失敗したか
+- 鮮度警告: 最終 ingest から一定時間以上経っていたら明示する。
+  **閾値をハードコードするならその根拠をコメントに書くこと**
+
+`print_footer_text()`（テキスト出力）と `--json` の両方に反映すること。
+**既存のフッター項目（`coverage` / `price_table` / `cost_basis` / `cost_estimate`）の
+意味を変えないこと。** 行を足すだけである。
+
+## テスト（`bin/tests/test_ocw_meter.py`）
+
+追加するテスト:
+
+- `report` が transcript を自動で取り込む（fixture の transcript を置いて、
+  `ingest` を明示的に叩かずに `report` だけで件数が増える）
+- `--no-ingest` では取り込まれない
+- **全ビューで自動 ingest が効く**（既定 / `--phase` / `--model` / `--role` / `--window` /
+  `--month` / `--reconcile` を1件ずつ）
+- ingest が失敗しても `report` が exit 0 で出力を返し、フッターに失敗が出る
+- `--json` 指定時、stdout が**厳密に valid JSON 単体**である（ingest の出力が混ざらない）
+- 最終 ingest 時刻がフッターに出る
+- `last_ingest_at` 相当のフィールドが無い**古い形式の `ingest-cursor.json`** を置いても落ちず、
+  「unknown」と出る
+- 鮮度警告が閾値を跨いだときだけ出る
+
+## 完了条件
+
+- `pre-commit run --all-files` が通る
+- `bin/tests/lint.sh` が通る
+- `python3 -m unittest discover -s bin/tests -v` が全件通る
+- 実ストアが変化していないことを確認済み（計画書「全孫共通の注意」§4）
+
+## 実装完了後の流れ（必須）
+
+実装が完了したら、以下を**自律的に**実行してください:
+1. PRを作成する。**PRの向き先は必ず `ocw-meter-accuracy` にすること。master には絶対に出さない。**
+2. /pr-review-loop を起動する（PRがない場合は自動で作成し、そのままレビューを開始する）
+3. レビュー指摘があれば修正し、承認されるまで繰り返す
+4. 承認されたら人間に「マージしてください」と依頼する
+実装が終わったタイミングで止まらず、必ずここまでやりきってください。
+
+## ブランチ作成時の注意（最重要）
+
+作業ブランチは**必ず `ocw-meter-accuracy` から切ること**。
+master から切ると PR の diff に傘ブランチ全体が混入してレビュー不能になる。
+実装開始前に以下を必ず実行すること:
+git checkout ocw-meter-accuracy && git pull --rebase origin ocw-meter-accuracy
+git checkout -b ocw-meter-02-ingest-freshness
+````
+
+## 孫3用プロンプト:
+
+````
+`ocw-meter` の価格表を時間帯（peak/off-peak）課金に対応させ、
+該当する価格表が無い期間を黙って概算しないようにしてください。
+
+## 最初に読むもの（順番に）
+
+1. リポジトリルートの `AGENTS.md`（最重要ルール）
+2. `docs/planning/DOC-2608081456_ocw-meter-accuracy_計画.md`（この計画書。
+   「調査で判明した事実」の【5】、**「実装上の罠」の罠5**、「全孫共通の注意」を必ず読む）
+3. `docs/reference/DOC-2608021229-c_ocw-meterイベントスキーマ.md` §4「費用計算式」と
+   「価格表（`bin/prices/*.json`）」節
+4. `bin/prices/deepseek-2026-08-01.json`（現状これ1枚しかない）
+5. `bin/ocw-meter`（孫1・孫2がマージ済み。特に `load_price_tables`:2650 付近 /
+   `select_price_table`:2673 / `compute_cost`:2691 / `build_usage_event`:3141 /
+   `usage_cost_footer`:1514 / `report_month_cash_and_capacity`:2008）
+6. `bin/tests/test_ocw_meter.py`
+
+## この孫のスコープ
+
+**価格表の構造と適用だけ。** 帰属（`run_id` / `role`）と `list_price_equiv` には触らないこと。
+
+## 背景（実測）と、最初に理解すべき制約
+
+`bin/prices/` に `deepseek-2026-08-01.json` の1枚しかない。`select_price_table()` は
+「`effective_date <= 対象日` の最新」を選ぶが、該当が1枚も無いときは `tables[0]`（最古の表）に
+フォールバックする。唯一の表の `effective_date` が `2026-08-01` なので、
+**6月〜7月の29,676件も8月の価格表で計算されている**（`$46.78` はその前提の数字）。
+フォールバックしたことは出力のどこにも出ない。
+
+さらにその表の `notes` に
+`peak/off-peak 2x pricing announced (Beijing 09:00-12:00, 14:00-18:00) — effective date TBD`
+とあるが、価格表の粒度は日単位（`effective_date`）なので、発効したら時間帯を表現する手段が無い。
+最大2倍の過小計上になる構造。
+
+### ⚠️ 最重要の制約: 過去の価格表を足しても、既存イベントの費用は直らない
+
+`cost_estimate_usd` は `ingest` 時点で計算されてイベントに焼き込まれる。
+「過去は再計算しない」不変条件があるため、**6〜7月に有効だった価格表を後から足しても、
+既存の29,676件の `cost_estimate_usd` は変わらない。**
+
+**したがってこの孫では、過去の価格表を自分で作ってはいけない。**
+価格表は出典 URL 付きの一次情報であり、AI が記憶から単価を書くと静かに嘘の数字が入る。
+やるのは以下の3点である。
+
+### 1. 価格表スキーマを時間帯対応に拡張する
+
+現状の形（`bin/prices/deepseek-2026-08-01.json`）:
+
+```
+{
+  "price_table_version": "deepseek-2026-08-01",
+  "effective_date": "2026-08-01",
+  "source": "...", "fetched_at": "...", "currency": "USD", "unit": "per_1m_tokens",
+  "models": {
+    "deepseek-v4-pro": { "cache_hit_in": 0.003625, "cache_miss_in": 0.435, "out": 0.87 }
+  },
+  "notes": "..."
+}
+```
+
+**後方互換が絶対条件。** 時間帯を持たない既存の表がそのまま今までどおり動くこと。
+時間帯情報はオプショナルな追加であり、無ければ従来の単価がそのまま全時間帯に適用される。
+
+設計の要点:
+
+- 時間帯窓は**タイムゾーン付きで定義する**。DeepSeek の告知は北京時間
+  （`Beijing 09:00-12:00, 14:00-18:00`）である
+- **中国は夏時間を採用していないので、北京時間は UTC+8 固定である。**
+  `zoneinfo` は Python 3.9+ かつ tzdata が必要で、環境によっては入っていない。
+  **固定オフセットで実装すること**（タイムゾーン名を書くなら、それは表示用の情報として持ち、
+  計算は固定オフセットで行う）。オフセットは価格表側に持たせ、コードにハードコードしないこと
+- 窓の境界の扱い（開始時刻を含むか、終了時刻を含むか）を**明示的に決めてコメントに書く**。
+  境界1秒の差で単価が2倍変わるので、曖昧にしない
+- 日を跨ぐ窓（例 `22:00-02:00`）を表現できるかどうかを決める。
+  **できないなら「できない」とスキーマ文書に書く**（黙って壊れるより良い）
+- 倍率で表現するか、時間帯ごとの単価を直接書くかを決め、理由を書くこと
+
+### 2. `compute_cost()` に時刻を渡す
+
+現在のシグネチャは `compute_cost(model, usage_fields, price_table)` で、
+**時刻を受け取っていない**（`select_price_table` に日付を渡す側で日単位の解決が済んでいるため）。
+時間帯判定にはメッセージのタイムスタンプが要るので、シグネチャを変える。
+
+呼び出し元は `build_usage_event()`（`bin/ocw-meter:3141`）。
+**時刻が取れないメッセージがあった場合の挙動を決めること**（推測で peak / off-peak を
+決めないこと。取れないなら従来の単価に倒し、その旨を `cost_basis` か別のフィールドで示す）。
+
+`compute_cost()` の既存の契約を壊さないこと:
+
+- **`claude-*` は必ず `(None, None, None, "subscription")` を返す**（定額契約を換算しない。
+  ADR DOC-2608021229 の判断。本傘でもこれは維持する）
+- **絶対に raise しない**（docstring に「Never raises」と明記されている）
+- 未知のモデル名には値段を当てない
+
+### 3. 該当する価格表が無い期間を黙らせない
+
+`select_price_table()` の `tables[0]` フォールバックは**残してよい**（クラッシュさせないため）。
+だが**フォールバックが起きたことを呼び出し側に伝えること。** 現状は戻り値からは区別できない。
+
+伝わった先で出すべきもの:
+
+- `usage_cost_footer()`（`bin/ocw-meter:1514`）の `price_table` 行に、
+  「対象期間より後に発効した価格表を適用した件数」を出す
+- `report --month` の cash cost 節に、**その月に適用された `price_table_version` と、
+  その表の `effective_date` が対象月より後であるかどうか**を出す。
+  実測で言えば `report --month 2026-07` は「`deepseek-2026-08-01` を適用（対象月より後に発効）」
+  と出るべきである
+
+**既存イベントに焼き込まれた `price_table_version` / `price_effective_date` から
+読み取り時に判定できる**（イベントを書き換える必要はない）。
+
+### 4. 過去の価格表を足すための手順を用意する（データは入れない）
+
+`bin/prices/` に価格表を追加する手順を短い README として書く。含めるもの:
+
+- 必須フィールドと意味（`load_price_tables` が要求する3つは
+  `price_table_version` / `effective_date` / `models`）
+- **`source`（出典 URL）と `fetched_at` を必ず埋めること**。単価は一次情報であり、
+  記憶や推測で書いてはいけない
+- **過去の表を足しても既に保存されたイベントの `cost_estimate_usd` は変わらない**こと
+  （変えたければイベントストアを作り直すしかない。それは本ツールの不変条件に反する）
+- 時間帯課金の書き方（上記1で決めた形）
+
+**サンプルの JSON を置く場合は、実在しない `example` プロバイダの明らかにダミーな数字にすること。**
+実在プロバイダのそれらしい数字を例として置くと、いつか誰かが本物だと思って使う。
+
+## テスト（`bin/tests/test_ocw_meter.py`）
+
+追加するテスト:
+
+**後方互換:**
+- 時間帯情報を持たない既存形式の価格表で、費用が従来どおり計算される
+  （既存のテストが無改変で通ることが主要な根拠になる）
+
+**時間帯:**
+- peak 窓の中のタイムスタンプで peak 単価、外で off-peak 単価が適用される
+- 窓の境界ちょうどのタイムスタンプ（開始時刻・終了時刻）で、決めたとおりの単価になる
+- UTC のタイムスタンプが正しく北京時間の窓へ変換される（**UTC 深夜 = 北京の朝** のように、
+  日付を跨ぐケースを必ず含めること）
+- 時刻が取れないメッセージで落ちず、決めたフォールバック挙動になる
+
+**フォールバック警告:**
+- 対象日より後に発効した価格表しか無いとき、`report` に警告が出る
+- `report --month` に、適用された `price_table_version` と発効日ミスマッチが出る
+- 期間に合う価格表があるときは警告が出ない
+
+**壊れた価格表:**
+- 時間帯定義が壊れている（窓が不正・オフセットが無い等）価格表があっても
+  `ingest` が落ちない（`load_price_tables` の既存方針「malformed は skip、fatal にしない」を維持）
+
+## 完了条件
+
+- `pre-commit run --all-files` が通る
+- `bin/tests/lint.sh` が通る
+- `python3 -m unittest discover -s bin/tests -v` が全件通る
+- **既存の価格表 `deepseek-2026-08-01.json` を1バイトも変えていない**か、
+  変えた場合はその内容が出典で裏が取れている（推測で単価を書き換えていない）
+- 実ストアが変化していないことを確認済み（計画書「全孫共通の注意」§4）
+
+## 実装完了後の流れ（必須）
+
+実装が完了したら、以下を**自律的に**実行してください:
+1. PRを作成する。**PRの向き先は必ず `ocw-meter-accuracy` にすること。master には絶対に出さない。**
+2. /pr-review-loop を起動する（PRがない場合は自動で作成し、そのままレビューを開始する）
+3. レビュー指摘があれば修正し、承認されるまで繰り返す
+4. 承認されたら人間に「マージしてください」と依頼する
+実装が終わったタイミングで止まらず、必ずここまでやりきってください。
+
+## ブランチ作成時の注意（最重要）
+
+作業ブランチは**必ず `ocw-meter-accuracy` から切ること**。
+master から切ると PR の diff に傘ブランチ全体が混入してレビュー不能になる。
+実装開始前に以下を必ず実行すること:
+git checkout ocw-meter-accuracy && git pull --rebase origin ocw-meter-accuracy
+git checkout -b ocw-meter-03-price-tables
+````
+
+## 孫4用プロンプト:
+
+````
+`quota.sample` に眠っている `session_cost_usd` を集計して、
+Claude 側の list price 相当額を `report` に出せるようにしてください。
+
+## 最初に読むもの（順番に）
+
+1. リポジトリルートの `AGENTS.md`（最重要ルール）
+2. `docs/planning/DOC-2608081456_ocw-meter-accuracy_計画.md`（この計画書。
+   「【2】【3】の鍵」節、「確定事項」、**「実装上の罠」の罠2・罠3・罠4**、「残る限界」、
+   「全孫共通の注意」を必ず読む）
+3. `docs/adr/DOC-2608021229_llm-cost-observability-collection-method.md`
+   （「定額契約を API 単価に換算しない」という判断。**本孫はこれを覆さない**）
+4. `docs/reference/DOC-2608021229-c_ocw-meterイベントスキーマ.md` §2.5（`quota.sample` の
+   ペイロード。`session_cost_usd` の定義がここにある）
+5. `bin/ocw-meter`（孫1〜3がマージ済み。特に `report_month_cash_and_capacity`:2008 /
+   `pr_review_summary`:1626 / `report_by_window` / `usage_cost_footer`:1514 /
+   `print_footer_text` / `cmd_report`:2284 / `_report_month_standalone`:2534 付近 /
+   `snapshot-quota` のイベント組み立て 4055-4110 付近）
+6. `bin/tests/test_ocw_meter.py`
+
+## この孫のスコープ
+
+**`quota.sample` の集計と、その表示だけ。** `usage.message` の書き込み経路には一切触らない。
+帰属（`run_id` / `role`）は孫5の担当。
+
+**スキーマ変更なし。既存フィールドの集計のみ。書き込み経路は無変更。**
+
+## 背景（実測。再調査不要）
+
+`snapshot-quota` が statusLine の `cost.total_cost_usd` を `session_cost_usd` として記録している。
+**これが 4,704 / 4,705 件で埋まっていて、しかもどのレポートにも一切出てこない。**
+
+```
+provider別（セッション累積の最大値を合計）
+  anthropic : $2,995.36 / 205 sessions（全部 2026-08）
+  deepseek  : $93.35    / 10 sessions
+
+PR単位にも落ちる（anthropic セッション 140/205 に pr_number あり）
+  PR #33: $103.36   PR #39: $126.94   PR #32: $58.14
+  PR #41: $56.56    PR #28: $49.60    PR #35: $33.77 ...
+```
+
+つまり `report --month 2026-08` が `$1.34` と表示している裏で、
+同じストアに $2,995 分の Claude 側自己申告コストが眠っている。
+
+**この経路は `quota.sample` だけを見るので、【1】の ingest 遅延の影響を受けない。**
+
+### 1. `report_capacity_list_price(quota_events)` を新設する
+
+**⚠️ 罠2: `provider == "anthropic"` で明示的にスコープすること。**
+`deepseek` の `session_cost_usd`（$93.35）を混ぜてはいけない。Claude Code が DeepSeek の
+モデル名に何の単価を当てているか不明であり、`ocw-meter` 自身の推定 $48.12 と二重計上になる。
+
+`quota.sample` の `provider` は `infer_provider(model_normalized)`、`model` が取れないときは
+`has_rate_limits` から `"anthropic"` にフォールバックして決まっている
+（`bin/ocw-meter:4069` 付近）。DeepSeek セッションは `rate_limits` を持たないため、
+`provider == "anthropic"` によるスコープはこの実装で正しく機能する。
+
+**⚠️ 罠3: `max()` を使ってはいけない。「正の差分の総和」を取ること。**
+`session_cost_usd` はセッション累積のはずだが、**214セッション中26セッションで値が減少している**
+（`/clear` やコンパクションでリセットされていると思われる）。`max()` ではリセット前の分を
+取りこぼす。
+
+```
+session_id ごとに ts 昇順でソート
+  → 隣り合うサンプルの差分を取る
+  → 正の差分だけを合計（負の差分は「リセットが挟まった」と解釈して 0 扱い）
+  → 各セッションの最初のサンプルの値そのものは初項として加算する
+```
+
+上記の **$2,995.36 は `max()` による集計なので下振れした値**である。
+正の差分の総和で取り直せば、これ以上の値が出るはずである。
+
+`session_id` が無いサンプル・`session_cost_usd` が `null` のサンプルの扱いを決め、
+除外した件数を報告に出せるようにすること（黙って落とさない）。
+
+### 2. 出し先
+
+- **`report --month` の capacity cost 節**（`report_month_cash_and_capacity`:2008 の
+  戻り値と、`_report_month_standalone` の `summary["capacity"]` 構築部）
+- **`report --pr <n>`**（`pr_review_summary`:1626 の `capacity_message_count` の隣）
+- **`report --window`**（自然に乗るはず。乗せられるか確認し、乗せられないなら理由を PR に書く）
+
+### 3. 表示（⚠️ 罠4）
+
+**必ず下限値として、請求書ではないと明示して出すこと。**
+最後の statusLine 描画以降の消費が入らないため、この数字は原理的に下限である。
+
+表示例:
+
+```
+list_price_equiv_usd: $2,995+ (下限 / Claude Code自己申告のlist price相当 / 請求書ではない / cash costと合算不可)
+```
+
+守るべき境界:
+
+- **`usage_cost_footer()`（`bin/ocw-meter:1514`）の `cost_estimate` 行とは別行にする。混ぜない**
+- **cash cost と絶対に足さない。** `report_month_cash_and_capacity` の docstring が
+  「cash cost と capacity は never summed」と明記している。これは様式の好みではなく
+  ハード要件である。`list_price_equiv_usd` は **capacity 側**に属する
+- `--json` にも同じ情報を出すこと。**JSON のキー名に単位と性質が分かる名前を使う**
+  （`list_price_equiv_usd` と、それが下限であることを示す別キー）
+- **対象期間に anthropic の `quota.sample` が1件も無いときは `null`**。
+  `$0.00` と出さない（「0ドルだった」と「データが無い」は別の事実である）
+
+### 4. 限界を出力に書く（正直さの要件）
+
+- `quota.sample` は **2026-08-01 開始**。それより前の月には Claude 側コストのデータが無い。
+  `report --month 2026-07` 等では「この期間に quota.sample が無いため不明」と出すこと
+- 下限であること（罠4）
+
+## テスト（`bin/tests/test_ocw_meter.py`）
+
+追加するテスト（計画書の「罠」に対応するものは省略不可）:
+
+**非単調セッション（罠3）:**
+- 1セッションで `10 → 20 → 5 → 15` と推移する `quota.sample` を並べ、
+  結果が `max()` の `20` ではなく **正の差分の総和 `10 + 10 + 10 = 30`** になる
+- 単調増加のみのセッションでは、最終値と一致する
+- サンプル1件だけのセッションで、その値がそのまま入る
+
+**deepseek 混入除外（罠2）:**
+- anthropic セッションと deepseek セッションが混在するストアで、
+  deepseek の `session_cost_usd` が**1セントも入っていない**
+- `rate_limits` を持たない（= DeepSeek 形状の）サンプルが混ざっても除外される
+
+**表示と境界:**
+- `list_price_equiv_usd` が cash cost と**別のキー / 別の行**で出る
+- 対象期間に anthropic の `quota.sample` が無いとき `null`（`0` ではない）
+- `--json` に出る
+- `report --pr <n>` に出る
+- `session_cost_usd` が `null` のサンプル、`session_id` が無いサンプルが混ざっても落ちない
+
+## 完了条件
+
+- `pre-commit run --all-files` が通る
+- `bin/tests/lint.sh` が通る
+- `python3 -m unittest discover -s bin/tests -v` が全件通る
+- **書き込み経路（`snapshot-quota` / `ingest`）の diff がゼロ**である
+  （この孫は集計と表示だけ。スキーマも変えない）
+- 実ストアが変化していないことを確認済み（計画書「全孫共通の注意」§4）
+
+## 実装完了後の流れ（必須）
+
+実装が完了したら、以下を**自律的に**実行してください:
+1. PRを作成する。**PRの向き先は必ず `ocw-meter-accuracy` にすること。master には絶対に出さない。**
+2. /pr-review-loop を起動する（PRがない場合は自動で作成し、そのままレビューを開始する）
+3. レビュー指摘があれば修正し、承認されるまで繰り返す
+4. 承認されたら人間に「マージしてください」と依頼する
+実装が終わったタイミングで止まらず、必ずここまでやりきってください。
+
+## ブランチ作成時の注意（最重要）
+
+作業ブランチは**必ず `ocw-meter-accuracy` から切ること**。
+master から切ると PR の diff に傘ブランチ全体が混入してレビュー不能になる。
+実装開始前に以下を必ず実行すること:
+git checkout ocw-meter-accuracy && git pull --rebase origin ocw-meter-accuracy
+git checkout -b ocw-meter-04-list-price-equiv
+````
+
+## 孫5用プロンプト:
+
+````
+`session_id` で `quota.sample` と `usage.message` を突き合わせ、
+`run_id` / `role` の帰属を解決してください（ingest 側フォールバック + report 側 join の併用）。
+
+## 最初に読むもの（順番に）
+
+1. リポジトリルートの `AGENTS.md`（最重要ルール）
+2. `docs/planning/DOC-2608081456_ocw-meter-accuracy_計画.md`（この計画書。
+   「調査で判明した事実」の【3】、「【2】【3】の鍵」節、「確定事項」、
+   **「実装上の罠」の罠1**、「残る限界」、「全孫共通の注意」を必ず読む）
+3. `docs/reference/DOC-2608021229-c_ocw-meterイベントスキーマ.md`
+4. `bin/ocw-meter`（孫1〜4がマージ済み。特に
+   `load_local_pr_binds_and_run_starts`:3007 / `resolve_run_id_via_ocw_run_id_file`:3041 /
+   `build_usage_event`:3141 と **その run.start 逆転チェック 3186 付近** /
+   `iter_stored_events`:1426 / `events_for_pr`:1589 / `pr_review_summary`:1626 /
+   `report_by_role`:1756 / `report_by_phase`:1844 / `usage_cost_footer`:1514）
+5. `bin/tests/test_ocw_meter.py`
+
+## この孫のスコープ
+
+**`run_id` / `role` の帰属解決だけ。** 費用計算・価格表・`list_price_equiv` には触らない。
+
+## 背景（実測。再調査不要）
+
+```
+run_id が入っている usage.message : 3,043 / 57,164 (5.3%)
+role=unknown                      : 51,959 / 57,164 (90.9%)
+report --phase の (unassigned)    : 56,648 / 57,164 (99.1%)
+```
+
+原因は共通で、**解決タイミングが「ingest 実行時点のライブ状態」だから**。
+`run_id` は `cwd` 配下の `<git-dir>/ocw-run-id` という *消える実ファイル* を読み、
+`role` は `herdr pane list` という *閉じたら引けないライブ状態* を読んでいる。
+しかも「過去は再計算しない」不変条件があるため、後から ingest し直しても永久に直らない。
+
+**答えは既にストアの中にある。** `quota.sample` は `session_id` 100% / `run_id` 78% /
+`role` 78%（unknown 22%）を持ち、`usage.message` も transcript 由来の `session_id` を100%持つ。
+**両者を `session_id` で突き合わせるだけ**で、実測こうなる:
+
+```
+8/1以降（quota.sample 稼働後）の usage.message 17,670件
+  run_id : 3,043 (17.2%)  ->  10,885 (61.6%)
+  role   : 4,814 (27.2%)  ->  12,740 (72.1%)
+```
+
+**この join は `ocw rm` に一切影響されない**（`quota.sample` は消えないイベントだから）。
+
+### 1. B: ingest 側フォールバック（新しく書き込むイベントを直す）
+
+`load_local_pr_binds_and_run_starts()`（`bin/ocw-meter:3007`）の戻り値に
+`session_attrs`（`session_id` → `{run_id, role, pr_number}`）を追加する。
+**この関数は ingest 中に既にイベントストアを全走査している**ので、追加コストはほぼゼロ。
+
+`build_usage_event()`（`bin/ocw-meter:3141`）の解決順を次にする:
+
+- `run_id`: `ocw-run-id` ファイル → **quota.sample 由来** → `null`
+- `role`: Herdr live → **quota.sample 由来** → `"unknown"`
+
+**1つの `session_id` に複数の `run_id` / `role` が紐づくケースの扱いを決めること**
+（同じセッションで worktree を移った場合など）。時刻で最も近いものを選ぶ / 一意でなければ
+解決しない、などの方針を決め、**理由をコメントと PR 説明文に書く**。推測で1つ選ばないこと。
+
+#### ⚠️ 罠1（この孫で最も踏みやすい）
+
+**quota.sample 由来の `run_id` には、既存の `run.start` 逆転チェックを適用してはいけない。**
+
+`bin/ocw-meter:3186` 付近に「その `run_id` の `run.start` より前のメッセージなら捨てる」という
+チェックがある。これは **「worktree パスは再利用される」ことを前提にした stale path 対策**であり、
+`ocw-run-id` ファイル経由の解決にのみ意味がある。
+
+`session_id` は再利用されないため、このチェックを quota.sample 由来の解決にかけると
+**正しい帰属まで null 化してしまう。** 解決経路ごとにチェックの適用を分けること。
+**この点はテストで固定すること**（後の誰かが「統一しよう」と言って壊すのを防ぐため）。
+
+### 2. A: report 側 join（既に保存済みのイベントを読み取り時に補完）
+
+`iter_stored_events()`（`bin/ocw-meter:1426`）の走査時に同じマップを組み、
+**`run_id` / `role` が `null` のイベントだけ**読み取り時に補完する。
+
+**既に値が入っているイベントの値を上書きしないこと**（ingest 時に直接解決できた値のほうが
+信頼度が高い）。
+
+影響先:
+`report_by_phase`（:1844）/ `report_by_role`（:1756）/ `events_for_pr`（:1589）/
+`pr_review_summary`（:1626）。**これら全部で同じ補完が効くこと**を確認すること。
+
+**保存されたイベントのファイルを書き換えないこと。** これは読み取り時の解決であり、
+「過去は再計算しない」不変条件を破らないためにこの方式を選んでいる
+（既存イベントを埋め直す `reattribute` サブコマンド案は、計画書で明示的に却下している）。
+
+`iter_stored_events` は**全ビューが通る道**なので、性能に注意すること。
+マップを毎回組み直さない（1回組んで使い回す）。実ストアは events 68MB / 62,763件である。
+
+### 3. ⚠️ 譲れない条件: 補完したことを出力に明示する
+
+これをしないと「推測で埋めない」という本ツールの方針に反して見える。
+フッター（`usage_cost_footer` = `bin/ocw-meter:1514` に足せば全ビューに乗る）に1行足す:
+
+```
+attribution:   direct 17.2% / via session_id 44.4% / unresolved 38.4%
+```
+
+- `direct`: ingest 時に `ocw-run-id` / Herdr live から直接解決できたもの
+- `via session_id`: quota.sample 由来（ingest 側フォールバックと report 側 join の両方を含む）
+- `unresolved`: どちらでも解決できなかったもの
+
+**`run_id` と `role` は別々の割合になる**（実測でも 61.6% と 72.1% で違う）。
+1行にまとめるか2行に分けるかを決め、**どちらの数字か分かる形にすること**。
+`--json` にも同じ情報を出す。
+
+### 4. 残る限界を出力または文書に書く（正直さの要件。「直った」と言わない）
+
+- **7月以前は救えない。** `quota.sample` が 2026-08-01 開始のため、
+  7月の29,676件（DeepSeek 時代）の `run_id` / `role` は復元手段が無い
+- 8月でも `run_id` 61.6% / `role` 72.1% で100%にはならない。
+  `claude-ds` セッションや statusLine が回らなかったセッションは取れない
+- `role` の 22% unknown は Herdr 外で起動した Claude なので**原理的に取得不能**
+
+## テスト（`bin/tests/test_ocw_meter.py`）
+
+追加するテスト:
+
+**session join（B: ingest 側）:**
+- `ocw-run-id` ファイルが無く、同じ `session_id` の `quota.sample` に `run_id` があるとき、
+  新しく ingest した `usage.message` にその `run_id` が入る
+- `ocw-run-id` ファイルがあるときは**そちらが優先される**
+- `role` も同様（Herdr live 優先、無ければ quota.sample 由来、それも無ければ `"unknown"`）
+- どちらも無ければ `run_id` は `null` / `role` は `"unknown"`
+
+**罠1（逆転チェックの非適用）:**
+- **`quota.sample` 由来の `run_id` が、対応する `run.start` より前の時刻の `usage.message` にも
+  正しく付く**（`ocw-run-id` ファイル経由なら捨てられる条件を作り、
+  session 経由では捨てられないことを対で確認する）
+- `ocw-run-id` ファイル経由の逆転チェックは**従来どおり効いている**（回帰防止）
+
+**A: report 側 join:**
+- `run_id` が `null` のまま保存済みの `usage.message` が、`report --phase` で
+  正しい phase に集計される（**保存ファイルは変わっていない**ことも確認する）
+- 既に `run_id` が入っているイベントの値が上書きされない
+- `report --role` / `report --pr` / `pr_review_summary` でも同じ補完が効く
+
+**attribution 行:**
+- `direct` / `via session_id` / `unresolved` の3分類が実際の内訳と一致する
+- 3分類の合計が母数と一致する（どこにも計上されないイベントが無い）
+- `--json` に出る
+
+**曖昧なケース:**
+- 1つの `session_id` に複数の `run_id` が紐づくとき、決めた方針どおりに振る舞う
+
+## 完了条件
+
+- `pre-commit run --all-files` が通る
+- `bin/tests/lint.sh` が通る
+- `python3 -m unittest discover -s bin/tests -v` が全件通る
+- **保存済みイベントファイルを書き換える経路を一切追加していない**
+- `report` の実行時間が実用範囲に収まっている（実ストア規模: events 68MB / 62,763件。
+  サンドボックスで同等規模の合成ストアを作って測り、結果を PR 説明文に書くこと）
+- 実ストアが変化していないことを確認済み（計画書「全孫共通の注意」§4）
+
+## 実装完了後の流れ（必須）
+
+実装が完了したら、以下を**自律的に**実行してください:
+1. PRを作成する。**PRの向き先は必ず `ocw-meter-accuracy` にすること。master には絶対に出さない。**
+2. /pr-review-loop を起動する（PRがない場合は自動で作成し、そのままレビューを開始する）
+3. レビュー指摘があれば修正し、承認されるまで繰り返す
+4. 承認されたら人間に「マージしてください」と依頼する
+実装が終わったタイミングで止まらず、必ずここまでやりきってください。
+
+## ブランチ作成時の注意（最重要）
+
+作業ブランチは**必ず `ocw-meter-accuracy` から切ること**。
+master から切ると PR の diff に傘ブランチ全体が混入してレビュー不能になる。
+実装開始前に以下を必ず実行すること:
+git checkout ocw-meter-accuracy && git pull --rebase origin ocw-meter-accuracy
+git checkout -b ocw-meter-05-session-attribution
+````
+
+## 孫6用プロンプト:
+
+````
+本傘（`ocw-meter-accuracy`）で変わった `ocw-meter` の仕様を文書へ反映してください。
+
+## 最初に読むもの（順番に）
+
+1. リポジトリルートの `AGENTS.md`（最重要ルール）
+2. `docs/planning/DOC-2608081456_ocw-meter-accuracy_計画.md`（この計画書。**全部読む**。
+   特に「残る限界」節は、そのまま文書に書くべき内容である）
+3. **`bin/ocw-meter` の実装そのもの**（孫1〜5がマージ済み。文書は計画書ではなく**実装**に
+   合わせること。食い違いがあれば実装を正とし、**その食い違い自体を人間に報告する**）
+4. `bin/README.md`（611行）と ルート `README.md`
+5. `docs/reference/DOC-2608021229-c_ocw-meterイベントスキーマ.md`
+6. `docs/adr/DOC-2608021229_llm-cost-observability-collection-method.md`
+
+## この孫のスコープ
+
+**文書のみ。** `bin/ocw-meter` と `bin/tests/test_ocw_meter.py` は変更しない
+（読んで内容を確認するのが仕事）。
+
+### 1. `bin/README.md` の改訂
+
+**古くなった記述の修正（必須）:**
+
+- **`bin/README.md:525` 付近**: 「このマシンの実ストア44,425件の `usage.message` のうち
+  `run_id` が設定されているものは0件」→ **実測3,043件 / 57,164件（5.3%）が正しい。**
+  さらに孫5の session join により 8/1 以降は 61.6% まで上がる。この節は
+  「`run_id` は解決できない」という前提で書かれているので、**孫5の解決策を含めて書き直す**
+- **`bin/README.md:412` 付近**: `session_cost_usd` が「別カラムであり合算しない」とだけ
+  書かれているが、孫4でこれが `list_price_equiv_usd` として集計・表示されるようになった。
+  **「合算しない」は維持したまま、集計されて出るようになったことを追記する**
+- **`bin/README.md:457` 付近の `prune` 未実装の決定**: **この決定は本傘でも維持している。**
+  ただし孫1が `prune-diagnostics`（`state/` の診断ファイル専用）を追加したので、
+  **両者が別物であることを明確に書く**（`events/` は消さない）
+
+**新しく書くこと:**
+
+- **`report` が `ingest` を自動実行するようになったこと**（孫2）と `--no-ingest`。
+  フッターの最終 ingest 時刻・鮮度表示の読み方
+- **価格表の時間帯（peak/off-peak）対応**（孫3）。スキーマの書き方は
+  `bin/prices/` の README（孫3が作った）を指し、ここでは概要だけ。
+  **該当する価格表が無い期間の費用は概算であり、警告が出ること**
+- **`list_price_equiv_usd`**（孫4）。**下限値であること・請求書ではないこと・
+  cash cost と合算できないこと・`quota.sample` が 2026-08-01 開始なので
+  それ以前の月は不明であること**を必ず書く
+- **attribution 行の読み方**（孫5）。`direct` / `via session_id` / `unresolved` の意味と、
+  **7月以前は救えない**という限界
+- **`prune-diagnostics` サブコマンド**（孫1）。既定が dry-run であること、
+  `events/` には触らないこと
+- **テストが実 `$HOME` を汚染していた不具合とその修正**（孫1）。
+  過去に `state/meter-errors.jsonl` へテスト由来の診断が混入していたことと、
+  `prune-diagnostics` で掃除できることを、運用上の注意として書く
+
+### 2. `docs/reference/DOC-2608021229-c_ocw-meterイベントスキーマ.md` の追記
+
+- **§4「費用計算式」/「価格表（`bin/prices/*.json`）」節**: 時間帯対応後のスキーマを追記。
+  **窓の境界の扱い（開始/終了を含むか）とタイムゾーンの扱い（固定オフセット）を明記する**。
+  日を跨ぐ窓が表現できるかどうかも書く（孫3の実装がどちらを選んだかを確認してから書く）
+- **`list_price_equiv` の集計定義を新設**: `provider == "anthropic"` に限定すること、
+  `session_id` ごとの**正の差分の総和**であること、**`max()` ではない**理由
+  （214セッション中26セッションで非単調だった実測）、下限値であること、
+  cash cost と合算しないこと
+- **attribution の解決順を新設**: `run_id` は `ocw-run-id` ファイル → quota.sample 由来 → `null`、
+  `role` は Herdr live → quota.sample 由来 → `"unknown"`。
+  **quota.sample 由来の `run_id` に `run.start` 逆転チェックを適用しない**という設計上の判断と
+  その理由（`session_id` は再利用されないため）を必ず記録する
+- §6「`schema_version` の変更ルール」に照らして、**本傘で `schema_version` の変更が
+  必要だったかどうか**を確認して記述を追随させる（孫2〜5がいずれもイベントのスキーマを
+  変えていないなら、変更不要である旨を明記する）
+
+### 3. ADR `DOC-2608021229` への追記節
+
+**ADR 本体の判断は覆さない。** 「サブスクを API 単価に換算しない」は維持されている。
+
+追記するのは**線引きの記録**である:
+
+> **Anthropic 自己申告値（`session_cost_usd`）の採用は「換算」ではない。**
+> 本 ADR が却下したのは「ocw-meter が定額契約を API 単価に換算して推定額を作ること」であって、
+> 「Claude Code 自身が申告した値をそのまま記録・集計すること」ではない。
+> 前者は ocw-meter の推定であり、後者は Anthropic 側の自己申告である。
+> データの出所も信頼レベルも異なるため、別カラム・別行として共存させる。
+
+既存の ADR の書式（見出しレベル・番号の付け方）に合わせること。
+節番号は既存の最後（§9）の後ろに足すか、`## 7. 代替案と不採用理由` の関連箇所から
+参照させるかを、文書全体を読んでから判断すること。
+
+**却下案も記録すること:**
+- B「価格表に anthropic を足して `usage.message` 側で自前計算」→ ADR の判断を覆す必要がある。
+  ただし A の後から**共存可能**である（意味の異なるカラムなので）
+- C「サブスク月額を按分」→ 実支払額と一致する唯一の方式だが、月末まで確定せず
+  按分の分母が恣意的
+
+### 4. ルート `README.md` の追随
+
+`bin/` の説明と `ocw-meter` に言及している箇所を確認し、嘘になっている記述があれば直す。
+**ルートは全体像、`bin/README.md` は詳細**という二層構造を崩さないこと
+（AGENTS.md「片方だけ更新しない」）。
+
+### 5. 実装との突き合わせ（省略不可）
+
+書く前に `bin/ocw-meter` の該当箇所を読み、**実装が実際にそうなっていることを確認してから書くこと。**
+計画書は決定の記録であって実装の保証ではない。食い違いを見つけたら文書を実装に合わせ、
+**その事実を PR 説明文に書いて人間に報告する。**
+
+特に確認すべき点:
+- `prune-diagnostics` の実際のオプション名・既定値（孫1が決めたもの）
+- 価格表の時間帯スキーマの実際の形（孫3が決めたもの）
+- attribution 行の実際の出力形式（孫5が決めたもの）
+- `list_price_equiv_usd` の実際のキー名と表示文言（孫4が決めたもの）
+
+**推測でコマンド例やフィールド名を書かないこと。** 実際に実行して出力を貼るのが最も確実である
+（`report` 系は副作用として ingest が走るようになっているので、
+**実 `$HOME` ではなくサンドボックス（`OCW_METER_HOME` と `HOME` の両方を tempdir に向けた
+環境）で実行すること**）。
+
+## 完了条件
+
+- `pre-commit run --all-files` が通る（`doc-id check` / `doc-id verify` を含む）
+- `bin/README.md` / ルート `README.md` / DOC-2608021229-c / DOC-2608021229 に、
+  実装と食い違う記述が残っていない
+- `bin/README.md:525` 付近の「`run_id` が設定されているものは0件」が実測値に更新されている
+- 本傘の**限界**（7月以前の帰属は救えない / `list_price_equiv` は下限値 /
+  6〜7月の Claude 側コストは不明）が、「直った」と読める書き方になっていない
+- 地の文で `docs/` の文書に言及する箇所で、**DOC-ID が明示されている**
+  （AGENTS.md「説明的ファイル名だけで呼ばない」）
+
+## 実装完了後の流れ（必須）
+
+実装が完了したら、以下を**自律的に**実行してください:
+1. PRを作成する。**PRの向き先は必ず `ocw-meter-accuracy` にすること。master には絶対に出さない。**
+2. /pr-review-loop を起動する（PRがない場合は自動で作成し、そのままレビューを開始する）
+3. レビュー指摘があれば修正し、承認されるまで繰り返す
+4. 承認されたら人間に「マージしてください」と依頼する
+実装が終わったタイミングで止まらず、必ずここまでやりきってください。
+
+## ブランチ作成時の注意（最重要）
+
+作業ブランチは**必ず `ocw-meter-accuracy` から切ること**。
+master から切ると PR の diff に傘ブランチ全体が混入してレビュー不能になる。
+実装開始前に以下を必ず実行すること:
+git checkout ocw-meter-accuracy && git pull --rebase origin ocw-meter-accuracy
+git checkout -b ocw-meter-06-docs
+````
+
+---
+
+## 傘の完了条件
+
+- 孫1〜6 がすべて `ocw-meter-accuracy` にマージ済み
+- 傘ブランチ上で以下がすべて通る:
+  - `pre-commit run --all-files`
+  - `bin/tests/lint.sh`
+  - `python3 -m unittest discover -s bin/tests -v`
+- **テストスイートを回しても実 `~/.local/state/ocw-meter` が変化しない**
+- `report` が `ingest` を自動実行し、最終 ingest 時刻と鮮度がフッターに出る
+- `report --month 2026-08` に `list_price_equiv_usd` が下限値として出る
+  （`$2,995+` を上回る値になるはず。罠3の「正の差分の総和」で取り直すため）
+- `report --phase` の `(unassigned)` が 99.1% から大きく下がる
+  （8月分について `run_id` 61.6% / `role` 72.1% が目安）
+- attribution の内訳（`direct` / `via session_id` / `unresolved`）が全ビューのフッターに出る
+- 対象期間より後に発効した価格表を適用した場合に警告が出る
+- 価格表が時間帯（peak/off-peak）課金を表現できる
+- `ocw-meter prune-diagnostics` が既定 dry-run で動き、`events/` には触らない
+- **保存済みイベントを書き換える経路が1つも増えていない**（「過去は再計算しない」不変条件の維持）
+- `bin/README.md` / ルート `README.md` / DOC-2608021229-c / DOC-2608021229 が実装と一致している
+
+### 本傘で解決しないもの（明示）
+
+以下は人間の判断でスコープ外とした。**孫が先回りして実装しない。**
+
+- `<synthetic>` 103件の除外（`completeness: unknown` 0.7% の中身）
+- `five_hour_window_completion` の定義見直しまたは廃止
+- `prune`（`events/` の削除。`bin/README.md:457` の意図的据え置きを維持）
+- 6〜7月の DeepSeek 価格表の投入（出典が要るため人間の作業。孫3は手順のみ整備）
+- 7月以前の `run_id` / `role` の復元（`quota.sample` が無いため原理的に不可能）
+- 6〜7月の Claude 側コスト（同上）

--- a/docs/planning/DOC-2608081456_ocw-meter-accuracy_計画.md
+++ b/docs/planning/DOC-2608081456_ocw-meter-accuracy_計画.md
@@ -20,8 +20,8 @@
 
 | 孫 | ブランチ | 内容 | 状況 |
 |---|---|---|---|
-| 1 | `ocw-meter-01-store-hygiene` | 【4】【6】テストによる実ストア汚染の停止・`quota-worktree-refusal.json` のプルーニング片手落ち修正・診断ファイル専用の掃除サブコマンド新設 | 🔄 実装中 |
-| 2 | `ocw-meter-02-ingest-freshness` | 【1】`report` からの ingest 自動実行と、最終 ingest 時刻・鮮度のフッター表示 | ⬜ 待機中 |
+| 1 | `ocw-meter-01-store-hygiene` | 【4】【6】テストによる実ストア汚染の停止・`quota-worktree-refusal.json` のプルーニング片手落ち修正・診断ファイル専用の掃除サブコマンド新設 | ✅ PR #56 マージ済 |
+| 2 | `ocw-meter-02-ingest-freshness` | 【1】`report` からの ingest 自動実行と、最終 ingest 時刻・鮮度のフッター表示 | 🔄 実装中 |
 | 3 | `ocw-meter-03-price-tables` | 【5】価格表スキーマの時間帯（peak/off-peak）対応・フォールバック時の警告・適用期間ミスマッチの可視化 | ⬜ 待機中 |
 | 4 | `ocw-meter-04-list-price-equiv` | 【2】`quota.sample` の `session_cost_usd` から `list_price_equiv_usd` を集計して `report` に出す | ⬜ 待機中 |
 | 5 | `ocw-meter-05-session-attribution` | 【3】`session_id` join による `run_id` / `role` の帰属解決（ingest 側フォールバック + report 側 join）と attribution 行 | ⬜ 待機中 |

--- a/docs/planning/DOC-2608081456_ocw-meter-accuracy_計画.md
+++ b/docs/planning/DOC-2608081456_ocw-meter-accuracy_計画.md
@@ -21,8 +21,8 @@
 | 孫 | ブランチ | 内容 | 状況 |
 |---|---|---|---|
 | 1 | `ocw-meter-01-store-hygiene` | 【4】【6】テストによる実ストア汚染の停止・`quota-worktree-refusal.json` のプルーニング片手落ち修正・診断ファイル専用の掃除サブコマンド新設 | ✅ PR #56 マージ済 |
-| 2 | `ocw-meter-02-ingest-freshness` | 【1】`report` からの ingest 自動実行と、最終 ingest 時刻・鮮度のフッター表示 | 🔄 実装中 |
-| 3 | `ocw-meter-03-price-tables` | 【5】価格表スキーマの時間帯（peak/off-peak）対応・フォールバック時の警告・適用期間ミスマッチの可視化 | ⬜ 待機中 |
+| 2 | `ocw-meter-02-ingest-freshness` | 【1】`report` からの ingest 自動実行と、最終 ingest 時刻・鮮度のフッター表示 | ✅ PR #57 マージ済 |
+| 3 | `ocw-meter-03-price-tables` | 【5】価格表スキーマの時間帯（peak/off-peak）対応・フォールバック時の警告・適用期間ミスマッチの可視化 | 🔄 実装中 |
 | 4 | `ocw-meter-04-list-price-equiv` | 【2】`quota.sample` の `session_cost_usd` から `list_price_equiv_usd` を集計して `report` に出す | ⬜ 待機中 |
 | 5 | `ocw-meter-05-session-attribution` | 【3】`session_id` join による `run_id` / `role` の帰属解決（ingest 側フォールバック + report 側 join）と attribution 行 | ⬜ 待機中 |
 | 6 | `ocw-meter-06-docs` | 文書（`bin/README.md` / スキーマ文書 DOC-2608021229-c / ADR DOC-2608021229 への追記節 / ルート `README.md`） | ⬜ 待機中 |

--- a/docs/planning/DOC-2608081456_ocw-meter-accuracy_計画.md
+++ b/docs/planning/DOC-2608081456_ocw-meter-accuracy_計画.md
@@ -25,7 +25,7 @@
 | 3 | `ocw-meter-03-price-tables` | 【5】価格表スキーマの時間帯（peak/off-peak）対応・フォールバック時の警告・適用期間ミスマッチの可視化 | ✅ PR #58 マージ済 |
 | 4 | `ocw-meter-04-list-price-equiv` | 【2】`quota.sample` の `session_cost_usd` から `list_price_equiv_usd` を集計して `report` に出す | ✅ PR #59 マージ済 |
 | 5 | `ocw-meter-05-session-attribution` | 【3】`session_id` join による `run_id` / `role` の帰属解決（ingest 側フォールバック + report 側 join）と attribution 行 | ✅ PR #60 マージ済 |
-| 6 | `ocw-meter-06-docs` | 文書（`bin/README.md` / スキーマ文書 DOC-2608021229-c / ADR DOC-2608021229 への追記節 / ルート `README.md`） | 🔄 実装中 |
+| 6 | `ocw-meter-06-docs` | 文書（`bin/README.md` / スキーマ文書 DOC-2608021229-c / ADR DOC-2608021229 への追記節 / ルート `README.md`） | ✅ PR #61 マージ済 |
 
 **ブランチ名に `ai/` 接頭辞は付けない。** PR #54（DOC-2608062258）で `ocw` の `ai/` 接頭辞は
 廃止済みであり、傘ブランチ自体も `ocw-meter-accuracy`（接頭辞なし）である。

--- a/docs/planning/DOC-2608081456_ocw-meter-accuracy_計画.md
+++ b/docs/planning/DOC-2608081456_ocw-meter-accuracy_計画.md
@@ -24,8 +24,8 @@
 | 2 | `ocw-meter-02-ingest-freshness` | 【1】`report` からの ingest 自動実行と、最終 ingest 時刻・鮮度のフッター表示 | ✅ PR #57 マージ済 |
 | 3 | `ocw-meter-03-price-tables` | 【5】価格表スキーマの時間帯（peak/off-peak）対応・フォールバック時の警告・適用期間ミスマッチの可視化 | ✅ PR #58 マージ済 |
 | 4 | `ocw-meter-04-list-price-equiv` | 【2】`quota.sample` の `session_cost_usd` から `list_price_equiv_usd` を集計して `report` に出す | ✅ PR #59 マージ済 |
-| 5 | `ocw-meter-05-session-attribution` | 【3】`session_id` join による `run_id` / `role` の帰属解決（ingest 側フォールバック + report 側 join）と attribution 行 | 🔄 実装中 |
-| 6 | `ocw-meter-06-docs` | 文書（`bin/README.md` / スキーマ文書 DOC-2608021229-c / ADR DOC-2608021229 への追記節 / ルート `README.md`） | ⬜ 待機中 |
+| 5 | `ocw-meter-05-session-attribution` | 【3】`session_id` join による `run_id` / `role` の帰属解決（ingest 側フォールバック + report 側 join）と attribution 行 | ✅ PR #60 マージ済 |
+| 6 | `ocw-meter-06-docs` | 文書（`bin/README.md` / スキーマ文書 DOC-2608021229-c / ADR DOC-2608021229 への追記節 / ルート `README.md`） | 🔄 実装中 |
 
 **ブランチ名に `ai/` 接頭辞は付けない。** PR #54（DOC-2608062258）で `ocw` の `ai/` 接頭辞は
 廃止済みであり、傘ブランチ自体も `ocw-meter-accuracy`（接頭辞なし）である。

--- a/docs/planning/DOC-2608081456_ocw-meter-accuracy_計画.md
+++ b/docs/planning/DOC-2608081456_ocw-meter-accuracy_計画.md
@@ -23,8 +23,8 @@
 | 1 | `ocw-meter-01-store-hygiene` | 【4】【6】テストによる実ストア汚染の停止・`quota-worktree-refusal.json` のプルーニング片手落ち修正・診断ファイル専用の掃除サブコマンド新設 | ✅ PR #56 マージ済 |
 | 2 | `ocw-meter-02-ingest-freshness` | 【1】`report` からの ingest 自動実行と、最終 ingest 時刻・鮮度のフッター表示 | ✅ PR #57 マージ済 |
 | 3 | `ocw-meter-03-price-tables` | 【5】価格表スキーマの時間帯（peak/off-peak）対応・フォールバック時の警告・適用期間ミスマッチの可視化 | ✅ PR #58 マージ済 |
-| 4 | `ocw-meter-04-list-price-equiv` | 【2】`quota.sample` の `session_cost_usd` から `list_price_equiv_usd` を集計して `report` に出す | 🔄 実装中 |
-| 5 | `ocw-meter-05-session-attribution` | 【3】`session_id` join による `run_id` / `role` の帰属解決（ingest 側フォールバック + report 側 join）と attribution 行 | ⬜ 待機中 |
+| 4 | `ocw-meter-04-list-price-equiv` | 【2】`quota.sample` の `session_cost_usd` から `list_price_equiv_usd` を集計して `report` に出す | ✅ PR #59 マージ済 |
+| 5 | `ocw-meter-05-session-attribution` | 【3】`session_id` join による `run_id` / `role` の帰属解決（ingest 側フォールバック + report 側 join）と attribution 行 | 🔄 実装中 |
 | 6 | `ocw-meter-06-docs` | 文書（`bin/README.md` / スキーマ文書 DOC-2608021229-c / ADR DOC-2608021229 への追記節 / ルート `README.md`） | ⬜ 待機中 |
 
 **ブランチ名に `ai/` 接頭辞は付けない。** PR #54（DOC-2608062258）で `ocw` の `ai/` 接頭辞は

--- a/docs/reference/DOC-2608021229-c_ocw-meterイベントスキーマ.md
+++ b/docs/reference/DOC-2608021229-c_ocw-meterイベントスキーマ.md
@@ -358,11 +358,12 @@ cost = ( cache_read_input_tokens               * price.cache_hit_in
 1. **`provider == "anthropic"`のイベントのみを対象にする。** `deepseek`（`claude-ds`経由の
    セッション）は除外する。Claude Codeが DeepSeekのモデル名にどの単価を当てて
    `cost.total_cost_usd`を計算しているか不明であり、含めると`usage.message`側の
-   DeepSeek価格表推定（cash cost）と二重計上になる。`provider`が`deepseek`以外
-   （`provider: null`を含む）のサンプルはすべて`list_price_equiv_excluded_other_provider_count`
-   に計上される。`deepseek`専用カウンタ（`list_price_equiv_excluded_deepseek_count`）とは
-   別だが、`deepseek`以外の非anthropicプロバイダ（`provider: null`を含む）は互いに区別されず
-   同じ`other_provider`カウンタへまとめて計上される
+   DeepSeek価格表推定（cash cost）と二重計上になる。`provider`が`anthropic`でも
+   `deepseek`でもない（`provider: null`を含む）サンプルはすべて
+   `list_price_equiv_excluded_other_provider_count`に計上される。`deepseek`専用カウンタ
+   （`list_price_equiv_excluded_deepseek_count`）とは別だが、`deepseek`以外の非anthropic
+   プロバイダ（`provider: null`を含む）は互いに区別されず同じ`other_provider`カウンタへ
+   まとめて計上される
 2. **`session_id`ごとに時系列でソートし、隣り合うサンプル間の正の差分だけを合計する
    （`max()`は使わない）。ただし、そのセッションでストア全体を通じて最初に観測されたサンプル
    （直前サンプルが存在しない、時系列で1件だけ）だけは例外で、差分ではなく値そのものを計上する**

--- a/docs/reference/DOC-2608021229-c_ocw-meterイベントスキーマ.md
+++ b/docs/reference/DOC-2608021229-c_ocw-meterイベントスキーマ.md
@@ -107,22 +107,37 @@ phase.start/phase.endとして発火されない**:
 `(unassigned)`バケットには「`implement`フェーズ中に生成されたusage.message」が実質的に集約される
 （`implement`という名前のバケットは決して現れない）。
 
-> **⚠️ 孫5で実データ検証して判明した重大な制約（実測）**: このマシンの実ストア
-> （`~/.local/state/ocw-meter/events/`、44,425件の`usage.message`）を集計すると、**`run_id`が
-> 設定されている`usage.message`は0件**だった。`report --phase`のトークン内訳は、この時点の実データでは
-> **全件が`(unassigned)`になる**（実行結果は`docs/reference/DOC-2608021229-b_LLM費用観測ベースライン計測手順.md`
-> §2.2参照）。原因は`ingest`の`run_id`解決ロジック
-> （`resolve_run_id_via_ocw_run_id_file`）が「そのメッセージの`cwd`（＝worktreeパス）の
-> `<git-dir>/ocw-run-id`ファイルを**ingest実行時点**で読む」方式であること: `ocw rm`はworktreeごと
-> このファイルを削除するため、**PRマージ後にworktreeを消してから`ingest`を実行すると、
-> そのworktreeで生成された全メッセージのrun_idが永久に`null`のまま保存される**（§4の
+> **⚠️ 孫5で実データ検証して判明した重大な制約（実測。計画書
+> [DOC-2608081456](../planning/DOC-2608081456_ocw-meter-accuracy_計画.md)【3】）**: このマシンの実ストア
+> （`~/.local/state/ocw-meter/events/`、57,164件の`usage.message`）を集計すると、直接解決だけで
+> `run_id`が設定されている`usage.message`は**3,043件（5.3%）**、`role`が`unknown`のままのものは
+> **51,959件（90.9%）**だった。原因は`ingest`の直接解決ロジック
+> （`run_id`は`resolve_run_id_via_ocw_run_id_file`が「そのメッセージの`cwd`（＝worktreeパス）の
+> `<git-dir>/ocw-run-id`ファイルを**ingest実行時点**で読む」方式、`role`はHerdrの`pane list`を
+> **ingest実行時点**の生きたペイン状態から読む方式）であること: `ocw rm`はworktreeごと
+> `ocw-run-id`ファイルを削除し、ペインを閉じればHerdrの`pane list`からも消えるため、
+> **PRマージ後にworktreeを消してから（あるいはペインを閉じてから）`ingest`を実行すると、
+> そのメッセージのrun_id/roleは直接解決の対象では永久に`null`/`"unknown"`のまま保存される**（§4の
 > 「過去は再計算しない」不変条件により、後から`ingest`し直しても直らない）。
-> `report --phase`を意味のある形で使うには、**PRの作業中〜マージ直後、worktreeを`ocw rm`する前に
-> `ocw-meter ingest`を実行する運用**が必須（`docs/reference/DOC-2608021229-b_...`§2で手順化）。
+>
+> **孫5でこれを緩和する`session_id` joinを追加した**（下記「attributionの解決順」参照）。
+> `quota.sample`がsession_idを100%持つのに対し、`run_id`は78%・`role`は78%（unknown 22%）しか
+> 持たないため、直接解決に失敗した`usage.message`を`quota.sample`とのsession_id joinで補う。
+> `quota.sample`の記録が始まった2026-08-01以降の実測では、`run_id` 17.2% → **61.6%**、
+> `role` 27.2% → **72.1%**まで上がった。**ただしこのjoinは`quota.sample`の記録開始より前へは
+> 遡れない**ため、7月の29,676件（DeepSeek時代の`deepseek-v4-pro`分）の`run_id`/`role`は
+> 復元手段が無いままである。`report`の`--reconcile`を除く全ビューのフッターに出る
+> `attribution (run_id):`/`attribution (role):`行が、実行のたびの実測内訳
+> （`direct`/`via session_id`/`unresolved`）を示す（`--reconcile`は`session_id` joinを経由しない
+> ためattributionを計算せず、この行自体が出ない）。
+> `report --phase`を意味のある形で使うには、引き続き**PRの作業中〜マージ直後、worktreeを
+> `ocw rm`する前に`ocw-meter ingest`を実行する運用**が望ましい（`docs/reference/DOC-2608021229-b_...`
+> §2で手順化。session_id joinは直接解決の救済策であり、完全な代替ではない）。
 
 ### 2.4 `usage.message` のペイロードフィールド（共通エンベロープに加えて）
 
-`~/.local/state/ocw-meter/events/*.jsonl`の実データ（44,425件、2026-08-01時点）で
+`~/.local/state/ocw-meter/events/*.jsonl`の実データ（当初44,425件、2026-08-01時点。本傘
+[DOC-2608081456](../planning/DOC-2608081456_ocw-meter-accuracy_計画.md)の調査時点では57,164件）で
 フィールド名の過不足を確認済み。
 
 | フィールド | 型 | 由来 |
@@ -140,7 +155,10 @@ phase.start/phase.endとして発火されない**:
 | `price_table_version` | string \| null | 適用した価格表のバージョン（再計算されない、§4） |
 | `price_effective_date` | string \| null | 同上の`effective_date` |
 | `cost_basis` | string | `estimated`（DeepSeek等の従量課金） / `subscription`（Anthropic定額契約） |
+| `time_of_day_basis` | string \| null | `not_applicable` / `in_window` / `base_rate` / `unknown_timestamp`、または`null`（Anthropicモデル`cost_basis: "subscription"`のとき、または適用可能な価格表が1枚も無いとき。孫3。§4.2「時間帯課金」参照） |
 | `currency` | string \| null | `USD`。`cost_basis == "subscription"`のときは`null` |
+| `run_id_source` | string \| null | `run_id`をどの経路で解決したか。`"direct"` / `"session_id"` / `null`（未解決、またはこのフィールドが無かった旧バージョンでのingest。孫5。§4.5「attributionの解決順」参照） |
+| `role_source` | string \| null | `role`をどの経路で解決したか。値の意味は`run_id_source`と同じ（孫5） |
 
 ### 2.5 `quota.sample` のペイロードフィールド（共通エンベロープに加えて）
 
@@ -150,7 +168,7 @@ phase.start/phase.endとして発火されない**:
 | `seven_day_used_pct` / `seven_day_resets_at` | number \| null | `rate_limits.seven_day` |
 | `window_id` | string \| null | `five_hour_resets_at`の値そのもの。**未来時刻のときのみ**採用（stale値は`null`にする — 計画書§8.5） |
 | `context_used_pct` | number \| null | `context_window.used_percentage`。`null`のときは`total_input_tokens / context_window_size`からのフォールバック計算値が入る場合がある（表示文字列側は使わない。`bin/README.md`参照） |
-| `session_cost_usd` | number \| null | statusLineの`cost.total_cost_usd`（Claude Code自己申告のセッション累積コスト）。`usage.message`の`cost_estimate_usd`とは別カラムで、合算しない |
+| `session_cost_usd` | number \| null | statusLineの`cost.total_cost_usd`（Claude Code自己申告のセッション累積コスト）。`usage.message`の`cost_estimate_usd`とは別カラムで、合算しない。`report`はこれを`list_price_equiv_usd`として集計・表示する（孫4。§4.4「`list_price_equiv_usd`の集計定義」参照） |
 | `plan_source` | string | 常に`"statusline"` |
 | `raw_ref` | string \| null | `OCW_METER_RAW=1`時のみ、redaction済みraw snapshotのファイル参照。既定`null` |
 | `cwd` | string \| null | statusLine JSONの`cwd`（作業ディレクトリ）。**`ENVELOPE_FIELDS`には含まれない forward-compatible な追加フィールド** — envelope標準の`worktree`とは別に、statusLineが報告した生の`cwd`をそのまま保存する |
@@ -230,7 +248,7 @@ cost = ( cache_read_input_tokens               * price.cache_hit_in
   価格表自体が存在しない/読めない等の異常時）は `cost_estimate_usd: null` / `completeness: "unknown"`
   （§5参照）
 
-### 価格表（`bin/prices/*.json`）
+### 4.1 価格表（`bin/prices/*.json`）
 
 ```json
 {
@@ -255,6 +273,158 @@ cost = ( cache_read_input_tokens               * price.cache_hit_in
 - `price_table_version`と`price_effective_date`は、そのイベントの費用計算に**実際に使われた**
   価格表のバージョン・発効日をそのまま複写したもの。「今の価格表」ではなく「このイベントを
   計算したときの価格表」を指す
+
+### 4.2 時間帯（peak/off-peak）課金
+
+孫3、計画書 [DOC-2608081456](../planning/DOC-2608081456_ocw-meter-accuracy_計画.md)【5】。
+
+価格表は`models`（基本単価）に加えて、任意で`time_of_day_pricing`ブロックを持てる:
+
+```jsonc
+"time_of_day_pricing": {
+  "tz_offset": "+08:00",
+  "tz_label": "Beijing time (China Standard Time, UTC+8, no DST)",
+  "boundary": "start_inclusive_end_exclusive",
+  "windows": [
+    {"start": "09:00", "end": "12:00", "models": {"<model名>": {"cache_hit_in": ..., "cache_miss_in": ..., "out": ...}}},
+    {"start": "14:00", "end": "18:00", "models": {"<model名>": {...}}}
+  ]
+}
+```
+
+設計上の決まりごと（詳しい書き方・実例は`bin/prices/README.md`を参照。ここではスキーマの意味だけ
+記す）:
+
+- **`tz_offset`は固定オフセット文字列（`"+08:00"`形式）のみ。** タイムゾーン名（`Asia/Shanghai`等）
+  は使えない — `zoneinfo`はPython 3.9+かつtzdataが必要で、実行環境に無い場合があるため。オフセットは
+  価格表側が持ち、コードにハードコードしない
+- **境界は開始時刻を含み、終了時刻を含まない**（`start <= t < end`）。この規則はコード側に固定されて
+  おり、価格表の`boundary`フィールドはこの規則と一致するかを検査するアサーション専用（別の境界規則
+  を選べるオプションではない）
+- **日を跨ぐ窓は表現できない。** `start >= end`（例`"22:00"`-`"02:00"`）な窓は単に一致しない
+- **窓ごとに単価を直接書く（倍率ではない）。** `models`ブロックと同じ形で窓ごとの単価をそのまま書く
+- **`in_window`/`base_rate`という中立な名前を使い、「どちらが高い時間帯か」は表現しない。**
+  窓が「割高な時間帯」を表すか「割引の時間帯」を表すかはプロバイダごとに違い、`usage.message`に
+  焼き込まれる`time_of_day_basis`は「過去は再計算しない」不変条件のため後から意味を直せないため
+- `time_of_day_pricing`が無い価格表（この機能より前から存在するすべての価格表を含む）は、
+  常に基本`models`の単価がそのまま全時間帯に適用される（後方互換）
+
+`usage.message`の`time_of_day_basis`フィールド（§2.4）は、そのメッセージに実際にどの単価が
+適用されたかを示す:
+
+| 値 | 意味 |
+|---|---|
+| `not_applicable` | 価格表に`time_of_day_pricing`が無い、またはこのモデルがどの窓にも登場しない（時間帯課金の対象外） |
+| `in_window` | メッセージのタイムスタンプがいずれかの窓に一致し、その窓の単価を適用した |
+| `base_rate` | このモデルは時間帯課金の対象だが、タイムスタンプがどの窓にも一致しなかったため基本単価を適用した |
+| `unknown_timestamp` | このモデルは時間帯課金の対象だが、メッセージのタイムスタンプが取得できなかったため基本単価にフォールバックした（**時間帯を推測しない**） |
+
+`time_of_day_pricing`キー自体はあるが形が壊れている（`tz_offset`が不正、`windows`が配列でない、
+`boundary`が上記の規則と食い違う等）価格表は、「`time_of_day_pricing`を最初から持たない」場合と
+同じ扱い（基本単価を適用、クラッシュしない）になるが、`ingest`は`state/meter-errors.jsonl`に
+`price_table_time_of_day_pricing_unusable`という診断を記録し、意図した時間帯課金が黙って無視
+されている状態を検知できるようにしている。
+
+**このスキーマ拡張は既存の価格表と互換であり、`bin/prices/deepseek-2026-08-01.json`は現時点で
+`time_of_day_pricing`を使っていない**（DeepSeekの時間帯課金は本傘の調査時点で発効日未定のため）。
+
+### 4.3 価格表フォールバックの検出（孫3、罠5対策）
+
+`select_price_table()`は、対象日以前に有効な価格表が1枚も無いとき、クラッシュせず最も古いテーブル
+（`tables[0]`）にフォールバックする。このとき保存される`price_effective_date`は、実際のメッセージ
+日付より**後**になる — この状態（`price_effective_date`がメッセージ自身の日付より後）を、
+`report`は（イベントを書き換えずに）読み取り時の突き合わせで検出する:
+
+- `report`の`--reconcile`を除くフッター`price_table:`行に、フォールバックが起きた件数を表示する
+  （`--reconcile`は`usage_cost_footer()`を経由せず自前で`price_table`文字列を組み立てており、
+  フォールバック件数に相当する情報を持たない）
+- `report --month`の`price_tables_applied[]`の各エントリに`is_fallback`（そのバージョンで
+  フォールバックが1件でも起きたか）と`fallback_event_count`（そのバージョンの中で実際に
+  フォールバックした件数。1つの価格表が月の前半はフォールバック・後半は正しく適用、という
+  混在も表現できる）を持つ
+
+### 4.4 `list_price_equiv_usd` の集計定義
+
+孫4、計画書 [DOC-2608081456](../planning/DOC-2608081456_ocw-meter-accuracy_計画.md)【2】。
+
+`quota.sample`の`session_cost_usd`（statusLineの`cost.total_cost_usd`。Claude Code自身の
+セッション累積コスト自己申告）を集計し、`report --month`のcapacity cost節・`report --pr`・
+`report --window`に`list_price_equiv_usd`として出す。`usage.message`の`cost_estimate_usd`
+（ocw-meter自身の価格表推定値。cash cost）とは**出所も信頼レベルも異なる別カラム**であり、
+絶対に合算しない。
+
+集計規則:
+
+1. **`provider == "anthropic"`のイベントのみを対象にする。** `deepseek`（`claude-ds`経由の
+   セッション）は除外する。Claude Codeが DeepSeekのモデル名にどの単価を当てて
+   `cost.total_cost_usd`を計算しているか不明であり、含めると`usage.message`側の
+   DeepSeek価格表推定（cash cost）と二重計上になる。`provider`が`deepseek`以外
+   （`provider: null`を含む）のサンプルはすべて`list_price_equiv_excluded_other_provider_count`
+   に計上される。`deepseek`専用カウンタ（`list_price_equiv_excluded_deepseek_count`）とは
+   別だが、`deepseek`以外の非anthropicプロバイダ（`provider: null`を含む）は互いに区別されず
+   同じ`other_provider`カウンタへまとめて計上される
+2. **`session_id`ごとに時系列でソートし、隣り合うサンプル間の正の差分だけを合計する
+   （`max()`は使わない）。ただし、そのセッションでストア全体を通じて最初に観測されたサンプル
+   （直前サンプルが存在しない、時系列で1件だけ）だけは例外で、差分ではなく値そのものを計上する**
+   （＝そのサンプルより前の消費も丸ごと含める）。
+   `session_cost_usd`はセッション累積のはずだが、実測で214セッション中26セッション（12.1%）が
+   非単調（値が減少する箇所がある）だった。`/clear`やコンパクションでのリセットが原因と推定される。
+   単純な`max()`ではリセット前の消費分を取りこぼすため、隣り合うサンプル間の差分のうち正のものだけ
+   を積算する（負の差分＝リセットは**0として扱う**。**リセット直後のサンプル自身の寄与は0であり、
+   「最初のサンプル」の特別扱いはストア全体で最初の1件にしか適用されない** —
+   リセットのたびに値そのものが計上されるわけではない）。この寄与（`event_id`ごとの寄与額）は
+   **必ずストア全体の`quota.sample`から計算し、窓/PR/月でスコープを絞った部分集合から
+   再計算してはいけない。** スコープを絞って計算すると、窓をまたぐセッションの累計が
+   窓2の「最初のサンプル」として丸ごと再計上され、実ストアで`report --window`の行合計が
+   48.7%（57/207 anthropicセッション、27.5%が2窓以上にまたがる）過大になることを実測で確認した
+3. `session_id`が無い、または`session_cost_usd`が数値でないサンプルは除外し、
+   `list_price_equiv_excluded_no_session_id_count` / `list_price_equiv_excluded_null_cost_count`
+   としてそれぞれ数える（黙って捨てない）
+4. 対象サンプルが1件も無いスコープ（例: `quota.sample`が始まる2026-08-01より前の月）では
+   `list_price_equiv_usd: null`（`$0.00`ではない）、`list_price_equiv_is_lower_bound: null`
+   になる — データが無いことと、ゼロだったことを区別する
+
+**常に下限値である。** 最後のstatusLine描画以降の消費は含まれないため、`list_price_equiv_usd`が
+`null`でない限り`list_price_equiv_is_lower_bound: true`が付く。請求書ではなく、cash costと
+合算してはならない（線引きの記録は
+`docs/adr/DOC-2608021229_llm-cost-observability-collection-method.md` §10参照）。
+
+### 4.5 attribution の解決順
+
+孫5、計画書 [DOC-2608081456](../planning/DOC-2608081456_ocw-meter-accuracy_計画.md)【3】。
+
+`usage.message`の`run_id`/`role`は、次の優先順で解決される（`run_id_source`/`role_source`が
+実際にどの経路で決まったかを保持する。§2.4参照）:
+
+- `run_id`: **①**`ocw-run-id`ファイル（そのメッセージの`cwd`配下、ingest実行時点で直接読む）
+  → **②**`quota.sample`との`session_id` join（同じ`session_id`を持つ`quota.sample`サンプルの
+  うち、そのメッセージのタイムスタンプに時刻が最も近いものの`run_id`を採用） → **③**`null`
+- `role`: **①**Herdr live（`herdr pane list`をingest実行時点で読む）→ **②**同上の`session_id`
+  join → **③**`"unknown"`
+
+②の`session_id` joinは2箇所で行われる: `ingest`実行時に新規イベントへ書き込む「ingest側
+フォールバック」と、既に保存済みのイベント（`run_id`/`role`が未解決のまま保存されているもの）を
+`report`の読み取り時に補完する「report側join」。**どちらも保存されたイベントファイルそのものは
+書き換えない**（「過去は再計算しない」不変条件の維持）。`report`のフッターの`attribution`行は
+両方を区別せず`via session_id`として合算する。
+
+**⚠️ 重要な設計上の判断**: `quota.sample`由来（②）の`run_id`には、`ocw-run-id`ファイル経由
+（①）にのみ適用される「その`run_id`の`run.start`より前のメッセージなら捨てる」という逆転
+チェックを**適用しない**。このチェックは「worktreeパスは再利用される」ことを前提にしたstale
+path対策であり、`session_id`はworktreeパスと違って再利用されないため、②に適用すると正しい
+帰属まで`null`化してしまう。解決経路ごとにこのチェックの適用を分けている（テストで固定済み）。
+
+1つの`session_id`に複数の`run_id`/`role`が紐づく場合（同じセッションでworktreeを移った等）は、
+「一意でなければ解決しない」ではなく、**そのメッセージのタイムスタンプに時刻が最も近いサンプルの
+値を採用する**方針とした（前後どちらのサンプルが「そのときの状態」かを決める積極的な根拠が無い
+ため、単に時刻近傍則で決定的に1つへ絞る。同点は前方のサンプルを優先する）。
+
+**この解決順・joinはどちらも`ocw rm`（worktree削除）に一切影響されない**（`quota.sample`は
+消えないイベントだが、`ocw-run-id`ファイルはworktreeと一緒に消える）。ただし限界は残る:
+`quota.sample`の記録が始まる前（各マシンへのデプロイ日より前）の期間は、session_id joinによる
+復元ができない。以降の期間でも100%には到達しない — `claude-ds`セッションやstatusLineが一度も
+走らなかったセッションは`run_id`/`role`とも復元不能。`role`の`unknown`の一部はHerdr外で起動
+したClaudeであり原理的に取得不能（推測で埋めない方針を維持）。
 
 ---
 
@@ -287,6 +457,13 @@ cost = ( cache_read_input_tokens               * price.cache_hit_in
   少なくとも件数として認識できるようにする）
 - 現時点（v1）でこのルールが実際に発動した例は無い。将来v2を検討する際は、この節を更新し、
   移行時に何が壊れ得たか・どう吸収したかを追記すること
+- **本傘（計画書
+  [DOC-2608081456](../planning/DOC-2608081456_ocw-meter-accuracy_計画.md)）は`schema_version`を
+  変更していない。** 孫3が`time_of_day_basis`、孫5が`run_id_source`/`role_source`をそれぞれ
+  `usage.message`へ新規追加したが、いずれも既存フィールドの意味変更・削除・型変更を伴わない
+  「フィールドの追加」（上記の互換ケース）にあたるため、`v1`のまま据え置いた。`list_price_equiv_usd`
+  はイベントのフィールドではなく`report`が集計時に計算する派生値のため、そもそもスキーマ変更の
+  対象外である
 
 ---
 
@@ -339,11 +516,25 @@ cost = ( cache_read_input_tokens               * price.cache_hit_in
 ```json
 {"schema_version": 1, "event_type": "usage.message", "idempotency_key": "u1", "ts": "2026-08-01T09:06:00.000Z",
  "source": "transcript", "parser_version": 1, "completeness": "complete", "run_id": "run1",
- "role": "implementer", "provider": "deepseek", "model": "deepseek-v4-pro", "phase": null, "round": null,
+ "run_id_source": "direct", "role": "implementer", "role_source": "direct", "provider": "deepseek",
+ "model": "deepseek-v4-pro", "phase": null, "round": null,
  "pr_number": 42, "message_id": "m1", "input_tokens": 1000, "cache_read_input_tokens": 500,
  "cache_creation_input_tokens": 0, "output_tokens": 200, "reasoning_tokens": null,
  "cost_estimate_usd": 0.01, "price_table_version": "deepseek-2026-08-01",
- "price_effective_date": "2026-08-01", "cost_basis": "estimated", "currency": "USD"}
+ "price_effective_date": "2026-08-01", "cost_basis": "estimated", "time_of_day_basis": "not_applicable",
+ "currency": "USD"}
+```
+
+`run_id_source`/`role_source`（孫5追加）は、この例のように`run_id`/`role`が`ocw-run-id`ファイル /
+Herdr liveから直接解決できた場合は`"direct"`、`quota.sample`とのsession_id joinで解決した場合は
+`"session_id"`になる（§4.5参照）。`time_of_day_basis`（孫3追加）はこの例が使う価格表
+（`bin/prices/deepseek-2026-08-01.json`）が`time_of_day_pricing`を持たないため`"not_applicable"`。
+サンドボックス実行で実際に確認した`run_id_source: "session_id"`の例:
+
+```json
+{"run_id": "run-sandbox-1", "run_id_source": "session_id", "role": "implementer",
+ "role_source": "session_id", "provider": "anthropic", "model": "claude-opus-5",
+ "cost_basis": "subscription", "cost_estimate_usd": null, "time_of_day_basis": null, "...": "..."}
 ```
 
 ### `quota.sample`


### PR DESCRIPTION
## 背景

dotfilesは、macOS / Linux / WSL2 で共通の開発環境を再現するための設定リポジトリです。その中の `ocw-meter` は、AIエージェントによる開発作業のトークン使用量や費用を記録・集計する計測ツールです。

このマシンで実際に蓄積されている記録（イベント数62,763件・約68MB）を実際の作業履歴と突き合わせて調査したところ、「計測基盤としては動いているが、出している数字が事実とズレている」状態にあることが判明しました。具体的には次の6つの問題です。

1. 記録の取り込みが手動実行のみで、直近数日分がまるごと欠落することがある
2. 費用の集計が、現在ほとんど使われていないプロバイダの数字しか反映していない
3. 作業の工程・担当者への紐付けが、ほぼ機能していない（該当率1%未満）
4. テストが実際の記録ストアを汚染してしまうバグがある
5. 価格表が実態に合っておらず、フォールバック時にその旨が表示されない
6. 古くなった診断ファイルを掃除する手段がなく、汚染データが残り続ける

本プルリクエストは、この6つの問題をすべて解消する一連の変更をまとめたものです。個々の変更は6件のプルリクエスト（#56〜#61）としてこの作業用ブランチに既にレビュー・マージ済みで、本プルリクエストはその内容をまとめて本番ブランチに反映するためのものです。

## このプルリクエストの目的

`ocw-meter` が出す数字を実態に近づけ、かつ「実態に近づけられない部分」は推測で埋めずに正直に示すようにします。

## 実装内容

- **記録の取り込み漏れの解消**: レポート表示時に記録の取り込みを自動実行するようにし、最後にいつ取り込んだか・どれくらい鮮度が古いかをレポートの末尾に表示するようにしました
- **費用の集計範囲の拡大**: これまで集計対象外だった、Claude側が自己申告する費用情報を集計し、レポートに「下限値」として表示するようにしました。定額契約の費用を単価換算する方式は採らず、あくまで自己申告値をそのまま集計する方式にとどめています
- **作業の紐付け精度の改善**: セッションIDを介した突き合わせにより、工程・担当者への紐付け率を大きく改善しました（対象期間の実測で、工程の紐付けが約17%から約62%、担当者の紐付けが約27%から約72%に改善）
- **テストによる記録ストア汚染の停止**: 一部のテストが実際の記録ストアに書き込んでしまうバグを修正し、同種の事故を構造的に防止しました
- **古い汚染データの掃除手段の追加**: 上記のバグで生じた汚染データを消すための専用コマンドを追加しました。既定では削除対象を表示するだけで、実際に消すには明示的な指定が必要です
- **価格表の拡張**: 時間帯によって単価が変わる料金体系を表現できるようにし、該当する価格表が見つからずに概算で計算した場合はその旨をレポートに明示するようにしました
- 上記の変更に合わせて、関連する文書（ツールのREADME・イベントの仕様書・関連する設計判断の記録）を更新しました

## レビューで見てほしいところ

- 費用の集計方法について、定額契約の費用をAPI単価に換算する方式ではなく、Claude側の自己申告値をそのまま使う方式を採用しています。この判断が妥当か確認してください
- 工程・担当者への紐付けは、過去に記録済みのデータを書き換える方式ではなく、レポート表示のたびに読み取り時点で解決する方式にしています。「過去の記録は書き換えない」という既存の方針を維持するための選択です
- 6件の個別プルリクエストそれぞれで、設計上の判断根拠や検討して採らなかった案を議論済みです。まとめて見る場合は、各コミットメッセージ（PR #56〜#61に対応）から遡ってご確認いただけます
- 今回の調査・改善では直せない・扱わない範囲があります。「今後の予定」の節を参照してください

## テスト結果

- lint（shellcheck / shfmt / bashの構文チェック / Pythonのコンパイルチェック等を含む一式）は全て緑です
- 自動テストは354件全て緑です（この一連の変更で追加された分を含みます）
- テスト実行後、実際の記録ストアが変化していないことも確認済みです

## 自己レビュー

- 正当性: 計画書に定めた6つの問題すべてに対応済みです。計画書の「傘の完了条件」節に列挙された各項目（自動取り込み・鮮度表示・費用の下限値表示・紐付け率の改善・価格表の時間帯対応・掃除コマンドの既定dry-run・過去記録を書き換えないこと・文書の追随）を1つずつ照合し、すべて満たしていることを確認しました。ただし「紐付けの内訳」と「価格表フォールバック警告」の2項目は`--reconcile`ビューには当てはまりません（`--reconcile`は`session_id` joinや`usage_cost_footer`を経由しない別系統の集計であり、対象外とした理由は`docs/reference/DOC-2608021229-c_ocw-meterイベントスキーマ.md`§4.3・§4.5に記録済みです）。それ以外の全ビューでは満たしています
- エッジケース: 個々の変更を含む6件のプルリクエストそれぞれで、異常系・境界値（不正な価格表・欠損フィールド・日付境界・タイムゾーン境界など）のテストが個別にレビュー済みです
- テスト: 自動テスト354件が全て緑であることを確認しました。テスト実行の前後で、実際の記録ストアの状態（`quota-worktree-refusal.json` の件数・診断ログの更新日時）が変化していないことも確認しました
- 無関係変更: 変更ファイルは `bin/ocw-meter` 本体・そのテスト・関連文書・価格表READMEのみで、対象範囲外の変更は含まれていません
- 後方互換性: 価格表の時間帯情報や記録の取り込み時刻の記録は、いずれも既存の形式に情報が無い場合の後方互換の挙動が個別にテストされています
- 保守性・スタイル: `pre-commit run --all-files`（shellcheck / shfmt / doc-id チェック等一式）が全て緑であることを確認しました

## 今後の予定

今回の調査で見つかったものの、意図的に対象外とした項目です。

- 素性不明な少数の記録（103件）の扱いの見直し
- 一部の指標（`five_hour_window_completion`）の定義見直しまたは廃止
- 記録そのものを削除する機能の実装
- 現在使われていないプロバイダの、過去の期間に対応する価格表の追加（正確な単価は一次情報源から人手で確認する必要があるため）
- 記録の取り込みが始まる前の期間について、工程・担当者への紐付けを復元すること（原理的に不可能です）
- 同じく取り込み開始前の期間について、Claude側の費用を把握すること（同上）
